### PR TITLE
feat: Skip video decoding when possible + WebM support

### DIFF
--- a/pkg/pipeline/input/builder.go
+++ b/pkg/pipeline/input/builder.go
@@ -115,8 +115,8 @@ func (b *Bin) buildMux(p *params.Params) error {
 				return err
 			}
 			err = b.mux.SetProperty("faststart", true)
-		// case livekit.EncodedFileType_WEBM:
-		// 	mux, err = gst.NewElement("webmmux")
+		case livekit.EncodedFileType_WEBM:
+			b.mux, err = gst.NewElement("webmmux")
 		case livekit.EncodedFileType_OGG:
 			b.mux, err = gst.NewElement("oggmux")
 		}

--- a/pkg/pipeline/input/builder_video.go
+++ b/pkg/pipeline/input/builder_video.go
@@ -2,7 +2,6 @@ package input
 
 import (
 	"fmt"
-
 	"github.com/tinyzimmer/go-gst/gst"
 
 	"github.com/livekit/protocol/livekit"
@@ -129,44 +128,37 @@ func (b *Bin) buildSDKVideoInput(p *params.Params) error {
 		return err
 	}
 
+	// Append RTP depacketizer pipeline
 	b.videoElements = append(b.videoElements, b.videoSrc.Element, rtpJitterBuffer, depay)
 
+	// If we can containerise directly, skip decoding
+	if mimeType == source.MimeTypeH264 && p.FileParams.FileType == livekit.EncodedFileType_MP4 {
+		return nil
+	}
+	if mimeType == source.MimeTypeVP8 && p.FileParams.FileType == livekit.EncodedFileType_WEBM {
+		return nil
+	}
+
+	// Else, we need to do transcoding: first build the decoding pipeline
 	switch mimeType {
 	case source.MimeTypeH264:
-
+		err = b.buildSdkDecoderPipeline("avdec_h264", p)
 	case source.MimeTypeVP8:
-		vp8Dec, err := gst.NewElement("vp8dec")
-		if err != nil {
+		err = b.buildSdkDecoderPipeline("vp8dec", p)
+	default:
+		return errors.ErrNotSupported(p.FileType.String())
+	}
+	if err != nil {
+		return err
+	}
+
+	// Build encoding pipeline
+	switch p.FileType {
+	case livekit.EncodedFileType_WEBM:
+		if err = b.buildVPXElements(8, p); err != nil {
 			return err
 		}
-
-		videoConvert, err := gst.NewElement("videoconvert")
-		if err != nil {
-			return err
-		}
-
-		videoScale, err := gst.NewElement("videoscale")
-		if err != nil {
-			return err
-		}
-
-		videoRate, err := gst.NewElement("videorate")
-		if err != nil {
-			return err
-		}
-
-		videoRawCaps, err := gst.NewElement("capsfilter")
-		if err != nil {
-			return err
-		}
-		if err = videoRawCaps.SetProperty("caps", gst.NewCapsFromString(
-			fmt.Sprintf("video/x-raw,format=I420,width=%d,height=%d,framerate=%d/1", p.Width, p.Height, p.Framerate),
-		)); err != nil {
-			return err
-		}
-
-		b.videoElements = append(b.videoElements, vp8Dec, videoConvert, videoScale, videoRate, videoRawCaps)
-
+	case livekit.EncodedFileType_MP4:
 		var profile string
 		switch p.VideoCodec {
 		case livekit.VideoCodec_H264_BASELINE:
@@ -181,8 +173,45 @@ func (b *Bin) buildSDKVideoInput(p *params.Params) error {
 		if err = b.buildH26XElements(264, profile, p); err != nil {
 			return err
 		}
+	default:
+		return errors.ErrNotSupported(p.FileType.String())
 	}
 
+	return nil
+}
+
+func (b *Bin) buildSdkDecoderPipeline(decoder string, p *params.Params) error {
+	videoDecoder, err := gst.NewElement(decoder)
+	if err != nil {
+		return nil
+	}
+
+	videoConvert, err := gst.NewElement("videoconvert")
+	if err != nil {
+		return err
+	}
+
+	videoScale, err := gst.NewElement("videoscale")
+	if err != nil {
+		return err
+	}
+
+	videoRate, err := gst.NewElement("videorate")
+	if err != nil {
+		return err
+	}
+
+	videoRawCaps, err := gst.NewElement("capsfilter")
+	if err != nil {
+		return err
+	}
+	if err = videoRawCaps.SetProperty("caps", gst.NewCapsFromString(
+		fmt.Sprintf("video/x-raw,format=I420,width=%d,height=%d,framerate=%d/1", p.Width, p.Height, p.Framerate),
+	)); err != nil {
+		return err
+	}
+
+	b.videoElements = append(b.videoElements, videoDecoder, videoConvert, videoScale, videoRate, videoRawCaps)
 	return nil
 }
 


### PR DESCRIPTION
- We should not need to transcode if the stream's codec can be containerised directly (H264 -> MP4, VP8 -> WebM)
- WebM types won't show up unless we build protocol locally