### PR TITLE
Handling zero value correctly for GCPConfig.CredentialsJSON

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,8 +86,12 @@ func NewConfig(confString string) (*Config, error) {
 			Bucket:    conf.S3.Bucket,
 		}
 	} else if conf.GCP != nil {
+		var credentials []byte
+		if conf.GCP.CredentialsJSON != "" {
+			credentials = []byte(conf.GCP.CredentialsJSON)
+		}
 		conf.FileUpload = &livekit.GCPUpload{
-			Credentials: []byte(conf.GCP.CredentialsJSON),
+			Credentials: credentials,
 			Bucket:      conf.GCP.Bucket,
 		}
 	} else if conf.Azure != nil {


### PR DESCRIPTION
Due to recent [change of type of  `GCPConfig.CredentialsJSON`](https://github.com/livekit/egress/commit/d3a87f460c9572c515d88cf0772574a8e85f0e8e) from `[]byte` to `string`, service does not handle zero value correctly (needed for picking `GOOGLE_APPLICATION_CREDENTIALS` from environment).

The zero value for string is `""` which gets converted to `[]` (0 length slice) which is not `nil`. This results in service creating an empty slice for `GCPConfig.CredentialsJSON`. 