### PR TITLE
Configurable CPU costs for egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ azure:
 gcp:
   credentials_json: GOOGLE_APPLICATION_CREDENTIALS env can be used instead
   bucket: bucket to upload files to
+
+# cpu costs for various egress types with their default values
+cpu_cost:
+  room_composite_cpu_cost: 3.0
+  track_composite_cpu_cost: 2.0
+  track_cpu_cost: 1.0
 ```
 
 The config file can be added to a mounted volume with its location passed in the EGRESS_CONFIG_FILE env var, or its body can be passed in the EGRESS_CONFIG_BODY env var.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,12 @@ import (
 	"github.com/livekit/egress/pkg/errors"
 )
 
+const (
+	RoomCompositeCpuCost  = 3
+	TrackCompositeCpuCost = 2
+	TrackCpuCost          = 1
+)
+
 type Config struct {
 	Redis     RedisConfig `yaml:"redis"`      // required
 	ApiKey    string      `yaml:"api_key"`    // required (env LIVEKIT_API_KEY)
@@ -30,6 +36,9 @@ type Config struct {
 	S3    *S3Config    `yaml:"s3"`
 	Azure *AzureConfig `yaml:"azure"`
 	GCP   *GCPConfig   `yaml:"gcp"`
+
+	// CPU costs for various egress types
+	CPUCost CPUCostConfig `yaml:"cpu_cost"`
 
 	// internal
 	NodeID     string      `yaml:"-"`
@@ -60,6 +69,12 @@ type AzureConfig struct {
 type GCPConfig struct {
 	CredentialsJSON string `yaml:"credentials_json"` // (env GOOGLE_APPLICATION_CREDENTIALS)
 	Bucket          string `yaml:"bucket"`
+}
+
+type CPUCostConfig struct {
+	RoomCompositeCpuCost  float64 `yaml:"room_composite_cpu_cost"`
+	TrackCompositeCpuCost float64 `yaml:"track_composite_cpu_cost"`
+	TrackCpuCost          float64 `yaml:"track_cpu_cost"`
 }
 
 func NewConfig(confString string) (*Config, error) {
@@ -96,6 +111,16 @@ func NewConfig(confString string) (*Config, error) {
 			AccountKey:    conf.Azure.AccountKey,
 			ContainerName: conf.Azure.ContainerName,
 		}
+	}
+	// Setting CPU costs from config. Ensure that CPU costs are positive
+	if conf.CPUCost.TrackCpuCost <= 0.0 {
+		conf.CPUCost.TrackCpuCost = TrackCpuCost
+	}
+	if conf.CPUCost.TrackCompositeCpuCost <= 0.0 {
+		conf.CPUCost.TrackCompositeCpuCost = TrackCompositeCpuCost
+	}
+	if conf.CPUCost.RoomCompositeCpuCost <= 0.0 {
+		conf.CPUCost.RoomCompositeCpuCost = RoomCompositeCpuCost
 	}
 
 	if err := conf.initLogger(); err != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -149,7 +149,8 @@ func (s *Service) acceptRequest(req *livekit.StartEgressRequest) bool {
 		}
 	}
 
-	if !sysload.CanAcceptRequest(req) {
+	logger.Infow("EGRESS_REQUEST: ", "egressRequest", req.String())
+	if !sysload.CanAcceptRequest(req, s.conf.CPUCost) {
 		logger.Debugw("rejecting request", "reason", "not enough cpu")
 		return false
 	}
@@ -163,7 +164,7 @@ func (s *Service) acceptRequest(req *livekit.StartEgressRequest) bool {
 		return false
 	}
 
-	sysload.AcceptRequest(req)
+	sysload.AcceptRequest(req, s.conf.CPUCost)
 	logger.Debugw("request claimed", "egressID", req.EgressId)
 
 	return true


### PR DESCRIPTION
Making CPU costs for various egress types configurable.
The default values are set to the constants in [`sysload/cpu.go`](https://github.com/livekit/egress/blob/b8e3c046c89e5a7e63e18bbe336de45c276b7f41/pkg/sysload/cpu.go#L18)