### PR TITLE
Add support for Listing active Egresses in service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,10 +19,10 @@ require (
 	github.com/grafov/m3u8 v0.11.1
 	github.com/livekit/livekit-server v1.0.2-0.20220613191817-4be096cf7405
 	github.com/livekit/protocol v0.13.4-0.20220623220447-eb06e1619afa
-	github.com/livekit/server-sdk-go v0.10.2
+	github.com/livekit/server-sdk-go v0.10.3
 	github.com/mackerelio/go-osstat v0.2.1
 	github.com/pion/rtp v1.7.13
-	github.com/pion/webrtc/v3 v3.1.40
+	github.com/pion/webrtc/v3 v3.1.42
 	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.7.1
 	github.com/tinyzimmer/go-glib v0.0.25
@@ -85,7 +85,7 @@ require (
 	github.com/pion/sdp/v3 v3.0.5 // indirect
 	github.com/pion/srtp/v2 v2.0.9 // indirect
 	github.com/pion/stun v0.3.5 // indirect
-	github.com/pion/transport v0.13.0 // indirect
+	github.com/pion/transport v0.13.1 // indirect
 	github.com/pion/turn/v2 v2.0.8 // indirect
 	github.com/pion/udp v0.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -100,9 +100,9 @@ require (
 	go.uber.org/goleak v1.1.12 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
-	golang.org/x/net v0.0.0-20220526153639-5463443f8c37 // indirect
+	golang.org/x/net v0.0.0-20220531201128-c960675eff93 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.17
 
 replace github.com/tinyzimmer/go-gst v0.2.32 => github.com/livekit/go-gst v0.0.0-20220603230042-cef031256427
 
-replace github.com/livekit/egress => ../egress
-
 require (
 	cloud.google.com/go/storage v1.22.1
 	github.com/Azure/azure-storage-blob-go v0.14.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.17
 
 replace github.com/tinyzimmer/go-gst v0.2.32 => github.com/livekit/go-gst v0.0.0-20220603230042-cef031256427
 
+replace github.com/livekit/egress => ../egress
+
 require (
 	cloud.google.com/go/storage v1.22.1
 	github.com/Azure/azure-storage-blob-go v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ github.com/livekit/rtcscore-go v0.0.0-20220524203225-dfd1ba40744a h1:cENjhGfslLS
 github.com/livekit/rtcscore-go v0.0.0-20220524203225-dfd1ba40744a/go.mod h1:116ych8UaEs9vfIE8n6iZCZ30iagUFTls0vRmC+Ix5U=
 github.com/livekit/server-sdk-go v0.10.2 h1:Wrlbv1k5EZ2L7eA4L9AEzvBIv3jDUTePlIB+0flihCI=
 github.com/livekit/server-sdk-go v0.10.2/go.mod h1:89o7K8dB1r1/NLqoyAW4oTonScX3GUwfKFd8jXDUtzg=
+github.com/livekit/server-sdk-go v0.10.3 h1:fsf8Kd4qKqAUwfd+fTBo8FrBf9hoVBUNMH9zKsJM9gA=
+github.com/livekit/server-sdk-go v0.10.3/go.mod h1:hcM4YgHm96fNGSkFQRjfbExDmbBGYPGDr7bj/zC837g=
 github.com/mackerelio/go-osstat v0.2.1 h1:5AeAcBEutEErAOlDz6WCkEvm6AKYgHTUQrfwm5RbeQc=
 github.com/mackerelio/go-osstat v0.2.1/go.mod h1:UzRL8dMCCTqG5WdRtsxbuljMpZt9PCAGXqxPst5QtaY=
 github.com/magefile/mage v1.13.0 h1:XtLJl8bcCM7EFoO8FyH8XK3t7G5hQAeK+i4tq+veT9M=
@@ -408,6 +410,8 @@ github.com/pion/transport v0.12.2/go.mod h1:N3+vZQD9HlDP5GWkZ85LohxNsDcNgofQmyL6
 github.com/pion/transport v0.12.3/go.mod h1:OViWW9SP2peE/HbwBvARicmAVnesphkNkCVZIWJ6q9A=
 github.com/pion/transport v0.13.0 h1:KWTA5ZrQogizzYwPEciGtHPLwpAjE91FgXnyu+Hv2uY=
 github.com/pion/transport v0.13.0/go.mod h1:yxm9uXpK9bpBBWkITk13cLo1y5/ur5VQpG22ny6EP7g=
+github.com/pion/transport v0.13.1 h1:/UH5yLeQtwm2VZIPjxwnNFxjS4DFhyLfS4GlfuKUzfA=
+github.com/pion/transport v0.13.1/go.mod h1:EBxbqzyv+ZrmDb82XswEE0BjfQFtuw1Nu6sjnjWCsGg=
 github.com/pion/turn/v2 v2.0.8 h1:KEstL92OUN3k5k8qxsXHpr7WWfrdp7iJZHx99ud8muw=
 github.com/pion/turn/v2 v2.0.8/go.mod h1:+y7xl719J8bAEVpSXBXvTxStjJv3hbz9YFflvkpcGPw=
 github.com/pion/udp v0.1.1 h1:8UAPvyqmsxK8oOjloDk4wUt63TzFe9WEJkg5lChlj7o=
@@ -415,6 +419,8 @@ github.com/pion/udp v0.1.1/go.mod h1:6AFo+CMdKQm7UiA0eUPA8/eVCTx8jBIITLZHc9DWX5M
 github.com/pion/webrtc/v3 v3.1.25-0.20220225075517-37e16a3b15a3/go.mod h1:mO/yv7fBN3Lp7YNlnYcTj1jtpvNvssJG+7eh6itZ4xM=
 github.com/pion/webrtc/v3 v3.1.40 h1:KTn18GSczgrEj0wgAjMMHoRJafbm7yLGrlPRK349Zag=
 github.com/pion/webrtc/v3 v3.1.40/go.mod h1:+RHmeR9uQQgoCaVs1R9vntldMbtFgD5Fk6klO7q06f4=
+github.com/pion/webrtc/v3 v3.1.42 h1:wJEQFIXVanptnQcHOLTuIo4AtGB2+mG2x4OhIhnITOA=
+github.com/pion/webrtc/v3 v3.1.42/go.mod h1:ffD9DulDrPxyWvDPUIPAOSAWx9GUlOExiJPf7cCcMLA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -607,6 +613,8 @@ golang.org/x/net v0.0.0-20220401154927-543a649e0bdd/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220526153639-5463443f8c37 h1:lUkvobShwKsOesNfWWlCS5q7fnbG1MEliIzwu886fn8=
 golang.org/x/net v0.0.0-20220526153639-5463443f8c37/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93 h1:MYimHLfoXEpOhqd/zgoA/uoXzHB86AEky4LAx5ij9xA=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -711,6 +719,8 @@ golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 h1:z8Hj/bl9cOV2grsOpEaQFUaly0JWN3i97mo3jXKJNp0=
+golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrGhostPadFailed      = errors.New("failed to add ghost pad to bin")
 	ErrStreamAlreadyExists = errors.New("stream already exists")
 	ErrStreamNotFound      = errors.New("stream not found")
+	ErrEgressTimedOut      = errors.New("egress timed out")
 )
 
 func New(err string) error {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -239,12 +239,12 @@ func (s *Service) launchHandler(ctx context.Context, req *livekit.StartEgressReq
 		return
 	}
 
-	cmd := exec.Command("/Users/bigben/go/src/github.com/livekit/cloud-egress/egress",
+	cmd := exec.Command("egress",
 		"run-handler",
 		"--config-body", string(confString),
 		"--request", string(reqString),
 	)
-	cmd.Dir = "/Users/bigben/go/src/github.com/livekit/cloud-egress"
+	cmd.Dir = "/"
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -299,5 +299,5 @@ func (s *Service) ListEgress() []string {
 		return true
 	})
 
-	return []string{"EG_1242"}
+	return res
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -292,7 +292,7 @@ func (s *Service) Stop(kill bool) {
 }
 
 func (s *Service) ListEgress() []string {
-	res := make([]string)
+	res := make([]string, 0)
 
 	s.processes.Range(func(key, value interface{}) bool {
 		res = append(res, key.(string))

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -290,3 +290,14 @@ func (s *Service) Stop(kill bool) {
 		})
 	}
 }
+
+func (s *Service) ListEgress() []string {
+	res := make([]string)
+
+	s.processes.Range(func(key, value interface{}) bool {
+		res = append(res, key.(string))
+		return true
+	})
+
+	return res
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -239,12 +239,12 @@ func (s *Service) launchHandler(ctx context.Context, req *livekit.StartEgressReq
 		return
 	}
 
-	cmd := exec.Command("egress",
+	cmd := exec.Command("/Users/bigben/go/src/github.com/livekit/cloud-egress/egress",
 		"run-handler",
 		"--config-body", string(confString),
 		"--request", string(reqString),
 	)
-	cmd.Dir = "/"
+	cmd.Dir = "/Users/bigben/go/src/github.com/livekit/cloud-egress"
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -299,5 +299,5 @@ func (s *Service) ListEgress() []string {
 		return true
 	})
 
-	return res
+	return []string{"EG_1242"}
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -73,7 +73,7 @@ func TestEgress(t *testing.T) {
 			RoomName:            conf.RoomName,
 			ParticipantName:     "sample",
 			ParticipantIdentity: fmt.Sprintf("sample-%d", rand.Intn(100)),
-		}, lsdk.NewRoomCallback())
+		}, lksdk.NewRoomCallback())
 		require.NoError(t, err)
 		defer room.Disconnect()
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -73,7 +73,7 @@ func TestEgress(t *testing.T) {
 			RoomName:            conf.RoomName,
 			ParticipantName:     "sample",
 			ParticipantIdentity: fmt.Sprintf("sample-%d", rand.Intn(100)),
-		})
+		}, lsdk.NewRoomCallback())
 		require.NoError(t, err)
 		defer room.Disconnect()
 	}

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -64,11 +64,11 @@ func testService(t *testing.T, conf *testConfig, room *lksdk.Room) {
 
 	filepath := getFilePath(conf.Config, filename)
 	info, err := rpcClient.SendRequest(context.Background(), &livekit.StartEgressRequest{
-		RoomId: room.SID,
+		RoomId: room.SID(),
 		WsUrl:  conf.WsUrl,
 		Request: &livekit.StartEgressRequest_RoomComposite{
 			RoomComposite: &livekit.RoomCompositeEgressRequest{
-				RoomName: room.Name,
+				RoomName: room.Name(),
 				Layout:   "speaker-dark",
 				Output: &livekit.RoomCompositeEgressRequest_File{
 					File: &livekit.EncodedFileOutput{

--- a/test/track_test.go
+++ b/test/track_test.go
@@ -83,7 +83,7 @@ func runTrackFileTest(t *testing.T, conf *testConfig, room *lksdk.Room, test *te
 
 	filepath := getFilePath(conf.Config, test.filename)
 	trackRequest := &livekit.TrackEgressRequest{
-		RoomName: room.Name,
+		RoomName: room.Name(),
 		TrackId:  trackID,
 		Output: &livekit.TrackEgressRequest_File{
 			File: &livekit.DirectFileOutput{
@@ -122,7 +122,7 @@ func runTrackWebsocketTest(t *testing.T, conf *testConfig, room *lksdk.Room, tes
 	}()
 
 	trackRequest := &livekit.TrackEgressRequest{
-		RoomName: room.Name,
+		RoomName: room.Name(),
 		TrackId:  trackID,
 		Output: &livekit.TrackEgressRequest_WebsocketUrl{
 			WebsocketUrl: "ws" + strings.TrimPrefix(s.URL, "http"),


### PR DESCRIPTION
This PR adds a call to service to return the list of active egresses. It also updates to the latest Go SDK, and makes required changes needed to adopt the new API. This also adds an "Egress timed out" error.

