### PR TITLE
Fix segfaults

### DIFF
--- a/pkg/pipeline/output/builder.go
+++ b/pkg/pipeline/output/builder.go
@@ -57,12 +57,11 @@ func buildStreamOutputBin(p *params.Params) (*Bin, error) {
 	}
 
 	b := &Bin{
-		isWebSource: p.IsWebSource,
-		bin:         bin,
-		protocol:    p.OutputType,
-		tee:         tee,
-		sinks:       make(map[string]*streamSink),
-		logger:      p.Logger,
+		bin:      bin,
+		protocol: p.OutputType,
+		tee:      tee,
+		sinks:    make(map[string]*streamSink),
+		logger:   p.Logger,
 	}
 
 	for _, url := range p.StreamUrls {

--- a/pkg/pipeline/output/builder.go
+++ b/pkg/pipeline/output/builder.go
@@ -57,11 +57,12 @@ func buildStreamOutputBin(p *params.Params) (*Bin, error) {
 	}
 
 	b := &Bin{
-		bin:      bin,
-		protocol: p.OutputType,
-		tee:      tee,
-		sinks:    make(map[string]*streamSink),
-		logger:   p.Logger,
+		bin:         bin,
+		protocol:    p.OutputType,
+		tee:         tee,
+		sinks:       make(map[string]*streamSink),
+		isSDKSource: !p.IsWebSource,
+		logger:      p.Logger,
 	}
 
 	for _, url := range p.StreamUrls {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -116,6 +116,7 @@ func New(ctx context.Context, conf *config.Config, p *params.Params) (*Pipeline,
 		if err = out.Link(); err != nil {
 			return nil, err
 		}
+
 		// link bins
 		if err = in.Bin().Link(out.Element()); err != nil {
 			return nil, err
@@ -279,7 +280,6 @@ func (p *Pipeline) messageWatch(msg *gst.Message) bool {
 
 	case gst.MessageStateChanged:
 		if p.playing {
-			p.Logger.Debugw(msg.String())
 			return true
 		}
 


### PR DESCRIPTION
Proxy pad and buffers were occasionally being dereferenced and freed early, resulting in segmentation faults.
The issue is random but happened more frequently with track composite than room composite