### PR TITLE
Update dockerfiles, fix handler signals

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Download Go modules
         run: go mod download

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM livekit/gstreamer:1.20.3-dev
+FROM livekit/gstreamer:1.20.3-dev-fork
 
 ARG TARGETPLATFORM
 
@@ -21,7 +21,7 @@ COPY version/ version/
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
     CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -o egress ./cmd/server
 
-FROM livekit/gstreamer:1.20.3-prod
+FROM livekit/gstreamer:1.20.3-prod-fork
 
 ARG TARGETPLATFORM
 

--- a/build/gstreamer/Dockerfile-dev
+++ b/build/gstreamer/Dockerfile-dev
@@ -1,6 +1,6 @@
 ARG GSTREAMER_VERSION
 
-FROM livekit/gstreamer:${GSTREAMER_VERSION}-base
+FROM livekit/gstreamer:${GSTREAMER_VERSION}-base-fork
 
 ENV DEBUG=true
 ENV OPTIMIZATIONS=false

--- a/build/gstreamer/Dockerfile-prod
+++ b/build/gstreamer/Dockerfile-prod
@@ -1,6 +1,6 @@
 ARG GSTREAMER_VERSION
 
-FROM livekit/gstreamer:${GSTREAMER_VERSION}-base
+FROM livekit/gstreamer:${GSTREAMER_VERSION}-base-fork
 
 ENV DEBUG=false
 ENV OPTIMIZATIONS=true

--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM livekit/gstreamer:1.20.3-dev
+FROM livekit/gstreamer:1.20.3-dev-fork
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/livekit/egress
 
-go 1.17
+go 1.18
 
 replace github.com/tinyzimmer/go-gst v0.2.32 => github.com/livekit/go-gst v0.0.0-20220603230042-cef031256427
 
@@ -17,6 +17,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/grafov/m3u8 v0.11.1
 	github.com/livekit/livekit-server v1.2.1
+	github.com/livekit/mageutil v0.0.0-20220927214055-ff37ecf1f093
 	github.com/livekit/protocol v1.1.2
 	github.com/livekit/server-sdk-go v1.0.0
 	github.com/mackerelio/go-osstat v0.2.3
@@ -104,6 +105,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/net v0.0.0-20220728211354-c7608f3a8462 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
+	golang.org/x/sync v0.0.0-20220923202941-7f9b1623fab7 // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect

--- a/go.sum
+++ b/go.sum
@@ -337,6 +337,8 @@ github.com/livekit/go-gst v0.0.0-20220603230042-cef031256427 h1:gHV/CCSlkURRIkjL
 github.com/livekit/go-gst v0.0.0-20220603230042-cef031256427/go.mod h1:0hI+orMYVT61TEh429LvmoV9UmyqjeTqdJ3DW2TX114=
 github.com/livekit/livekit-server v1.2.1 h1:eyhjpQe9HBrEH2iVhMsOlrzorgW+T0XG71CKrYBNqWw=
 github.com/livekit/livekit-server v1.2.1/go.mod h1:DzyJyStwd1+F/5x95DacrVCtsgTh2FlXaSyDr+3js5Q=
+github.com/livekit/mageutil v0.0.0-20220927214055-ff37ecf1f093 h1:a5Pzvr9EC+qLVDOVxM/008CCBogusc9pNIfCrXCTQtw=
+github.com/livekit/mageutil v0.0.0-20220927214055-ff37ecf1f093/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/protocol v1.0.2-0.20220909090645-6ec04e9ca47e/go.mod h1:ykRtMmaq4blqGyLWWPtYkB/74JYsyK7N2DAXLGnfSa4=
 github.com/livekit/protocol v1.1.2 h1:LDEFKK16T57pwDwxlJkkWMpbgvR0DJ3PozjOnvq29CI=
 github.com/livekit/protocol v1.1.2/go.mod h1:eburCdz6ZtbgKSKYkAeCdWP1z33DB9clTphz7uNaxp0=
@@ -685,6 +687,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220923202941-7f9b1623fab7 h1:ZrnxWX62AgTKOSagEqxvb3ffipvEDX2pl7E1TdqLqIc=
+golang.org/x/sync v0.0.0-20220923202941-7f9b1623fab7/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/magefile.go
+++ b/magefile.go
@@ -3,14 +3,13 @@
 package main
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
-	"github.com/livekit/egress/version"
+	"github.com/livekit/mageutil"
 )
 
 const (
@@ -22,10 +21,6 @@ const (
 )
 
 func Integration(configFile string) error {
-	return integration(configFile)
-}
-
-func integration(configFile string) error {
 	dir, err := os.Getwd()
 	if err != nil {
 		return err
@@ -56,8 +51,8 @@ func integration(configFile string) error {
 		}
 	}()
 
-	return run(
-		fmt.Sprintf("docker pull livekit/gstreamer:%s-dev", gstVersion),
+	return mageutil.Run(context.Background(),
+		fmt.Sprintf("docker pull livekit/gstreamer:%s-dev-fork", gstVersion),
 		"docker build -t egress-test -f build/test/Dockerfile .",
 		fmt.Sprintf(
 			"docker run --rm -e %s=%s -v %s/test:/out egress-test",
@@ -66,70 +61,33 @@ func integration(configFile string) error {
 	)
 }
 
-func GStreamer() error {
-	commands := []string{"docker pull ubuntu:22.04"}
-	for _, build := range []string{"base", "dev", "prod"} {
-		commands = append(commands, fmt.Sprintf(
-			"docker build"+
-				" --no-cache"+
-				" -t %s:%s-%s"+
-				" --build-arg GSTREAMER_VERSION=%s"+
-				" -f build/gstreamer/Dockerfile-%s"+
-				" ./build/gstreamer",
-			gstImageName, gstVersion, build, gstVersion, build,
-		))
-	}
-
-	return run(commands...)
-}
-
-func PublishGStreamer() error {
-	commands := []string{"docker pull ubuntu:22.04"}
-	for _, build := range []string{"base", "dev", "prod"} {
-		commands = append(commands, fmt.Sprintf(
-			"docker buildx build --push"+
-				" --no-cache"+
-				" --platform linux/amd64,linux/arm64"+
-				" -t %s:%s-%s"+
-				" --build-arg GSTREAMER_VERSION=%s"+
-				" -f build/gstreamer/Dockerfile-%s"+
-				" ./build/gstreamer",
-			gstImageName, gstVersion, build, gstVersion, build,
-		))
-	}
-
-	return run(commands...)
-}
-
-func Docker() error {
-	return run(
-		fmt.Sprintf("docker pull livekit/gstreamer:%s-dev", gstVersion),
-		fmt.Sprintf("docker pull livekit/gstreamer:%s-prod", gstVersion),
-		fmt.Sprintf("docker build -t %s:v%s -f build/Dockerfile .", imageName, version.Version),
+func Build() error {
+	return mageutil.Run(context.Background(),
+		fmt.Sprintf("docker pull livekit/gstreamer:%s-dev-fork", gstVersion),
+		fmt.Sprintf("docker pull livekit/gstreamer:%s-prod-fork", gstVersion),
+		fmt.Sprintf("docker build -t %s:latest -f build/Dockerfile .", imageName),
 	)
 }
 
-func PublishDocker() error {
-	if !strings.Contains(version.Version, "SNAPSHOT") {
-		return errors.New("cannot publish non-snapshot version")
-	}
-
-	return run(fmt.Sprintf(
-		"docker buildx build --push"+
-			" --platform linux/amd64,linux/arm64"+
-			" -t %s:v%s -f build/Dockerfile .",
-		imageName, version.Version))
+func BuildGStreamer() error {
+	return buildGstreamer("docker build --no-cache")
 }
 
-func run(commands ...string) error {
-	for _, command := range commands {
-		args := strings.Split(command, " ")
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return err
-		}
+func PublishGStreamer() error {
+	return buildGstreamer("docker buildx build --no-cache --push --platform linux/amd64,linux/arm64")
+}
+
+func buildGstreamer(cmd string) error {
+	commands := []string{"docker pull ubuntu:22.04"}
+	for _, build := range []string{"base", "dev", "prod"} {
+		commands = append(commands, fmt.Sprintf("%s"+
+			" --build-arg GSTREAMER_VERSION=%s"+
+			" -t %s:%s-%s-fork"+
+			" -f build/gstreamer/Dockerfile-%s"+
+			" ./build/gstreamer",
+			cmd, gstVersion, gstImageName, build, gstVersion, build,
+		))
 	}
-	return nil
+
+	return mageutil.Run(context.Background(), commands...)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "1.4.1"
+const Version = "1.4.2"


### PR DESCRIPTION
v1.4.1 appears to still be using the old gstreamer dockerfiles (builder had possibly cached them?)
Changed gstreamer dockerfile names to force update and can no longer reproduce the Caps changes not supported issue.

Also fixes handler shutdown, which was being killed instead of the signal being caught