### PR TITLE
Fix starting stopped container

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -81,7 +81,6 @@ RUN adduser root pulse-access
 # clean up
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/run/pulse /var/lib/pulse /root/.config/pulse && \
     mkdir -pv ~/.cache/xdgr
 
 # set xdg_runtime_dir

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -3,6 +3,9 @@ set -euxo pipefail
 
 export TMPDIR=/tmp/lkegress
 
+# Cleanup to be "stateless" on startup, otherwise pulseaudio daemon can't start again
+rm -rf /var/run/pulse /var/lib/pulse /root/.config/pulse
+
 # Start pulseaudio as system wide daemon; for debugging it helps to start in non-daemon mode
 pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
 


### PR DESCRIPTION
Prior this commit it's impossible to start again already stopped container.
```
[nkonev@fedora ~]$ docker logs -f videochat_egress_1
+ export TMPDIR=/tmp/lkegress
+ TMPDIR=/tmp/lkegress
+ pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
W: [pulseaudio] main.c: Running in system mode, but --disallow-module-loading not set.
N: [pulseaudio] main.c: Running in system mode, forcibly disabling SHM mode.
I: [pulseaudio] main.c: Daemon startup successful.
+ '[' -z /tmp/lkegress ']'
+ mkdir -p /tmp/lkegress
+ exec egress
{"level":"info","ts":1665693000.0708337,"logger":"egress","caller":"redis/redis.go:53","msg":"connecting to redis","nodeID":"NE_wQ5UGX87HS5d","sentinel":false,"addr":"redis:6379"}

^C
[nkonev@fedora ~]$ docker stop videochat_egress_1
videochat_egress_1
[nkonev@fedora ~]$ docker start videochat_egress_1
videochat_egress_1
[nkonev@fedora ~]$ docker logs -f videochat_egress_1
+ export TMPDIR=/tmp/lkegress
+ TMPDIR=/tmp/lkegress
+ pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
W: [pulseaudio] main.c: Running in system mode, but --disallow-module-loading not set.
N: [pulseaudio] main.c: Running in system mode, forcibly disabling SHM mode.
I: [pulseaudio] main.c: Daemon startup successful.
+ '[' -z /tmp/lkegress ']'
+ mkdir -p /tmp/lkegress
+ exec egress
{"level":"info","ts":1665693000.0708337,"logger":"egress","caller":"redis/redis.go:53","msg":"connecting to redis","nodeID":"NE_wQ5UGX87HS5d","sentinel":false,"addr":"redis:6379"}
{"level":"info","ts":1665693008.62964,"logger":"egress","caller":"server/main.go:100","msg":"exit requested, finishing recording then shutting down","nodeID":"NE_wQ5UGX87HS5d","signal":"terminated"}
{"level":"info","ts":1665693008.6298237,"logger":"egress","caller":"service/service.go:98","msg":"shutting down","nodeID":"NE_wQ5UGX87HS5d"}
+ export TMPDIR=/tmp/lkegress
+ TMPDIR=/tmp/lkegress
+ pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
W: [pulseaudio] main.c: Running in system mode, but --disallow-module-loading not set.
N: [pulseaudio] main.c: Running in system mode, forcibly disabling SHM mode.
E: [pulseaudio] main.c: Daemon startup failed.
```

After a long time of debugging I found the solution here https://superuser.com/a/1545361

After applying this PR container can start again after stop.