### PR TITLE
Clean up active counter

### DIFF
--- a/pkg/pipeline/input/sdk/input.go
+++ b/pkg/pipeline/input/sdk/input.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pion/webrtc/v3"
 	"github.com/tinyzimmer/go-gst/gst/app"
-	"go.uber.org/atomic"
 
 	"github.com/livekit/egress/pkg/pipeline/input/bin"
 	"github.com/livekit/egress/pkg/pipeline/params"
@@ -28,7 +27,6 @@ type SDKInput struct {
 
 	room   *lksdk.Room
 	logger logger.Logger
-	active atomic.Int32
 	cs     *synchronizer
 
 	// track

--- a/pkg/pipeline/input/sdk/source.go
+++ b/pkg/pipeline/input/sdk/source.go
@@ -193,15 +193,9 @@ func (s *SDKInput) onParticipantDisconnected(p *lksdk.RemoteParticipant) {
 	identity := p.Identity()
 	if identity == s.audioParticipant {
 		s.audioWriter.sendEOS()
-		if s.active.Dec() == 0 {
-			s.onDisconnected()
-		}
 	}
 	if identity == s.videoParticipant {
 		s.videoWriter.sendEOS()
-		if s.active.Dec() == 0 {
-			s.onDisconnected()
-		}
 	}
 }
 
@@ -248,10 +242,6 @@ func (s *SDKInput) onTrackUnmuted(pub lksdk.TrackPublication, _ lksdk.Participan
 func (s *SDKInput) onTrackUnpublished(track *lksdk.RemoteTrackPublication, _ *lksdk.RemoteParticipant) {
 	if w := s.getWriterForTrack(track.SID()); w != nil {
 		w.sendEOS()
-	}
-
-	if s.active.Dec() == 0 {
-		s.onDisconnected()
 	}
 }
 
@@ -301,7 +291,6 @@ func (s *SDKInput) subscribeToTracks(expecting map[string]struct{}) error {
 						}
 
 						delete(expecting, track.SID())
-						s.active.Inc()
 						if len(expecting) == 0 {
 							return nil
 						}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -282,17 +282,7 @@ func (p *Pipeline) messageWatch(msg *gst.Message) bool {
 
 		p.Logger.Debugw("EOS received, stopping pipeline")
 		p.closeOnce.Do(func() {
-			close(p.closed)
-			if p.limitTimer != nil {
-				p.limitTimer.Stop()
-			}
-
-			if p.Info.Status == livekit.EgressStatus_EGRESS_ACTIVE {
-				p.Info.Status = livekit.EgressStatus_EGRESS_ENDING
-				if p.onStatusUpdate != nil {
-					p.onStatusUpdate(context.Background(), p.Info)
-				}
-			}
+			p.close(context.Background())
 		})
 
 		p.stop()
@@ -466,15 +456,7 @@ func (p *Pipeline) SendEOS(ctx context.Context) {
 	defer span.End()
 
 	p.closeOnce.Do(func() {
-		close(p.closed)
-		if p.limitTimer != nil {
-			p.limitTimer.Stop()
-		}
-
-		p.Info.Status = livekit.EgressStatus_EGRESS_ENDING
-		if p.onStatusUpdate != nil {
-			p.onStatusUpdate(ctx, p.Info)
-		}
+		p.close(ctx)
 
 		go func() {
 			p.Logger.Debugw("sending EOS to pipeline")
@@ -492,6 +474,20 @@ func (p *Pipeline) SendEOS(ctx context.Context) {
 			}
 		}()
 	})
+}
+
+func (p *Pipeline) close(ctx context.Context) {
+	close(p.closed)
+	if p.limitTimer != nil {
+		p.limitTimer.Stop()
+	}
+
+	if p.Info.Status == livekit.EgressStatus_EGRESS_ACTIVE {
+		p.Info.Status = livekit.EgressStatus_EGRESS_ENDING
+		if p.onStatusUpdate != nil {
+			p.onStatusUpdate(ctx, p.Info)
+		}
+	}
 }
 
 func (p *Pipeline) startSessionLimitTimer(ctx context.Context) {


### PR DESCRIPTION
not needed, since each appsrc handles its own stream and sends EOS events