### PR TITLE
Revert "Adopt cgroup based CPU monitoring from protocol (#144)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,9 @@ require (
 	github.com/grafov/m3u8 v0.11.1
 	github.com/livekit/livekit-server v1.2.1
 	github.com/livekit/mageutil v0.0.0-20220927214055-ff37ecf1f093
-	github.com/livekit/protocol v1.1.3-0.20221017221212-9b09be77efec
+	github.com/livekit/protocol v1.1.3-0.20221014231313-85bf30570f0f
 	github.com/livekit/server-sdk-go v1.0.0
+	github.com/mackerelio/go-osstat v0.2.3
 	github.com/pion/rtp v1.7.13
 	github.com/pion/webrtc/v3 v3.1.44
 	github.com/prometheus/client_golang v1.13.0
@@ -67,7 +68,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
 	github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995 // indirect
-	github.com/mackerelio/go-osstat v0.2.3 // indirect
 	github.com/magefile/mage v1.13.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-ieproxy v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/livekit/livekit-server v1.2.1 h1:eyhjpQe9HBrEH2iVhMsOlrzorgW+T0XG71CK
 github.com/livekit/livekit-server v1.2.1/go.mod h1:DzyJyStwd1+F/5x95DacrVCtsgTh2FlXaSyDr+3js5Q=
 github.com/livekit/mageutil v0.0.0-20220927214055-ff37ecf1f093 h1:a5Pzvr9EC+qLVDOVxM/008CCBogusc9pNIfCrXCTQtw=
 github.com/livekit/mageutil v0.0.0-20220927214055-ff37ecf1f093/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/protocol v1.1.3-0.20221017221212-9b09be77efec h1:hlFRD++CoQkBsuxqMWkgG/uy+W1/ScQAGiFkr97LxQ0=
-github.com/livekit/protocol v1.1.3-0.20221017221212-9b09be77efec/go.mod h1:2xNj9tUehjGYkptvCF7r0vgx3+D7kawK+a8rTsaLelY=
+github.com/livekit/protocol v1.1.3-0.20221014231313-85bf30570f0f h1:pGJ6SFZzL77Fj70RmnMdTn7bSmCsJiBb4S1gEsClHo4=
+github.com/livekit/protocol v1.1.3-0.20221014231313-85bf30570f0f/go.mod h1:jshI3nWbZkF1y1TUr2WIqzhN9HnyMqM9v/e/31L78z0=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995 h1:vOaY2qvfLihDyeZtnGGN1Law9wRrw8BMGCr1TygTvMw=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995/go.mod h1:116ych8UaEs9vfIE8n6iZCZ30iagUFTls0vRmC+Ix5U=
 github.com/livekit/server-sdk-go v1.0.0 h1:bcWTcvbAc4QgA1d8a9iyJVFeN8uIh5y23IeJIK+nvI0=


### PR DESCRIPTION
This reverts commit 3304f9aa2f5401100ab6c551c8a6543e5025235e.

https://github.com/livekit/egress/issues/150