### PR TITLE
Fix pointer logic in convertS3Metadata

### DIFF
--- a/pkg/pipeline/sink/upload.go
+++ b/pkg/pipeline/sink/upload.go
@@ -72,7 +72,8 @@ func UploadS3(conf *livekit.S3Upload, localFilepath, storageFilepath string, mim
 func convertS3Metadata(metadata map[string]string) map[string]*string {
 	var result = map[string]*string{}
 	for k, v := range metadata {
-		result[k] = &v
+		allocatedVal := v
+		result[k] = &allocatedVal
 	}
 	return result
 }


### PR DESCRIPTION
Before this commit values in convertS3Metadata aren't copied correctly:
Here is an example of my debug logs
```
{"level":"info","ts":1666821215.93387,"logger":"egress","caller":"sink/upload.go:74","msg":"Converting metadata","nodeID":"NE_uctjWkgHRqgc","metadata":{"chatid":"1","filename":"recording_1666821174.mp4","ownerid":"2"}}
{"level":"info","ts":1666821215.933929,"logger":"egress","caller":"sink/upload.go:77","msg":"Converting","nodeID":"NE_uctjWkgHRqgc","key":"chatid","value":"1"}
{"level":"info","ts":1666821215.9339428,"logger":"egress","caller":"sink/upload.go:77","msg":"Converting","nodeID":"NE_uctjWkgHRqgc","key":"filename","value":"recording_1666821174.mp4"}
{"level":"info","ts":1666821215.93395,"logger":"egress","caller":"sink/upload.go:77","msg":"Converting","nodeID":"NE_uctjWkgHRqgc","key":"ownerid","value":"2"}
{"level":"info","ts":1666821215.933957,"logger":"egress","caller":"sink/upload.go:80","msg":"Converted metadata","nodeID":"NE_uctjWkgHRqgc","metadata2":{"chatid":"2","filename":"2","ownerid":"2"}}
```

We can see that in resulting metadata2 we have the same value in metadata2.

Here is isolated examples of this behaviour on Go playground
before https://go.dev/play/p/RAAerT4uiu1
after https://go.dev/play/p/XxXytXsEhTD

PTAL @frostbyte73 