### PR TITLE
Fixed disabling storing manifest

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -660,6 +660,10 @@ func (p *Pipeline) storeFile(ctx context.Context, localFilepath, storageFilepath
 }
 
 func (p *Pipeline) storeManifest(ctx context.Context, localFilepath, storageFilepath string) error {
+	if p.DisableManifest {
+		p.Logger.Debugw("Storing manifest is disabled")
+		return nil
+	}
 	manifest, err := os.Create(localFilepath)
 	if err != nil {
 		return err


### PR DESCRIPTION
![Screenshot from 2022-10-27 12-48-58](https://user-images.githubusercontent.com/3160384/198238849-fa5c44a5-cb29-46c0-90b4-3bafdf167ff3.png)
Before:
UploadParams.DisableManifest is written but isn't read.
After:
It's possible to skip storing manifest

PTAL @frostbyte73 @davidzhao 