### PR TITLE
v1.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/grafov/m3u8 v0.11.1
 	github.com/livekit/livekit-server v1.2.1
 	github.com/livekit/mageutil v0.0.0-20220927214055-ff37ecf1f093
-	github.com/livekit/protocol v1.2.3-0.20221111192145-b1eab0ff3832
+	github.com/livekit/protocol v1.2.3
 	github.com/livekit/server-sdk-go v1.0.5
 	github.com/pion/rtp v1.7.13
 	github.com/pion/webrtc/v3 v3.1.47

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,8 @@ github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b h1:RBNV
 github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b/go.mod h1:1Dlx20JPoIKGP45eo+yuj0HjeE25zmyeX/EWHiPCjFw=
 github.com/livekit/protocol v1.2.3-0.20221111192145-b1eab0ff3832 h1:VJfv3PtAcX3t0f7YfnuH2JY64/VhriOsQ7nIIhKefbg=
 github.com/livekit/protocol v1.2.3-0.20221111192145-b1eab0ff3832/go.mod h1:eveiL9UJGmVsmqVXVVZtCMkkqH83YyHcDt+ryZWbc6E=
+github.com/livekit/protocol v1.2.3 h1:iy0mVixq6u2X+X1Z74OMOZ4R7MVgkb2po6hFCeJ7XNU=
+github.com/livekit/protocol v1.2.3/go.mod h1:eveiL9UJGmVsmqVXVVZtCMkkqH83YyHcDt+ryZWbc6E=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995 h1:vOaY2qvfLihDyeZtnGGN1Law9wRrw8BMGCr1TygTvMw=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995/go.mod h1:116ych8UaEs9vfIE8n6iZCZ30iagUFTls0vRmC+Ix5U=
 github.com/livekit/server-sdk-go v1.0.5 h1:BV/MrehCCVi1VxjZxjxqkWDbqpnjhH4a7TWQXGH30/Y=

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "1.5.1"
+const Version = "1.5.2"


### PR DESCRIPTION
Version 1.5.2
    
## Changelog
### Fixed
- support for running on linux systems with no cgroup support #169
- CPU usage ratio reporting when a cgroup CPU quota is set #169
- H264 subscription support with web composite exports
