### PR TITLE
Egress record start failed with pulse sink load module Failure: Module initialization failed #196

### DIFF
--- a/pkg/pipeline/input/web/source.go
+++ b/pkg/pipeline/input/web/source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"strings"
 
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
@@ -44,7 +45,7 @@ func (s *WebInput) createPulseSink(ctx context.Context, p *config.PipelineConfig
 		return errors.Fatal(err)
 	}
 
-	s.pulseSink = b.String()
+	s.pulseSink = strings.TrimRight(b.String(), "\n")
 	return nil
 }
 


### PR DESCRIPTION
* Remove the \n  character from the return result
*  I add debug log after WebInput.close() to show the module NO. which it wants to unload-module and found that the "pulseSink" has value include "\n". And I try to execute the command "pactl unload-module 10\n"at egress server, it returns error:
```
root@qm-egress-deployment-bbcf5fbc6-7p5fq:/data# pactl unload-module 10\n
Failed to unload module: Module 10n not loaded
```
* So I think that the "pulseSink" is comes from the result of "pactl load-module ...", but it contains the \n character. So we can remove it before set it to "pulseSink". 
* I test the changed code in my environment, and it works well, and no more new modules left in pulse audio after egress stop.

@davidzhao , @frostbyte73 , please help to review the code.
