### PR TITLE
Use separate queues for audio and video into the muxer. Fix integration test performance

### DIFF
--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -4,6 +4,33 @@ WORKDIR /workspace
 
 ARG TARGETPLATFORM
 
+# install go
+RUN apt-get update && apt-get install -y golang
+
+# download go modules
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# copy source
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+COPY version/ version/
+
+COPY test/ test/
+
+# build (service tests will need to launch the handler)
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -o egress ./cmd/server
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go test -c -v --tags=integration ./test
+
+
+FROM livekit/gstreamer:1.20.4-prod
+
+ARG TARGETPLATFORM
+
 # install deps
 RUN apt-get update && \
     apt-get install -y \
@@ -11,7 +38,6 @@ RUN apt-get update && \
         ffmpeg \
         fonts-noto \
         gnupg \
-        golang \
         gstreamer1.0-pulseaudio \
         pulseaudio \
         unzip \
@@ -42,22 +68,13 @@ ENV PATH=${PATH}:/chrome
 ENV XDG_RUNTIME_DIR=$PATH:~/.cache/xdgr
 ENV RTSP_LOGDESTINATIONS=file
 
-# download go modules
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
+COPY test/ /workspace/test/
 
-# copy source
-COPY cmd/ cmd/
-COPY pkg/ pkg/
-COPY version/ version/
+# egress
+COPY --from=0 /workspace/egress /bin/
 
-# build (service tests will need to launch the handler)
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -o /bin/egress ./cmd/server
-
-# copy test after building to allow for cached server
-COPY test/ test/
+# test
+COPY --from=0 /workspace/test.test .
 
 # run
 COPY build/test/entrypoint.sh .

--- a/build/test/entrypoint.sh
+++ b/build/test/entrypoint.sh
@@ -8,4 +8,4 @@ pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
 ./rtsp-simple-server &
 
 # Run tests
-exec go test -v --tags=integration -timeout 20m ./test
+exec ./test.test -test.v -test.timeout 20m

--- a/magefile.go
+++ b/magefile.go
@@ -106,7 +106,7 @@ func Integration(configFile string) error {
 
 	return mageutil.Run(context.Background(),
 		"docker build -t egress-test -f build/test/Dockerfile .",
-		fmt.Sprintf("docker run --rm -e EGRESS_CONFIG_FILE=%s -p 9000:9000 -v %s/test:/out egress-test", configFile, dir),
+		fmt.Sprintf("docker run --rm -e EGRESS_CONFIG_FILE=%s -v %s/test:/out egress-test", configFile, dir),
 	)
 }
 

--- a/pkg/pipeline/input/builder/audio.go
+++ b/pkg/pipeline/input/builder/audio.go
@@ -178,7 +178,7 @@ func (a *AudioInput) buildSDKDecoder(p *config.PipelineConfig, src *app.Source, 
 }
 
 func (a *AudioInput) addConverter(p *config.PipelineConfig) error {
-	audioQueue, err := buildQueue()
+	audioQueue, err := buildQueue(Latency/10, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/pipeline/input/builder/video.go
+++ b/pkg/pipeline/input/builder/video.go
@@ -72,7 +72,7 @@ func (v *VideoInput) buildWebDecoder(p *config.PipelineConfig) error {
 		return err
 	}
 
-	videoQueue, err := buildQueue()
+	videoQueue, err := buildQueue(Latency/10, true)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func (v *VideoInput) buildSDKDecoder(p *config.PipelineConfig, src *app.Source, 
 		return errors.ErrNotSupported(codec.MimeType)
 	}
 
-	videoQueue, err := buildQueue()
+	videoQueue, err := buildQueue(Latency/10, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/pipeline/input/builder/video.go
+++ b/pkg/pipeline/input/builder/video.go
@@ -72,12 +72,17 @@ func (v *VideoInput) buildWebDecoder(p *config.PipelineConfig) error {
 		return err
 	}
 
-	videoQueue, err := buildQueue(Latency/10, true)
+	videoQueueSrc, err := buildQueue(Latency/10, true)
 	if err != nil {
 		return err
 	}
 
 	videoConvert, err := gst.NewElement("videoconvert")
+	if err != nil {
+		return err
+	}
+
+	videoQueueEnc, err := buildQueue(Latency/10, false)
 	if err != nil {
 		return err
 	}
@@ -92,7 +97,7 @@ func (v *VideoInput) buildWebDecoder(p *config.PipelineConfig) error {
 		return err
 	}
 
-	v.elements = []*gst.Element{xImageSrc, videoQueue, videoConvert, caps}
+	v.elements = []*gst.Element{xImageSrc, videoQueueSrc, videoConvert, videoQueueEnc, caps}
 	return nil
 }
 
@@ -162,12 +167,7 @@ func (v *VideoInput) buildSDKDecoder(p *config.PipelineConfig, src *app.Source, 
 		return err
 	}
 
-	videoConvert, err := gst.NewElement("videoconvert")
-	if err != nil {
-		return err
-	}
-
-	videoScale, err := gst.NewElement("videoscale")
+	videoConvertScale, err := gst.NewElement("videoconvertscale")
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func (v *VideoInput) buildSDKDecoder(p *config.PipelineConfig, src *app.Source, 
 		return err
 	}
 
-	v.elements = append(v.elements, videoQueue, videoConvert, videoScale, videoRate, caps)
+	v.elements = append(v.elements, videoQueue, videoConvertScale, videoRate, caps)
 	return nil
 }
 

--- a/pkg/pipeline/input/builder/video.go
+++ b/pkg/pipeline/input/builder/video.go
@@ -162,7 +162,12 @@ func (v *VideoInput) buildSDKDecoder(p *config.PipelineConfig, src *app.Source, 
 		return err
 	}
 
-	videoConvertScale, err := gst.NewElement("videoconvertscale")
+	videoConvert, err := gst.NewElement("videoconvert")
+	if err != nil {
+		return err
+	}
+
+	videoScale, err := gst.NewElement("videoscale")
 	if err != nil {
 		return err
 	}
@@ -185,7 +190,7 @@ func (v *VideoInput) buildSDKDecoder(p *config.PipelineConfig, src *app.Source, 
 		return err
 	}
 
-	v.elements = append(v.elements, videoQueue, videoConvertScale, videoRate, caps)
+	v.elements = append(v.elements, videoQueue, videoConvert, videoScale, videoRate, caps)
 	return nil
 }
 


### PR DESCRIPTION
This PR switches the multi queue for 2 separate queues for audio and video. It also reduces the length of the input raw buffer queues to decreases memory usage.

In order to improve the performance of the integration test suite, run against an optimized version of Gstreamer.