### PR TITLE
Add support for setting the key frame interval in encoding parameters.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grafov/m3u8 v0.11.1
 	github.com/livekit/livekit-server v1.3.3-0.20221227214332-5d3f64466700
 	github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290
-	github.com/livekit/protocol v1.3.1
+	github.com/livekit/protocol v1.3.2-0.20221228042140-d4406dd27954
 	github.com/livekit/psrpc v0.2.1
 	github.com/livekit/server-sdk-go v1.0.6
 	github.com/pion/rtp v1.7.13

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,10 @@ github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290 h1:ZVsQUuUOM9G7O3
 github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b h1:RBNV8TckETSkIkKxcD12d8nZKVkB9GSY/sQlMoaruP4=
 github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b/go.mod h1:1Dlx20JPoIKGP45eo+yuj0HjeE25zmyeX/EWHiPCjFw=
-github.com/livekit/protocol v1.3.1 h1:LunQgRkEbUTvXhtP7Q509CvWlfQqSTwZ/aEb9bWdKi4=
-github.com/livekit/protocol v1.3.1/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
+github.com/livekit/protocol v1.3.2-0.20221228030635-ad1f77de853e h1:eHc+mYJIniYi7rQ4I7EJHedaLeg5TF3DFNjkwFidAd0=
+github.com/livekit/protocol v1.3.2-0.20221228030635-ad1f77de853e/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
+github.com/livekit/protocol v1.3.2-0.20221228042140-d4406dd27954 h1:KNh364GX2ipBRGIza6b7xh6OijUwKw4ZVLPBwv0Bs10=
+github.com/livekit/protocol v1.3.2-0.20221228042140-d4406dd27954/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
 github.com/livekit/psrpc v0.2.1 h1:ph/4egUMueUPoh5PZ/Aw4v6SH3wAbA+2t/GyCbpPKTg=
 github.com/livekit/psrpc v0.2.1/go.mod h1:MCe0xLdFPXmzogPiLrM94JIJbctb9+fAv5qYPkY2DXw=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995 h1:vOaY2qvfLihDyeZtnGGN1Law9wRrw8BMGCr1TygTvMw=

--- a/pkg/config/encoding.go
+++ b/pkg/config/encoding.go
@@ -92,4 +92,7 @@ func (p *PipelineConfig) applyAdvanced(advanced *livekit.EncodingOptions) {
 	if advanced.VideoBitrate != 0 {
 		p.VideoBitrate = advanced.VideoBitrate
 	}
+	if advanced.KeyFrameInterval != 0 {
+		p.KeyFrameInterval = advanced.KeyFrameInterval
+	}
 }

--- a/pkg/pipeline/input/builder/video.go
+++ b/pkg/pipeline/input/builder/video.go
@@ -225,11 +225,14 @@ func (v *VideoInput) buildEncoder(p *config.PipelineConfig) error {
 			return err
 		}
 		x264Enc.SetArg("speed-preset", "veryfast")
-		if p.OutputType == types.OutputTypeHLS {
-			// The muxer should request key frames to match the segment duration. Set a 2 x segment duration on the encoder as a safeguard.
-			if err = x264Enc.SetProperty("key-int-max", uint(int32(p.SegmentDuration)*p.Framerate*2)); err != nil {
+
+		if p.KeyFrameInterval != 0 {
+			if err = x264Enc.SetProperty("key-int-max", uint(p.KeyFrameInterval*float64(p.Framerate))); err != nil {
 				return err
 			}
+		}
+
+		if p.OutputType == types.OutputTypeHLS {
 			// Avoid key frames other than at segments boundaries as splitmuxsink can become inconsistent otherwise
 			if err = x264Enc.SetProperty("option-string", "scenecut=0"); err != nil {
 				return err

--- a/test/ffprobe.go
+++ b/test/ffprobe.go
@@ -274,6 +274,18 @@ func verify(t *testing.T, input string, p *config.PipelineConfig, res *livekit.E
 					require.NoError(t, err)
 					require.NotZero(t, bitrate)
 					require.Less(t, int32(bitrate), p.VideoBitrate*1010)
+
+					// framerate
+					frac := strings.Split(stream.AvgFrameRate, "/")
+					require.Len(t, frac, 2)
+					n, err := strconv.ParseFloat(frac[0], 64)
+					require.NoError(t, err)
+					d, err := strconv.ParseFloat(frac[1], 64)
+					require.NoError(t, err)
+					require.NotZero(t, d)
+					require.Less(t, n/d, float64(p.Framerate)*1.05)
+					require.Greater(t, n/d, float64(sourceFramerate)*0.95)
+
 				}
 				fallthrough
 
@@ -285,16 +297,6 @@ func verify(t *testing.T, input string, p *config.PipelineConfig, res *livekit.E
 					require.Equal(t, p.Width, stream.Width)
 					require.Equal(t, p.Height, stream.Height)
 
-					// framerate
-					frac := strings.Split(stream.RFrameRate, "/")
-					require.Len(t, frac, 2)
-					n, err := strconv.ParseFloat(frac[0], 64)
-					require.NoError(t, err)
-					d, err := strconv.ParseFloat(frac[1], 64)
-					require.NoError(t, err)
-					require.NotZero(t, d)
-					require.Less(t, n/d, float64(p.Framerate)*1.05)
-					require.Greater(t, n/d, float64(sourceFramerate)*0.95)
 				}
 			}
 


### PR DESCRIPTION
Default to 4s for streaming.

Also disable frame rate test for segments that fails on older versions of ffmpeg.