### PR TITLE
Restore capacity to set the segment filename suffix as a UTC timestamp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/livekit/egress
 
 go 1.18
 
-replace github.com/tinyzimmer/go-glib v0.0.25 => github.com/livekit/go-glib v0.0.0-20230222202039-9989900995bc
+replace github.com/tinyzimmer/go-glib v0.0.25 => github.com/livekit/go-glib v0.0.0-20230223001336-834490045522
 
 replace github.com/tinyzimmer/go-gst v0.2.33 => github.com/livekit/go-gst v0.2.34-0.20230210170313-8fc9f59623d4
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/livekit/egress
 
 go 1.18
 
+replace github.com/tinyzimmer/go-glib v0.0.25 => github.com/livekit/go-glib v0.0.0-20230222202039-9989900995bc
+
 replace github.com/tinyzimmer/go-gst v0.2.33 => github.com/livekit/go-gst v0.2.34-0.20230210170313-8fc9f59623d4
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/livekit/egress
 
 go 1.18
 
-replace github.com/tinyzimmer/go-gst v0.2.33 => github.com/livekit/go-gst v0.0.0-20220603230042-cef031256427
+replace github.com/tinyzimmer/go-gst v0.2.33 => github.com/livekit/go-gst v0.2.34-0.20230210170313-8fc9f59623d4
 
 require (
 	cloud.google.com/go/storage v1.29.0

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,8 @@ github.com/lithammer/shortuuid/v3 v3.0.7 h1:trX0KTHy4Pbwo/6ia8fscyHoGA+mf1jWbPJV
 github.com/lithammer/shortuuid/v3 v3.0.7/go.mod h1:vMk8ke37EmiewwolSO1NLW8vP4ZaKlRuDIi8tWWmAts=
 github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw7k08o4c=
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
-github.com/livekit/go-gst v0.0.0-20220603230042-cef031256427 h1:gHV/CCSlkURRIkjLmLjuXimvGGi7wedhXxk/zvUPLV0=
-github.com/livekit/go-gst v0.0.0-20220603230042-cef031256427/go.mod h1:0hI+orMYVT61TEh429LvmoV9UmyqjeTqdJ3DW2TX114=
+github.com/livekit/go-gst v0.2.34-0.20230210170313-8fc9f59623d4 h1:j/EJqSLOzBafKT/0OMvoEuA8JR8GRToaUOa7VwhVnpo=
+github.com/livekit/go-gst v0.2.34-0.20230210170313-8fc9f59623d4/go.mod h1:0hI+orMYVT61TEh429LvmoV9UmyqjeTqdJ3DW2TX114=
 github.com/livekit/livekit-server v1.3.5-0.20230218061519-7a2d9b3d615e h1:kohLaM1NGDE6uIKX6AdXF8ODehThBfflcOk+QE8+ons=
 github.com/livekit/livekit-server v1.3.5-0.20230218061519-7a2d9b3d615e/go.mod h1:4RMMhfu+ytX6JBCS2EJtMBo8V4abpRxntY4cU9/FaIc=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkDaKb5iXdynYrzB84ErPPO4LbRASk58=

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,8 @@ github.com/lithammer/shortuuid/v3 v3.0.7 h1:trX0KTHy4Pbwo/6ia8fscyHoGA+mf1jWbPJV
 github.com/lithammer/shortuuid/v3 v3.0.7/go.mod h1:vMk8ke37EmiewwolSO1NLW8vP4ZaKlRuDIi8tWWmAts=
 github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw7k08o4c=
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
-github.com/livekit/go-glib v0.0.0-20230222202039-9989900995bc h1:MV/24yEmeEU5p4jFEBs91rv45QVes1AxrttXjTk+krg=
-github.com/livekit/go-glib v0.0.0-20230222202039-9989900995bc/go.mod h1:ltV0gO6xNFzZhsIRbFXv8RTq9NGoNT2dmAER4YmZfaM=
+github.com/livekit/go-glib v0.0.0-20230223001336-834490045522 h1:AlU57PAPgzde7q9u6iFU+gyPhwWFUmyFCdzonBif4f4=
+github.com/livekit/go-glib v0.0.0-20230223001336-834490045522/go.mod h1:ltV0gO6xNFzZhsIRbFXv8RTq9NGoNT2dmAER4YmZfaM=
 github.com/livekit/go-gst v0.2.34-0.20230210170313-8fc9f59623d4 h1:j/EJqSLOzBafKT/0OMvoEuA8JR8GRToaUOa7VwhVnpo=
 github.com/livekit/go-gst v0.2.34-0.20230210170313-8fc9f59623d4/go.mod h1:0hI+orMYVT61TEh429LvmoV9UmyqjeTqdJ3DW2TX114=
 github.com/livekit/livekit-server v1.3.5-0.20230218061519-7a2d9b3d615e h1:kohLaM1NGDE6uIKX6AdXF8ODehThBfflcOk+QE8+ons=

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,8 @@ github.com/lithammer/shortuuid/v3 v3.0.7 h1:trX0KTHy4Pbwo/6ia8fscyHoGA+mf1jWbPJV
 github.com/lithammer/shortuuid/v3 v3.0.7/go.mod h1:vMk8ke37EmiewwolSO1NLW8vP4ZaKlRuDIi8tWWmAts=
 github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw7k08o4c=
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
+github.com/livekit/go-glib v0.0.0-20230222202039-9989900995bc h1:MV/24yEmeEU5p4jFEBs91rv45QVes1AxrttXjTk+krg=
+github.com/livekit/go-glib v0.0.0-20230222202039-9989900995bc/go.mod h1:ltV0gO6xNFzZhsIRbFXv8RTq9NGoNT2dmAER4YmZfaM=
 github.com/livekit/go-gst v0.2.34-0.20230210170313-8fc9f59623d4 h1:j/EJqSLOzBafKT/0OMvoEuA8JR8GRToaUOa7VwhVnpo=
 github.com/livekit/go-gst v0.2.34-0.20230210170313-8fc9f59623d4/go.mod h1:0hI+orMYVT61TEh429LvmoV9UmyqjeTqdJ3DW2TX114=
 github.com/livekit/livekit-server v1.3.5-0.20230218061519-7a2d9b3d615e h1:kohLaM1NGDE6uIKX6AdXF8ODehThBfflcOk+QE8+ons=
@@ -406,8 +408,6 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/thoas/go-funk v0.9.3 h1:7+nAEx3kn5ZJcnDm2Bh23N2yOtweO14bi//dvRtgLpw=
 github.com/thoas/go-funk v0.9.3/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
-github.com/tinyzimmer/go-glib v0.0.25 h1:2GpumtkxA0wpXhCXP6D3ksb5pGMfo9WbhgLvEw8njK4=
-github.com/tinyzimmer/go-glib v0.0.25/go.mod h1:ltV0gO6xNFzZhsIRbFXv8RTq9NGoNT2dmAER4YmZfaM=
 github.com/twitchtv/twirp v8.1.3+incompatible h1:+F4TdErPgSUbMZMwp13Q/KgDVuI7HJXP61mNV3/7iuU=
 github.com/twitchtv/twirp v8.1.3+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/urfave/cli/v2 v2.24.3 h1:7Q1w8VN8yE0MJEHP06bv89PjYsN4IHWED2s1v/Zlfm0=

--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -46,6 +46,7 @@ type SegmentParams struct {
 	LocalFilePrefix   string
 	StoragePathPrefix string
 	PlaylistFilename  string
+	SegmentSuffix     livekit.SegmentedFileSuffix
 	SegmentDuration   int
 }
 
@@ -300,6 +301,7 @@ func (p *PipelineConfig) getSegmentConfig(segments *livekit.SegmentedFileOutput)
 		SegmentParams: SegmentParams{
 			SegmentsInfo:     &livekit.SegmentsInfo{},
 			LocalFilePrefix:  segments.FilenamePrefix,
+			SegmentSuffix:    segments.FilenameSuffix,
 			PlaylistFilename: segments.PlaylistName,
 			SegmentDuration:  int(segments.SegmentDuration),
 		},

--- a/pkg/pipeline/sink/segments.go
+++ b/pkg/pipeline/sink/segments.go
@@ -30,6 +30,7 @@ type SegmentSink struct {
 	currentItemFilename       string
 	playlistPath              string
 	startDate                 time.Time
+	startDateTimestamp        time.Duration
 
 	openSegmentsStartTime map[string]int64
 	openSegmentsLock      sync.Mutex
@@ -122,14 +123,15 @@ func (s *SegmentSink) StartSegment(filepath string, startTime int64) error {
 		return fmt.Errorf("invalid start timestamp")
 	}
 
-	if s.startDate.IsZero() {
-		s.startDate = time.Now().Add(-time.Duration(startTime))
-	}
-
 	k := getFilenameFromFilePath(filepath)
 
 	s.openSegmentsLock.Lock()
 	defer s.openSegmentsLock.Unlock()
+
+	if s.startDateTimestamp == 0 {
+		s.startDateTimestamp = time.Duration(startTime)
+	}
+
 	if _, ok := s.openSegmentsStartTime[k]; ok {
 		return fmt.Errorf("segment with this name already started")
 	}
@@ -137,6 +139,13 @@ func (s *SegmentSink) StartSegment(filepath string, startTime int64) error {
 	s.openSegmentsStartTime[k] = startTime
 
 	return nil
+}
+
+func (s *SegmentSink) UpdateStartDate(t time.Time) {
+	s.openSegmentsLock.Lock()
+	defer s.openSegmentsLock.Unlock()
+
+	s.startDate = t
 }
 
 func (s *SegmentSink) EnqueueSegmentUpload(segmentPath string, endTime int64) error {
@@ -179,7 +188,7 @@ func (s *SegmentSink) endSegment(filepath string, endTime int64) error {
 		return err
 	}
 
-	segmentStartDate := s.startDate.Add(time.Duration(t))
+	segmentStartDate := s.startDate.Add(-s.startDateTimestamp).Add(time.Duration(t))
 	err = s.playlist.SetProgramDateTime(segmentStartDate)
 	if err != nil {
 		return err

--- a/pkg/pipeline/watch.go
+++ b/pkg/pipeline/watch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tinyzimmer/go-gst/gst"
 
 	"github.com/livekit/egress/pkg/errors"
+	"github.com/livekit/egress/pkg/pipeline/output"
 	"github.com/livekit/egress/pkg/pipeline/sink"
 	"github.com/livekit/egress/pkg/pipeline/source"
 	"github.com/livekit/egress/pkg/types"
@@ -16,11 +17,12 @@ import (
 )
 
 const (
-	msgClockProblem     = "GStreamer error: clock problem."
-	msgStreamingStopped = "streaming stopped, reason not-negotiated (-4)"
-	msgMuxer            = ":muxer"
-	msgFragmentOpened   = "splitmuxsink-fragment-opened"
-	msgFragmentClosed   = "splitmuxsink-fragment-closed"
+	msgClockProblem        = "GStreamer error: clock problem."
+	msgStreamingStopped    = "streaming stopped, reason not-negotiated (-4)"
+	msgMuxer               = ":muxer"
+	msgFragmentOpened      = "splitmuxsink-fragment-opened"
+	msgFragmentClosed      = "splitmuxsink-fragment-closed"
+	msgFirstSampleMetadata = "FirstSampleMetadata"
 
 	fragmentLocation    = "location"
 	fragmentRunningTime = "running-time"
@@ -204,6 +206,14 @@ func (p *Pipeline) handleMessageElement(msg *gst.Message) error {
 				logger.Errorw("failed to end segment with playlist writer", err, "running time", t)
 				return err
 			}
+		case msgFirstSampleMetadata:
+			startDate, err := getFirstSampleMetadataFromGstStructure(s)
+			if err != nil {
+				return err
+			}
+			logger.Debugw("reveived FirstSampleMetadata message", "startDate", startDate)
+
+			p.getSegmentSink().UpdateStartDate(startDate)
 		}
 	}
 
@@ -230,6 +240,16 @@ func getSegmentParamsFromGstStructure(s *gst.Structure) (filepath string, time i
 	}
 
 	return filepath, int64(ti), nil
+}
+
+func getFirstSampleMetadataFromGstStructure(s *gst.Structure) (startDate time.Time, err error) {
+	firstSampleMetadata := output.FirstSampleMetadata{}
+	err = s.UnmarshalInto(&firstSampleMetadata)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Unix(0, firstSampleMetadata.StartDate), nil
 }
 
 func (p *Pipeline) getSegmentSink() *sink.SegmentSink {

--- a/test/ffprobe.go
+++ b/test/ffprobe.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -24,6 +25,10 @@ const (
 	maxRetries = 5
 	minDelay   = time.Millisecond * 100
 	maxDelay   = time.Second * 5
+)
+
+var (
+	segmentTimeRegexp = regexp.MustCompile(`_(\d{14})(\d{3})\.ts`)
 )
 
 type FFProbeInfo struct {
@@ -125,7 +130,7 @@ func verifyStreams(t *testing.T, p *config.PipelineConfig, conf *TestConfig, url
 	}
 }
 
-func verifySegments(t *testing.T, conf *TestConfig, p *config.PipelineConfig, res *livekit.EgressInfo) {
+func verifySegments(t *testing.T, conf *TestConfig, p *config.PipelineConfig, filenameSuffix livekit.SegmentedFileSuffix, res *livekit.EgressInfo) {
 	// egress info
 	require.Equal(t, res.Error == "", res.Status != livekit.EgressStatus_EGRESS_FAILED)
 	require.NotZero(t, res.StartedAt)
@@ -145,7 +150,7 @@ func verifySegments(t *testing.T, conf *TestConfig, p *config.PipelineConfig, re
 	storedPlaylistPath := segments.PlaylistName
 	localPlaylistPath := segments.PlaylistName
 
-	verifyPlaylistProgramDateTime(t, localPlaylistPath)
+	verifyPlaylistProgramDateTime(t, filenameSuffix, localPlaylistPath)
 
 	// download from cloud storage
 	if uploadConfig := p.Outputs[types.EgressTypeSegments].UploadConfig; uploadConfig != nil {
@@ -164,7 +169,7 @@ func verifySegments(t *testing.T, conf *TestConfig, p *config.PipelineConfig, re
 	verify(t, localPlaylistPath, p, res, types.EgressTypeSegments, conf.Muting, conf.sourceFramerate)
 }
 
-func verifyPlaylistProgramDateTime(t *testing.T, localPlaylistPath string) {
+func verifyPlaylistProgramDateTime(t *testing.T, filenameSuffix livekit.SegmentedFileSuffix, localPlaylistPath string) {
 	file, err := os.Open(localPlaylistPath)
 	require.NoError(t, err)
 	defer file.Close()
@@ -175,16 +180,33 @@ func verifyPlaylistProgramDateTime(t *testing.T, localPlaylistPath string) {
 
 	now := time.Now()
 
-	for i, s := range pl.(*m3u8.MediaPlaylist).Segments[:pl.(*m3u8.MediaPlaylist).Count()-1] {
+	for i, s := range pl.(*m3u8.MediaPlaylist).Segments[:pl.(*m3u8.MediaPlaylist).Count()] {
 		const leeway = 50 * time.Millisecond
 
 		// Make sure the program date time is current, ie not more than 2 min in the past
 		require.InDelta(t, now.Unix(), s.ProgramDateTime.Unix(), 120)
 
-		nextSegmentStartDate := pl.(*m3u8.MediaPlaylist).Segments[i+1].ProgramDateTime
+		if filenameSuffix == livekit.SegmentedFileSuffix_TIMESTAMP {
+			m := segmentTimeRegexp.FindStringSubmatch(s.URI)
+			require.Equal(t, 3, len(m))
 
-		dateDuration := nextSegmentStartDate.Sub(s.ProgramDateTime)
-		require.InDelta(t, time.Duration(s.Duration*float64(time.Second)), dateDuration, float64(leeway))
+			tm, err := time.Parse("20060102150405", m[1])
+			require.NoError(t, err)
+
+			ms, err := strconv.Atoi(m[2])
+			require.NoError(t, err)
+
+			tm = tm.Add(time.Duration(ms) * time.Millisecond)
+
+			require.InDelta(t, s.ProgramDateTime.UnixNano(), tm.UnixNano(), float64(time.Millisecond))
+		}
+
+		if uint(i) < pl.(*m3u8.MediaPlaylist).Count()-1 {
+			nextSegmentStartDate := pl.(*m3u8.MediaPlaylist).Segments[i+1].ProgramDateTime
+
+			dateDuration := nextSegmentStartDate.Sub(s.ProgramDateTime)
+			require.InDelta(t, time.Duration(s.Duration*float64(time.Second)), dateDuration, float64(leeway))
+		}
 	}
 }
 

--- a/test/integration.go
+++ b/test/integration.go
@@ -45,7 +45,8 @@ type testCase struct {
 	options  *livekit.EncodingOptions
 
 	// used by segmented file tests
-	playlist string
+	playlist       string
+	filenameSuffix livekit.SegmentedFileSuffix
 
 	// used by track and track composite tests
 	audioCodec types.MimeType
@@ -406,10 +407,10 @@ func runSegmentsTest(t *testing.T, conf *TestConfig, req *rpc.StartEgressRequest
 	require.NoError(t, err)
 
 	require.Equal(t, test.expectVideoTranscoding, p.VideoTranscoding)
-	verifySegments(t, conf, p, res)
+	verifySegments(t, conf, p, test.filenameSuffix, res)
 }
 
-func runMultipleTest(t *testing.T, conf *TestConfig, req *rpc.StartEgressRequest, file, stream, segments bool) {
+func runMultipleTest(t *testing.T, conf *TestConfig, req *rpc.StartEgressRequest, file, stream, segments bool, filenameSuffix livekit.SegmentedFileSuffix) {
 	egressID := startEgress(t, conf, req)
 
 	time.Sleep(time.Second * 10)
@@ -429,7 +430,7 @@ func runMultipleTest(t *testing.T, conf *TestConfig, req *rpc.StartEgressRequest
 		verifyFile(t, conf, p, res)
 	}
 	if segments {
-		verifySegments(t, conf, p, res)
+		verifySegments(t, conf, p, filenameSuffix, res)
 	}
 }
 

--- a/test/room_composite.go
+++ b/test/room_composite.go
@@ -216,6 +216,7 @@ func testRoomCompositeSegments(t *testing.T, conf *TestConfig) {
 			},
 			filename:               "rs_{room_name}_{time}",
 			playlist:               "rs_{room_name}_{time}.m3u8",
+			filenameSuffix:         livekit.SegmentedFileSuffix_TIMESTAMP,
 			expectVideoTranscoding: true,
 		},
 		{
@@ -246,12 +247,14 @@ func testRoomCompositeSegments(t *testing.T, conf *TestConfig) {
 				room.SegmentOutputs = []*livekit.SegmentedFileOutput{{
 					FilenamePrefix: getFilePath(conf.ServiceConfig, test.filename),
 					PlaylistName:   test.playlist,
+					FilenameSuffix: test.filenameSuffix,
 				}}
 			} else {
 				room.Output = &livekit.RoomCompositeEgressRequest_Segments{
 					Segments: &livekit.SegmentedFileOutput{
 						FilenamePrefix: getFilePath(conf.ServiceConfig, test.filename),
 						PlaylistName:   test.playlist,
+						FilenameSuffix: test.filenameSuffix,
 					},
 				}
 			}
@@ -298,5 +301,5 @@ func testRoomCompositeMulti(t *testing.T, conf *TestConfig) {
 		},
 	}
 
-	runMultipleTest(t, conf, req, true, true, false)
+	runMultipleTest(t, conf, req, true, true, false, livekit.SegmentedFileSuffix_TIMESTAMP)
 }

--- a/test/track_composite.go
+++ b/test/track_composite.go
@@ -156,11 +156,12 @@ func testTrackCompositeSegments(t *testing.T, conf *TestConfig) {
 			playlist:   "tcs_{room_name}_h264_{time}.m3u8",
 		},
 		{
-			name:       "tcs-limit",
-			audioCodec: types.MimeTypeOpus,
-			videoCodec: types.MimeTypeH264,
-			filename:   "tcs_limit_{time}",
-			playlist:   "tcs_limit_{time}.m3u8",
+			name:           "tcs-limit",
+			audioCodec:     types.MimeTypeOpus,
+			videoCodec:     types.MimeTypeH264,
+			filename:       "tcs_limit_{time}",
+			playlist:       "tcs_limit_{time}.m3u8",
+			filenameSuffix: livekit.SegmentedFileSuffix_TIMESTAMP,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -185,12 +186,14 @@ func testTrackCompositeSegments(t *testing.T, conf *TestConfig) {
 				trackRequest.SegmentOutputs = []*livekit.SegmentedFileOutput{{
 					FilenamePrefix: filepath,
 					PlaylistName:   test.playlist,
+					FilenameSuffix: test.filenameSuffix,
 				}}
 			} else {
 				trackRequest.Output = &livekit.TrackCompositeEgressRequest_Segments{
 					Segments: &livekit.SegmentedFileOutput{
 						FilenamePrefix: filepath,
 						PlaylistName:   test.playlist,
+						FilenameSuffix: test.filenameSuffix,
 					},
 				}
 			}
@@ -239,5 +242,5 @@ func testTrackCompositeMulti(t *testing.T, conf *TestConfig) {
 		},
 	}
 
-	runMultipleTest(t, conf, req, false, true, true)
+	runMultipleTest(t, conf, req, false, true, true, livekit.SegmentedFileSuffix_INDEX)
 }

--- a/test/web.go
+++ b/test/web.go
@@ -131,5 +131,5 @@ func testWebMulti(t *testing.T, conf *TestConfig) {
 		},
 	}
 
-	runMultipleTest(t, conf, req, true, false, true)
+	runMultipleTest(t, conf, req, true, false, true, livekit.SegmentedFileSuffix_INDEX)
 }


### PR DESCRIPTION
This also updated go-glib to fix a crash.