### PR TITLE
Disable async-finalize on the splitmuxsink for segmented output

### DIFF
--- a/pkg/pipeline/output/segments.go
+++ b/pkg/pipeline/output/segments.go
@@ -48,9 +48,6 @@ func (b *Bin) buildSegmentOutput(p *config.PipelineConfig, out *config.OutputCon
 	if err = sink.SetProperty("send-keyframe-requests", true); err != nil {
 		return nil, errors.ErrGstPipelineError(err)
 	}
-	if err = sink.SetProperty("async-finalize", true); err != nil {
-		return nil, errors.ErrGstPipelineError(err)
-	}
 	if err = sink.SetProperty("muxer-factory", "mpegtsmux"); err != nil {
 		return nil, errors.ErrGstPipelineError(err)
 	}


### PR DESCRIPTION
This works around what seems like a race in the GStreamer splitmuxsink where the sink would sometimes send a fragment-closed event with a 0 run-time, causing the egress to fail.