### PR TITLE
Disable async connect on rtmp2sink

### DIFF
--- a/pkg/pipeline/output/stream.go
+++ b/pkg/pipeline/output/stream.go
@@ -112,6 +112,9 @@ func buildStreamSink(protocol types.OutputType, url string) (*streamSink, error)
 		if err = sink.SetProperty("sync", false); err != nil {
 			return nil, errors.ErrGstPipelineError(err)
 		}
+		if err = sink.SetProperty("async-connect", false); err != nil {
+			return nil, errors.ErrGstPipelineError(err)
+		}
 		if err = sink.Set("location", url); err != nil {
 			return nil, errors.ErrGstPipelineError(err)
 		}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -169,6 +169,7 @@ func (p *Pipeline) Run(ctx context.Context) *livekit.EgressInfo {
 	// wait until room is ready
 	start := p.src.StartRecording()
 	if start != nil {
+		logger.Debugw("waiting for start signal")
 		select {
 		case <-p.closed.Watch():
 			p.src.Close()

--- a/test/room_composite.go
+++ b/test/room_composite.go
@@ -289,6 +289,7 @@ func testRoomCompositeSegments(t *testing.T, conf *TestConfig) {
 
 func testRoomCompositeMulti(t *testing.T, conf *TestConfig) {
 	awaitIdle(t, conf.svc)
+	publishSamplesToRoom(t, conf.room, types.MimeTypeOpus, types.MimeTypeVP8, conf.Muting)
 
 	req := &rpc.StartEgressRequest{
 		EgressId: utils.NewGuid(utils.EgressPrefix),


### PR DESCRIPTION
Fixes the issue where if one rtmp output fails at the start, they all fail