### PR TITLE
Fix fatal errors, publish new tracks for each test

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -202,7 +202,14 @@ func runHandler(c *cli.Context) error {
 		}
 		handler, err = service.NewHandler(conf, bus, ioClient)
 		if err != nil {
-			return err
+			if errors.IsFatal(err) {
+				// service will send info update and shut down
+				logger.Errorw("fatal error", err)
+				return err
+			} else {
+				// update sent by handler
+				return nil
+			}
 		}
 	}
 

--- a/pkg/pipeline/output/bin.go
+++ b/pkg/pipeline/output/bin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/livekit/egress/pkg/pipeline/sink"
 	"github.com/livekit/egress/pkg/types"
 	"github.com/livekit/protocol/tracer"
+	"github.com/livekit/psrpc"
 )
 
 type Bin struct {
@@ -197,7 +198,7 @@ func (b *Bin) RemoveStream(url string) error {
 func (b *Bin) SetWebsocketSink(writer *sink.WebsocketSink) error {
 	o := b.outputs[types.EgressTypeWebsocket]
 	if o == nil {
-		return errors.ErrGstPipelineError(errors.New("missing websocket output"))
+		return psrpc.NewErrorf(psrpc.Internal, "missing websocket output")
 	}
 
 	o.(*WebsocketOutput).SetSink(writer)

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -129,9 +129,8 @@ func (s *ProcessManager) launchHandler(req *rpc.StartEgressRequest, info *liveki
 
 func (s *ProcessManager) awaitCleanup(h *process) {
 	if err := h.cmd.Wait(); err != nil {
-		logger.Errorw("process failed", err)
 		h.info.Status = livekit.EgressStatus_EGRESS_FAILED
-		h.info.Error = err.Error()
+		h.info.Error = "internal error"
 		s.onFatalError(h.info)
 	}
 

--- a/test/track.go
+++ b/test/track.go
@@ -130,7 +130,7 @@ func testTrackStream(t *testing.T, conf *TestConfig) {
 			}
 
 			conf.SessionLimits.StreamOutputMaxDuration = test.sessionTimeout
-			
+
 			filepath := getFilePath(conf.ServiceConfig, test.filename)
 			wss := newTestWebsocketServer(filepath)
 			s := httptest.NewServer(http.HandlerFunc(wss.handleWebsocket))

--- a/test/web.go
+++ b/test/web.go
@@ -5,14 +5,45 @@ package test
 import (
 	"testing"
 
+	"github.com/livekit/egress/pkg/types"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/rpc"
 	"github.com/livekit/protocol/utils"
 )
 
-func testWebFile(t *testing.T, conf *TestConfig) {
-	awaitIdle(t, conf.svc)
+func runWebTests(t *testing.T, conf *TestConfig) {
+	if !conf.runWebTests {
+		return
+	}
 
+	conf.sourceFramerate = 30
+
+	if conf.runFileTests {
+		runWebTest(t, conf, "Web/File", types.MimeTypeOpus, types.MimeTypeVP8, func(t *testing.T) {
+			testWebFile(t, conf)
+		})
+	}
+
+	if conf.runStreamTests {
+		runWebTest(t, conf, "Web/Stream", types.MimeTypeOpus, types.MimeTypeVP8, func(t *testing.T) {
+			testWebStream(t, conf)
+		})
+	}
+
+	if conf.runSegmentTests {
+		runWebTest(t, conf, "Web/Segments", types.MimeTypeOpus, types.MimeTypeVP8, func(t *testing.T) {
+			testWebSegments(t, conf)
+		})
+	}
+
+	if conf.runMultiTests {
+		runWebTest(t, conf, "Web/Multi", types.MimeTypeOpus, types.MimeTypeVP8, func(t *testing.T) {
+			testWebMulti(t, conf)
+		})
+	}
+}
+
+func testWebFile(t *testing.T, conf *TestConfig) {
 	fileOutput := &livekit.EncodedFileOutput{
 		Filepath: getFilePath(conf.ServiceConfig, "web_{time}"),
 	}
@@ -39,8 +70,6 @@ func testWebFile(t *testing.T, conf *TestConfig) {
 }
 
 func testWebStream(t *testing.T, conf *TestConfig) {
-	awaitIdle(t, conf.svc)
-
 	req := &rpc.StartEgressRequest{
 		EgressId: utils.NewGuid(utils.EgressPrefix),
 		Request: &rpc.StartEgressRequest_Web{
@@ -60,8 +89,6 @@ func testWebStream(t *testing.T, conf *TestConfig) {
 }
 
 func testWebSegments(t *testing.T, conf *TestConfig) {
-	awaitIdle(t, conf.svc)
-
 	segmentOutput := &livekit.SegmentedFileOutput{
 		FilenamePrefix: getFilePath(conf.ServiceConfig, "web_{time}"),
 		PlaylistName:   "web_{time}.m3u8",
@@ -89,8 +116,6 @@ func testWebSegments(t *testing.T, conf *TestConfig) {
 }
 
 func testWebMulti(t *testing.T, conf *TestConfig) {
-	awaitIdle(t, conf.svc)
-
 	req := &rpc.StartEgressRequest{
 		EgressId: utils.NewGuid(utils.EgressPrefix),
 


### PR DESCRIPTION
Previously, input errors that aren't caught in validation (e.g. bad website or missing trackID) were treated as fatal, which set the egress info error to `exit status 1` and shut the server down.

Also fixes test flakiness (if some tests take too long, the sample tracks end and then subsequent tests fail)