### PR TITLE
revert latency updates, add websocket tests

### DIFF
--- a/pkg/pipeline/builder/builder.go
+++ b/pkg/pipeline/builder/builder.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 
 	"github.com/tinyzimmer/go-gst/gst"
-	"github.com/tinyzimmer/go-gst/gst/app"
 
-	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
 )
 
@@ -27,14 +25,12 @@ func LinkPads(src string, srcPad pad, sink string, sinkPad *gst.Pad) error {
 	return nil
 }
 
-func BuildQueue(name string, leaky bool) (*gst.Element, error) {
+func BuildQueue(name string, latency uint64, leaky bool) (*gst.Element, error) {
 	queue, err := gst.NewElementWithName("queue", name)
 	if err != nil {
 		return nil, errors.ErrGstPipelineError(err)
 	}
-
-	// max-size-time sets the maximum latency for the pipeline - set to 1s higher than source latency
-	if err = queue.SetProperty("max-size-time", config.MaxPipelineLatency); err != nil {
+	if err = queue.SetProperty("max-size-time", latency); err != nil {
 		return nil, errors.ErrGstPipelineError(err)
 	}
 	if err = queue.SetProperty("max-size-bytes", uint(0)); err != nil {
@@ -52,18 +48,4 @@ func BuildQueue(name string, leaky bool) (*gst.Element, error) {
 
 func GetSrcPad(elements []*gst.Element) *gst.Pad {
 	return elements[len(elements)-1].GetStaticPad("src")
-}
-
-func UpdateAppSrc(src *app.Source) error {
-	src.Element.SetArg("format", "time")
-	if err := src.Element.SetProperty("is-live", true); err != nil {
-		return errors.ErrGstPipelineError(err)
-	}
-	if err := src.Element.SetProperty("min-latency", int64(config.MinSDKLatency)); err != nil {
-		return errors.ErrGstPipelineError(err)
-	}
-	if err := src.Element.SetProperty("emit-signals", false); err != nil {
-		return errors.ErrGstPipelineError(err)
-	}
-	return nil
 }

--- a/pkg/pipeline/input/video.go
+++ b/pkg/pipeline/input/video.go
@@ -73,7 +73,7 @@ func (v *VideoInput) buildWebDecoder(p *config.PipelineConfig) error {
 		return errors.ErrGstPipelineError(err)
 	}
 
-	videoQueue, err := builder.BuildQueue("video_input_queue", true)
+	videoQueue, err := builder.BuildQueue("video_input_queue", p.Latency, true)
 	if err != nil {
 		return err
 	}
@@ -99,11 +99,12 @@ func (v *VideoInput) buildWebDecoder(p *config.PipelineConfig) error {
 
 func (v *VideoInput) buildSDKDecoder(p *config.PipelineConfig) error {
 	src := p.VideoSrc
-	if err := builder.UpdateAppSrc(src); err != nil {
-		return err
+	src.Element.SetArg("format", "time")
+	if err := src.Element.SetProperty("is-live", true); err != nil {
+		return errors.ErrGstPipelineError(err)
 	}
-	v.elements = append(v.elements, src.Element)
 
+	v.elements = append(v.elements, src.Element)
 	switch {
 	case strings.EqualFold(p.VideoCodecParams.MimeType, string(types.MimeTypeH264)):
 		if err := src.Element.SetProperty("caps", gst.NewCapsFromString(
@@ -170,7 +171,7 @@ func (v *VideoInput) buildSDKDecoder(p *config.PipelineConfig) error {
 		return errors.ErrNotSupported(p.VideoCodecParams.MimeType)
 	}
 
-	videoQueue, err := builder.BuildQueue("video_input_queue", true)
+	videoQueue, err := builder.BuildQueue("video_input_queue", p.Latency, true)
 	if err != nil {
 		return err
 	}
@@ -208,7 +209,7 @@ func (v *VideoInput) buildSDKDecoder(p *config.PipelineConfig) error {
 
 func (v *VideoInput) buildEncoder(p *config.PipelineConfig) error {
 	// Put a queue in front of the encoder for pipelining with the stage before
-	videoQueue, err := builder.BuildQueue("video_encoder_queue", false)
+	videoQueue, err := builder.BuildQueue("video_encoder_queue", p.Latency, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/pipeline/output/base.go
+++ b/pkg/pipeline/output/base.go
@@ -19,7 +19,7 @@ func (b *Bin) buildOutputBase(p *config.PipelineConfig, egressType types.EgressT
 	base := &outputBase{}
 
 	if p.AudioEnabled {
-		audioQueue, err := builder.BuildQueue(fmt.Sprintf("audio_%s_queue", egressType), true)
+		audioQueue, err := builder.BuildQueue(fmt.Sprintf("audio_%s_queue", egressType), p.Latency, true)
 		if err != nil {
 			return nil, err
 		}
@@ -30,7 +30,7 @@ func (b *Bin) buildOutputBase(p *config.PipelineConfig, egressType types.EgressT
 	}
 
 	if p.VideoEnabled {
-		videoQueue, err := builder.BuildQueue(fmt.Sprintf("video_%s_queue", egressType), true)
+		videoQueue, err := builder.BuildQueue(fmt.Sprintf("video_%s_queue", egressType), p.Latency, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pipeline/output/stream.go
+++ b/pkg/pipeline/output/stream.go
@@ -87,9 +87,8 @@ func buildStreamMux(p *config.PipelineConfig, o *config.StreamConfig) (*gst.Elem
 		if err = mux.SetProperty("skip-backwards-streams", true); err != nil {
 			return nil, errors.ErrGstPipelineError(err)
 		}
-
 		// add latency to give time for flvmux to receive and order packets from both streams
-		if err = mux.SetProperty("latency", config.StreamLatency); err != nil {
+		if err = mux.SetProperty("latency", p.Latency); err != nil {
 			return nil, errors.ErrGstPipelineError(err)
 		}
 

--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -14,7 +14,6 @@ import (
 	"github.com/tinyzimmer/go-gst/gst/app"
 	"go.uber.org/atomic"
 
-	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
 	"github.com/livekit/egress/pkg/types"
 	"github.com/livekit/protocol/logger"
@@ -32,7 +31,8 @@ const (
 )
 
 const (
-	drainTimeout      = time.Millisecond * 3500
+	latency           = time.Second * 2
+	drainTimeout      = time.Second * 4
 	errBufferTooSmall = "buffer too small"
 )
 
@@ -111,7 +111,7 @@ func NewAppWriter(
 	w.buffer = jitter.NewBuffer(
 		depacketizer,
 		track.Codec().ClockRate,
-		config.MaxJitterLatency,
+		latency,
 		jitter.WithPacketDroppedHandler(w.sendPLI),
 		jitter.WithLogger(w.logger),
 	)

--- a/test/ffprobe.go
+++ b/test/ffprobe.go
@@ -140,6 +140,17 @@ func verify(t *testing.T, in string, p *config.PipelineConfig, res *livekit.Egre
 		segments := res.GetSegmentResults()[0]
 		expected := int64(math.Ceil(actual / float64(p.GetSegmentConfig().SegmentDuration)))
 		require.True(t, segments.SegmentCount == expected || segments.SegmentCount == expected-1)
+
+	case types.EgressTypeWebsocket:
+		size, err := strconv.Atoi(info.Format.Size)
+		require.NoError(t, err)
+		require.Greater(t, size, 6500000)
+
+		expected := float64(res.StreamResults[0].Duration) / 1e9
+		actual, err := strconv.ParseFloat(info.Format.Duration, 64)
+		require.NoError(t, err)
+
+		require.InDelta(t, expected, actual, 1)
 	}
 
 	// check stream info


### PR DESCRIPTION
Latency updates resulted in track websocket egress missing a lot of data (resulting .raw file would contain about 4s of data instead of 35). Exact cause is still unknown