### PR TITLE
Do not mark streams as failed after EOS

### DIFF
--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -124,6 +124,10 @@ func (p *PipelineConfig) updateEncodedOutputs(req EncodedOutput) error {
 		return errors.ErrInvalidInput("output")
 	}
 
+	if p.OutputCount == 1 && stream != nil {
+		p.StreamOnly = true
+	}
+
 	return nil
 }
 
@@ -156,6 +160,7 @@ func (p *PipelineConfig) updateDirectOutput(req *livekit.TrackEgressRequest) err
 
 		p.Outputs[types.EgressTypeWebsocket] = conf
 		p.OutputCount = 1
+		p.StreamOnly = true
 
 	default:
 		return errors.ErrInvalidInput("output")

--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -37,6 +37,7 @@ type PipelineConfig struct {
 
 	Outputs     map[types.EgressType]OutputConfig `yaml:"-"`
 	OutputCount int
+	StreamOnly  bool
 
 	GstReady chan struct{}       `yaml:"-"`
 	Failure  chan error          `yaml:"-"`

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -400,11 +400,16 @@ func (p *Pipeline) SendEOS(ctx context.Context) {
 				logger.Infow("sending EOS to pipeline")
 
 				p.eosTimer = time.AfterFunc(eosTimeout, func() {
-					logger.Errorw("pipeline frozen", nil)
+					logger.Errorw("pipeline frozen", nil, "stream", p.StreamOnly)
 					if p.Debug.EnableProfiling {
 						p.uploadDebugFiles()
 					}
-					p.Failure <- errors.New("pipeline frozen")
+
+					if p.StreamOnly {
+						p.stop()
+					} else {
+						p.Failure <- errors.New("pipeline frozen")
+					}
 				})
 
 				if p.SourceType == types.SourceTypeSDK {


### PR DESCRIPTION
Streams still succeed if they work until EOS was sent