### PR TITLE
Stream reset on connection error

### DIFF
--- a/pkg/pipeline/output/bin.go
+++ b/pkg/pipeline/output/bin.go
@@ -178,6 +178,15 @@ func (b *Bin) AddStream(url string) error {
 	return o.(*StreamOutput).AddSink(b.bin, url)
 }
 
+func (b *Bin) ResetStream(name string) (bool, error) {
+	o := b.outputs[types.EgressTypeStream]
+	if o == nil {
+		return false, errors.ErrStreamNotFound(name)
+	}
+
+	return o.(*StreamOutput).Reset(name)
+}
+
 func (b *Bin) GetStreamUrl(name string) (string, error) {
 	o := b.outputs[types.EgressTypeStream]
 	if o == nil {

--- a/pkg/pipeline/output/bin.go
+++ b/pkg/pipeline/output/bin.go
@@ -178,13 +178,13 @@ func (b *Bin) AddStream(url string) error {
 	return o.(*StreamOutput).AddSink(b.bin, url)
 }
 
-func (b *Bin) ResetStream(name string) (bool, error) {
+func (b *Bin) ResetStream(name string, streamErr error) (bool, error) {
 	o := b.outputs[types.EgressTypeStream]
 	if o == nil {
 		return false, errors.ErrStreamNotFound(name)
 	}
 
-	return o.(*StreamOutput).Reset(name)
+	return o.(*StreamOutput).Reset(name, streamErr)
 }
 
 func (b *Bin) GetStreamUrl(name string) (string, error) {

--- a/pkg/pipeline/watch.go
+++ b/pkg/pipeline/watch.go
@@ -166,7 +166,7 @@ func (p *Pipeline) handleMessageError(gErr *gst.GError) error {
 	case element == elementGstRtmp2Sink:
 		if strings.HasPrefix(gErr.Error(), "Connection error") {
 			// try reconnecting
-			ok, err := p.out.ResetStream(name)
+			ok, err := p.out.ResetStream(name, gErr)
 			if ok || err != nil {
 				return err
 			}


### PR DESCRIPTION
Tested with custom code to simulate connection errors

```
2023-07-28T01:47:20.522Z	INFO	egress	output/stream.go:218	resetting stream	{"nodeID": "NE_VzJyPwzvhzCa", "handlerID": "EGH_NxKH7yjSkr7G", "clusterID": "", "egressID": "EG_kTbmwaC6Abb2"}
2023-07-28T01:47:20.525Z	INFO	egress	output/stream.go:231	stream reset	{"nodeID": "NE_VzJyPwzvhzCa", "handlerID": "EGH_NxKH7yjSkr7G", "clusterID": "", "egressID": "EG_kTbmwaC6Abb2"}
2023-07-28T01:47:20.533Z	DEBUG	egress	[gst fixme] gst_rtmp_connection_handle_protocol_control: set peer bandwidth: 2500000, 2	{"nodeID": "NE_VzJyPwzvhzCa", "handlerID": "EGH_NxKH7yjSkr7G", "clusterID": "", "egressID": "EG_kTbmwaC6Abb2", "caller": "../gst/rtmp2/rtmp/rtmpconnection.c:867"}
``` 