### PR TITLE
Set the vbv-buf-capacity property on the x264 encoder

### DIFF
--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -336,7 +336,7 @@ func addVideoEncoder(b *gstreamer.Bin, p *config.PipelineConfig) error {
 			if err = x264Enc.SetProperty("option-string", "scenecut=0"); err != nil {
 				return errors.ErrGstPipelineError(err)
 			}
-			bufCapacity = uint(p.GetSegmentConfig().SegmentDuration * (time.Second / time.Millisecond))
+			bufCapacity = uint(time.Duration(p.GetSegmentConfig().SegmentDuration) * (time.Second / time.Millisecond))
 		}
 
 		if err = x264Enc.SetProperty("vbv-buf-capacity", bufCapacity); err != nil {

--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -16,6 +16,7 @@ package builder
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/tinyzimmer/go-gst/gst"
 
@@ -329,11 +330,17 @@ func addVideoEncoder(b *gstreamer.Bin, p *config.PipelineConfig) error {
 				return errors.ErrGstPipelineError(err)
 			}
 		}
+		bufCapacity := uint(2000) // 2s
 		if p.GetSegmentConfig() != nil {
 			// Avoid key frames other than at segments boundaries as splitmuxsink can become inconsistent otherwise
 			if err = x264Enc.SetProperty("option-string", "scenecut=0"); err != nil {
 				return errors.ErrGstPipelineError(err)
 			}
+			bufCapacity = uint(p.GetSegmentConfig().SegmentDuration * (time.Second / time.Millisecond))
+		}
+
+		if err = x264Enc.SetProperty("vbv-buf-capacity", bufCapacity); err != nil {
+			return err
 		}
 
 		caps, err := gst.NewElement("capsfilter")


### PR DESCRIPTION
This gives a little more breathing room to the rate controller. Use 2s by default, and the segment duration for segment output.