### PR TITLE
Add more options to the S3 section of config.yaml for egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ s3:
   region: AWS_DEFAULT_REGION env or IAM role can be used instead
   endpoint: (optional) custom endpoint
   bucket: bucket to upload files to
+  # the following s3 options can only be set in config, *not* per request, they will be added to any per-request options
+  proxy: (optional, no default) proxy url
+  max_retries: (optional, default=3) number or retries to attempt
+  max_retry_delay: (optional, default=5s) max delay between retries (e.g. 5s, 100ms, 1m...)
+  min_retry_delay: (optional, default=500ms) min delay between retries (e.g. 100ms, 1s...)
+  aws_log_level: (optional, default=LogOff) log level for aws sdk (LogDebugWithRequestRetries, LogDebug, ...) 
 azure:
   account_name: AZURE_STORAGE_ACCOUNT env can be used instead
   account_key: AZURE_STORAGE_KEY env can be used instead

--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -63,12 +63,17 @@ type StorageConfig struct {
 }
 
 type S3Config struct {
-	AccessKey      string `yaml:"access_key"` // (env AWS_ACCESS_KEY_ID)
-	Secret         string `yaml:"secret"`     // (env AWS_SECRET_ACCESS_KEY)
-	Region         string `yaml:"region"`     // (env AWS_DEFAULT_REGION)
-	Endpoint       string `yaml:"endpoint"`
-	Bucket         string `yaml:"bucket"`
-	ForcePathStyle bool   `yaml:"force_path_style"`
+	AccessKey      string        `yaml:"access_key"` // (env AWS_ACCESS_KEY_ID)
+	Secret         string        `yaml:"secret"`     // (env AWS_SECRET_ACCESS_KEY)
+	Region         string        `yaml:"region"`     // (env AWS_DEFAULT_REGION)
+	Endpoint       string        `yaml:"endpoint"`
+	Bucket         string        `yaml:"bucket"`
+	ForcePathStyle bool          `yaml:"force_path_style"`
+	Proxy          string        `yaml:"proxy"`
+	MaxRetries     int           `yaml:"max_retries"`
+	MaxRetryDelay  time.Duration `yaml:"max_retry_delay"`
+	MinRetryDelay  time.Duration `yaml:"min_retry_delay"`
+	AwsLogLevel    string        `yaml:"aws_log_level"`
 }
 
 type AzureConfig struct {

--- a/pkg/pipeline/sink/uploader/uploader.go
+++ b/pkg/pipeline/sink/uploader/uploader.go
@@ -46,7 +46,7 @@ func New(conf config.UploadConfig, backup string) (Uploader, error) {
 	var err error
 
 	switch c := conf.(type) {
-	case *livekit.S3Upload:
+	case *config.EgressS3Upload:
 		u, err = newS3Uploader(c)
 	case *livekit.GCPUpload:
 		u, err = newGCPUploader(c)


### PR DESCRIPTION
Added additional S3 configuration to the `config.yaml` for egress to allow specification of

* HTTP proxy
* max retries
* max/min retry delay
* AWS logging option

The change does not alter the `livekit.S3Upload` struct which is shared across components.  It extends it within the egress component to add the additional information.   The intended usage is in an environment where egress files on requests would NOT specify the S3 file information.... but if such info was specified, the information in the extended part of the s3 `config.yaml` would be added (uploads.go lines 48-56).