### PR TITLE
Fix backup Error in Egress when Using Subdirectories in `filePath`

### DIFF
--- a/pkg/pipeline/sink/uploader/uploader.go
+++ b/pkg/pipeline/sink/uploader/uploader.go
@@ -105,7 +105,12 @@ func (u *remoteUploader) Upload(localFilepath, storageFilepath string, outputTyp
 			return "", 0, err
 		}
 
-		backupFilepath := path.Join(u.backup, storageFilepath)
+		backupDir := path.Join(u.backup, path.Dir(storageFilepath))
+		backupFileName := path.Base(storageFilepath)
+		if err = os.MkdirAll(backupDir, 0755); err != nil {
+			return "", 0, err
+		}
+		backupFilepath := path.Join(backupDir, backupFileName)
 		if err = os.Rename(localFilepath, backupFilepath); err != nil {
 			return "", 0, err
 		}


### PR DESCRIPTION
This PR aims to fix https://github.com/livekit/egress/issues/549

If the upload fails, It simply creates the directory with the `os.MkdirAll` so it creates all necessary subdirectories and does nothing if the directory currently exists before moving the egress recording.