### PR TITLE
Fix critical gstreamer error

### DIFF
--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -45,7 +45,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd
     CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on GODEBUG=disablethp=1 go build -a -o egress ./cmd/server
 
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go test -c -v --tags=integration ./test
+    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go test -c -v -race --tags=integration ./test
 
 
 FROM livekit/gstreamer:1.22.8-prod

--- a/build/test/entrypoint.sh
+++ b/build/test/entrypoint.sh
@@ -27,5 +27,5 @@ if [[ -z ${GITHUB_WORKFLOW+x} ]]; then
   exec ./test.test -test.v -test.timeout 30m
 else
   go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
-  exec go tool test2json -p egress ./test.test -test.v -test.timeout 30m 2>&1 | "$HOME"/go/bin/gotestfmt
+  exec go tool test2json -p egress ./test.test -test.v -test.race -test.timeout 30m 2>&1 | "$HOME"/go/bin/gotestfmt
 fi

--- a/build/test/entrypoint.sh
+++ b/build/test/entrypoint.sh
@@ -27,5 +27,5 @@ if [[ -z ${GITHUB_WORKFLOW+x} ]]; then
   exec ./test.test -test.v -test.timeout 30m
 else
   go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
-  exec go tool test2json -p egress ./test.test -test.v -test.race -test.timeout 30m 2>&1 | "$HOME"/go/bin/gotestfmt
+  exec go tool test2json -p egress ./test.test -test.v -test.timeout 30m 2>&1 | "$HOME"/go/bin/gotestfmt
 fi


### PR DESCRIPTION
Error when removing a source bin:
```
(egress:93): GStreamer-WARNING **: 22:05:15.736:
Trying to join task 0xffff38173bc0 from its thread would deadlock.
You cannot change the state of an element from its streaming
thread. Use g_idle_add() or post a GstMessage on the bus to
schedule the state change from the main thread.

(egress:93): GStreamer-CRITICAL **: 22:05:15.741: Failed to deactivate pad video_input_queue:src, very bad
```