### PR TITLE
Aborted sink errors

### DIFF
--- a/pkg/gstreamer/bin.go
+++ b/pkg/gstreamer/bin.go
@@ -224,8 +224,9 @@ func (b *Bin) probeRemoveSource(src *Bin) {
 				return false
 			}
 
-			sinkPad := sinkGhostPad.GetTarget()
-			b.elements[0].ReleaseRequestPad(sinkPad)
+			if sinkPad := sinkGhostPad.GetTarget(); sinkPad != nil {
+				b.elements[0].ReleaseRequestPad(sinkPad)
+			}
 
 			srcGhostPad.Unlink(sinkGhostPad.Pad)
 			b.bin.RemovePad(sinkGhostPad.Pad)

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -241,7 +241,7 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 	logger.Debugw("closing sinks")
 	for _, si := range c.sinks {
 		for _, s := range si {
-			if err := s.Close(); err != nil {
+			if err := s.Close(); err != nil && c.playing.IsBroken() {
 				c.Info.Status = livekit.EgressStatus_EGRESS_FAILED
 				c.Info.Error = err.Error()
 				return c.Info


### PR DESCRIPTION
Ignore sink errors if eos is sent before the pipeline reaches the playing state