### PR TITLE
Drop upstream events when removing src bin

### DIFF
--- a/pkg/gstreamer/callbacks.go
+++ b/pkg/gstreamer/callbacks.go
@@ -25,8 +25,9 @@ import (
 )
 
 type Callbacks struct {
-	mu       sync.RWMutex
-	GstReady chan struct{}
+	mu         sync.RWMutex
+	GstReady   chan struct{}
+	BuildReady chan struct{}
 
 	// upstream callbacks
 	onError func(error)

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -116,6 +116,7 @@ func (h *Handler) Run() error {
 		select {
 		case <-kill:
 			// kill signal received
+			h.conf.Info.Details = "service terminated by deployment"
 			h.controller.SendEOS(ctx)
 
 		case res := <-result:

--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -16,7 +16,6 @@ package builder
 
 import (
 	"fmt"
-	"math/rand"
 	"sync"
 
 	"github.com/go-gst/go-gst/gst"
@@ -34,8 +33,9 @@ type AudioBin struct {
 	bin  *gstreamer.Bin
 	conf *config.PipelineConfig
 
-	mu    sync.Mutex
-	names map[string]string
+	mu     sync.Mutex
+	nextID int
+	names  map[string]string
 }
 
 func BuildAudioBin(pipeline *gstreamer.Pipeline, p *config.PipelineConfig) error {
@@ -159,7 +159,8 @@ func (b *AudioBin) addAudioAppSrcBin(ts *config.TrackSource) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	name := fmt.Sprintf("%s_%d", ts.TrackID, rand.Int()%1000)
+	name := fmt.Sprintf("%s_%d", ts.TrackID, b.nextID)
+	b.nextID++
 	b.names[ts.TrackID] = name
 
 	appSrcBin := b.bin.NewBin(name)

--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -16,7 +16,6 @@ package builder
 
 import (
 	"fmt"
-	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +45,7 @@ type VideoBin struct {
 	nextPad     string
 
 	mu          sync.Mutex
+	nextID      int
 	pads        map[string]*gst.Pad
 	names       map[string]string
 	selector    *gst.Element
@@ -282,7 +282,8 @@ func (b *VideoBin) buildSDKInput() error {
 }
 
 func (b *VideoBin) addAppSrcBin(ts *config.TrackSource) error {
-	name := fmt.Sprintf("%s_%d", ts.TrackID, rand.Int()%1000)
+	name := fmt.Sprintf("%s_%d", ts.TrackID, b.nextID)
+	b.nextID++
 
 	appSrcBin, err := b.buildAppSrcBin(ts, name)
 	if err != nil {

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -72,7 +72,8 @@ func New(ctx context.Context, conf *config.PipelineConfig, ioClient rpc.IOInfoCl
 	c := &Controller{
 		PipelineConfig: conf,
 		callbacks: &gstreamer.Callbacks{
-			GstReady: make(chan struct{}),
+			GstReady:   make(chan struct{}),
+			BuildReady: make(chan struct{}),
 		},
 		ioClient:  ioClient,
 		gstLogger: logger.GetLogger().(logger.ZapLogger).ToZap().WithOptions(zap.WithCaller(false)),
@@ -186,6 +187,7 @@ func (c *Controller) BuildPipeline() error {
 	}
 
 	c.p = p
+	close(c.callbacks.BuildReady)
 	return nil
 }
 


### PR DESCRIPTION
Race with an upstream flush event can cause an internal data stream error
Also fixes races around tracks being published as the pipeline is being built