### PR TITLE
Updated dependencies to support livekit-client ^2.0.0

### DIFF
--- a/template-sdk/package.json
+++ b/template-sdk/package.json
@@ -12,7 +12,7 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "livekit-client": "^1.7.0 || ^2.0.0",
+    "livekit-client": "^1.15.13 || ^2.0.10",
     "prettier": "^2.8.4",
     "typescript": "^5.0.0"
   },

--- a/template-sdk/package.json
+++ b/template-sdk/package.json
@@ -12,11 +12,11 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "livekit-client": "^1.7.0",
+    "livekit-client": "^1.7.0 || ^2.0.0",
     "prettier": "^2.8.4",
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "livekit-client": "^1.7.0"
+    "livekit-client": "^1.7.0 || ^2.0.0"
   }
 }

--- a/template-sdk/package.json
+++ b/template-sdk/package.json
@@ -17,6 +17,6 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "livekit-client": "^1.7.0 || ^2.0.0"
+    "livekit-client": "^1.15.13 || ^2.0.10"
   }
 }

--- a/template-sdk/pnpm-lock.yaml
+++ b/template-sdk/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 devDependencies:
   livekit-client:
-    specifier: ^1.7.0
+    specifier: ^1.7.0 || ^2.0.0
     version: 1.14.4
   prettier:
     specifier: ^2.8.4


### PR DESCRIPTION
Updated dependencies and peerDependencies in package.json to include support for livekit-client versions ^1.7.0 and ^2.0.0, providing flexibility for users using either version series.

Fixes #610 