### PR TITLE
Support for aws session_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ session_limits: # optional egress duration limits - once hit, egress will end wi
 s3:
   access_key: AWS_ACCESS_KEY_ID env or IAM role can be used instead
   secret: AWS_SECRET_ACCESS_KEY env or IAM role can be used instead
+  session_token: AWS_SESSION_TOKEN env or IAM role can be used instead
   region: AWS_DEFAULT_REGION env or IAM role can be used instead
   endpoint: (optional) custom endpoint
   bucket: bucket to upload files to

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/gorilla/websocket v1.5.1
 	github.com/livekit/livekit-server v1.6.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
-	github.com/livekit/protocol v1.16.1-0.20240513145257-511f517b1abf
-	github.com/livekit/psrpc v0.5.3-0.20240403150641-811331b106d9
+	github.com/livekit/protocol v1.17.1-0.20240612003900-1dd95af54240
+	github.com/livekit/psrpc v0.5.3-0.20240526192918-fbdaf10e6aa5
 	github.com/livekit/server-sdk-go/v2 v2.1.2-0.20240425022832-17b2be53a0d7
 	github.com/pion/rtp v1.8.6
 	github.com/pion/webrtc/v3 v3.2.38
@@ -116,6 +116,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap/exp v0.2.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
+	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/oauth2 v0.19.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,12 @@ github.com/livekit/mediatransportutil v0.0.0-20240406063423-a67d961689df h1:DVhJ
 github.com/livekit/mediatransportutil v0.0.0-20240406063423-a67d961689df/go.mod h1:jwKUCmObuiEDH0iiuJHaGMXwRs3RjrB4G6qqgkr/5oE=
 github.com/livekit/protocol v1.16.1-0.20240513145257-511f517b1abf h1:dUJ3PGgesuyWju8g3TL4WF9wuTdF758lL6UXFTVeO6E=
 github.com/livekit/protocol v1.16.1-0.20240513145257-511f517b1abf/go.mod h1:pnn0Dv+/0K0OFqKHX6J6SreYO1dZxl6tDuAZ1ns8L/w=
+github.com/livekit/protocol v1.17.1-0.20240612003900-1dd95af54240 h1:aaL3N0lSJZEbaAxTckNGZHTjowmMJYYYoSDVND+kH8g=
+github.com/livekit/protocol v1.17.1-0.20240612003900-1dd95af54240/go.mod h1:cN8WmGQR+kWz1+UWcAQdFFUcbW76PnfZDdkLAbYIqd4=
 github.com/livekit/psrpc v0.5.3-0.20240403150641-811331b106d9 h1:4CngtPIJ58WcQ1sUDGdxJDkTndQpN6M/T8jXvRAd7Oc=
 github.com/livekit/psrpc v0.5.3-0.20240403150641-811331b106d9/go.mod h1:CQUBSPfYYAaevg1TNCc6/aYsa8DJH4jSRFdCeSZk5u0=
+github.com/livekit/psrpc v0.5.3-0.20240526192918-fbdaf10e6aa5 h1:mTZyrjk5WEWMsvaYtJ42pG7DuxysKj21DKPINpGSIto=
+github.com/livekit/psrpc v0.5.3-0.20240526192918-fbdaf10e6aa5/go.mod h1:CQUBSPfYYAaevg1TNCc6/aYsa8DJH4jSRFdCeSZk5u0=
 github.com/livekit/server-sdk-go/v2 v2.1.2-0.20240425022832-17b2be53a0d7 h1:iZJnxZ0ZHMbiiUKHR3mV2CBWR5quNWv1disk7H4Iw5A=
 github.com/livekit/server-sdk-go/v2 v2.1.2-0.20240425022832-17b2be53a0d7/go.mod h1:kwoe9UD6QwSyFAlZGfpJOymgE794DwJJ/CNTHYCz8PY=
 github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=
@@ -326,6 +330,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -64,9 +64,10 @@ type StorageConfig struct {
 }
 
 type S3Config struct {
-	AccessKey      string        `yaml:"access_key"` // (env AWS_ACCESS_KEY_ID)
-	Secret         string        `yaml:"secret"`     // (env AWS_SECRET_ACCESS_KEY)
-	Region         string        `yaml:"region"`     // (env AWS_DEFAULT_REGION)
+	AccessKey      string        `yaml:"access_key"`    // (env AWS_ACCESS_KEY_ID)
+	Secret         string        `yaml:"secret"`        // (env AWS_SECRET_ACCESS_KEY)
+	SessionToken   string        `yaml:"session_token"` // (env AWS_SESSION_TOKEN)
+	Region         string        `yaml:"region"`        // (env AWS_DEFAULT_REGION)
 	Endpoint       string        `yaml:"endpoint"`
 	Bucket         string        `yaml:"bucket"`
 	ForcePathStyle bool          `yaml:"force_path_style"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -47,9 +47,10 @@ func TestRedactUpload(t *testing.T) {
 						Filepath: "filepath",
 						Output: &livekit.EncodedFileOutput_S3{
 							S3: &livekit.S3Upload{
-								AccessKey: "access",
-								Secret:    "secret",
-								Bucket:    "bucket",
+								AccessKey:    "access",
+								Secret:       "secret",
+								SessionToken: "",
+								Bucket:       "bucket",
 							},
 						},
 					},

--- a/pkg/config/uploads.go
+++ b/pkg/config/uploads.go
@@ -73,6 +73,7 @@ func (c StorageConfig) ToUploadConfig() UploadConfig {
 			S3Upload: &livekit.S3Upload{
 				AccessKey:      c.S3.AccessKey,
 				Secret:         c.S3.Secret,
+				SessionToken:   c.S3.SessionToken,
 				Region:         c.S3.Region,
 				Endpoint:       c.S3.Endpoint,
 				Bucket:         c.S3.Bucket,

--- a/pkg/pipeline/sink/uploader/s3.go
+++ b/pkg/pipeline/sink/uploader/s3.go
@@ -82,7 +82,7 @@ func newS3Uploader(conf *config.EgressS3Upload) (uploader, error) {
 		"minDelay", conf.MinRetryDelay,
 	)
 	if conf.AccessKey != "" && conf.Secret != "" {
-		awsConfig.Credentials = credentials.NewStaticCredentials(conf.AccessKey, conf.Secret, "")
+		awsConfig.Credentials = credentials.NewStaticCredentials(conf.AccessKey, conf.Secret, conf.SessionToken)
 	}
 	if conf.Endpoint != "" {
 		awsConfig.Endpoint = aws.String(conf.Endpoint)

--- a/test/download.go
+++ b/test/download.go
@@ -58,7 +58,7 @@ func download(t *testing.T, uploadParams interface{}, localFilepath, storageFile
 
 func downloadS3(t *testing.T, conf *config.EgressS3Upload, localFilepath, storageFilepath string) {
 	sess, err := session.NewSession(&aws.Config{
-		Credentials: credentials.NewStaticCredentials(conf.AccessKey, conf.Secret, ""),
+		Credentials: credentials.NewStaticCredentials(conf.AccessKey, conf.Secret, conf.SessionToken),
 		Endpoint:    aws.String(conf.Endpoint),
 		Region:      aws.String(conf.Region),
 		MaxRetries:  aws.Int(maxRetries),


### PR DESCRIPTION
AWS offers a third component of aws-credentials: `access_key_id` + `secret_access_key` + **`session_token`**, see [LINK](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html) (and livekit/egress currently only supports two of them).

I've already asked the same question on livekit/slack [LINK](https://livekit-users.slack.com/archives/C01KVTJH6BX/p1717084987144909). I was directed to this place by cool people, for which I thank them.

PS: I tried passing the `session_token` via `metadata`, but it doesn't seem to work (mp4 file wasn't placed on S3), like:
```
            …
            "s3": {
                "access_key": "<access_key_id>",
                "secret": "<secret_access_key>",
                "metadata": {
                    "X-Amz-Security-Token": "<session_token>"
                },
                …
            }
            …
```
(the aws documentation does not confirm that this should work at all, links: [Working with object metadata - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html), [Using temporary credentials with AWS resources - AWS Identity and Access Management (](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html)[amazon.com](http://amazon.com/)[)](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html), [Signing and authenticating REST requests - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#UsingTemporarySecurityCredentials))
