### PR TITLE
support arm64 variance in install-chrome

### DIFF
--- a/build/chrome/install-chrome
+++ b/build/chrome/install-chrome
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-if [ "$1" = "linux/arm64" ]
-then
+if [[ "$1" == linux/arm64* ]]; then
   apt-get update
   apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
Not sure when it started, but `TARGETPLATFORM=linux/arm64/v8` on my machine. So, this script mistakenly thought I was on an amd64.