### PR TITLE
Sinks operate independently on EOS when frozen

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -321,7 +321,6 @@ github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8w
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/pkg/gstreamer/bin.go
+++ b/pkg/gstreamer/bin.go
@@ -385,6 +385,7 @@ func (b *Bin) sendEOS() {
 	}
 }
 
+// AddOnEOSReceived adds a callback to be called when EOS is received on every pad of the last element in the bin
 func (b *Bin) AddOnEOSReceived(f func()) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/pkg/gstreamer/bin.go
+++ b/pkg/gstreamer/bin.go
@@ -406,7 +406,7 @@ func (b *Bin) AddOnEOSReceived(f func()) error {
 		sinkPad.AddProbe(gst.PadProbeTypeEventDownstream, func(_ *gst.Pad, info *gst.PadProbeInfo) gst.PadProbeReturn {
 			if event := info.GetEvent(); event != nil && event.Type() == gst.EventTypeEOS {
 				if expecting.Dec() == 0 {
-					go f()
+					f()
 				}
 				return gst.PadProbeRemove
 			}

--- a/pkg/gstreamer/callbacks.go
+++ b/pkg/gstreamer/callbacks.go
@@ -17,8 +17,6 @@ package gstreamer
 import (
 	"sync"
 
-	"github.com/go-gst/go-gst/gst"
-
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
 )
@@ -38,10 +36,6 @@ type Callbacks struct {
 	onTrackUnmuted []func(string)
 	onTrackRemoved []func(string)
 	onEOSSent      func()
-
-	// internal
-	addBin    func(bin *gst.Bin)
-	removeBin func(bin *gst.Bin)
 }
 
 func (c *Callbacks) SetOnError(f func(error)) {

--- a/pkg/pipeline/builder/image.go
+++ b/pkg/pipeline/builder/image.go
@@ -31,22 +31,6 @@ const (
 	imageQueueLatency = uint64(200 * time.Millisecond)
 )
 
-func BuildImageBins(pipeline *gstreamer.Pipeline, p *config.PipelineConfig) ([]*gstreamer.Bin, error) {
-	o := p.GetImageConfigs()
-
-	var bins []*gstreamer.Bin
-	for _, c := range o {
-		b, err := BuildImageBin(c, pipeline, p)
-		if err != nil {
-			return nil, err
-		}
-
-		bins = append(bins, b)
-	}
-
-	return bins, nil
-}
-
 func BuildImageBin(c *config.ImageConfig, pipeline *gstreamer.Pipeline, p *config.PipelineConfig) (*gstreamer.Bin, error) {
 	b := pipeline.NewBin(fmt.Sprintf("image_%s", c.Id))
 
@@ -140,7 +124,7 @@ func BuildImageBin(c *config.ImageConfig, pipeline *gstreamer.Pipeline, p *confi
 	if err != nil {
 		return nil, err
 	}
-	if err := b.AddElements(sink); err != nil {
+	if err = b.AddElements(sink); err != nil {
 		return nil, errors.ErrGstPipelineError(err)
 	}
 

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -208,8 +208,8 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 	logger.Debugw("closing source")
 	c.src.Close()
 
-	logger.Debugw("closing sinks")
 	if c.playing.IsBroken() {
+		logger.Debugw("closing sinks")
 		for _, si := range c.sinks {
 			for _, s := range si {
 				if c.eosReceived.IsBroken() || s.EOSReceived() {
@@ -406,7 +406,7 @@ func (c *Controller) sendEOS() {
 
 	go func() {
 		c.p.SendEOS()
-		logger.Debugw("eosSent sent")
+		logger.Debugw("eos sent")
 	}()
 }
 

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -208,13 +208,13 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 	logger.Debugw("closing source")
 	c.src.Close()
 
+	logger.Debugw("closing sinks")
 	if c.playing.IsBroken() {
 		for _, si := range c.sinks {
 			for _, s := range si {
 				if c.eosReceived.IsBroken() || s.EOSReceived() {
-					if err := <-s.Err(); err != nil {
+					if err := s.Close(); err != nil && c.Info.Status != livekit.EgressStatus_EGRESS_FAILED {
 						c.Info.SetFailed(err)
-						return c.Info
 					}
 				}
 			}

--- a/pkg/pipeline/sink/sink.go
+++ b/pkg/pipeline/sink/sink.go
@@ -18,8 +18,8 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/livekit/egress/pkg/config"
+	"github.com/livekit/egress/pkg/errors"
 	"github.com/livekit/egress/pkg/gstreamer"
-	"github.com/livekit/egress/pkg/pipeline/builder"
 	"github.com/livekit/egress/pkg/stats"
 	"github.com/livekit/egress/pkg/types"
 	"github.com/livekit/protocol/logger"
@@ -29,15 +29,13 @@ type Sink interface {
 	Start() error
 	AddEOSProbe()
 	EOSReceived() bool
-	Err() chan error
+	Close() error
 	UploadManifest(string) (string, bool, error)
 }
 
-type sink struct {
+type base struct {
 	bin         *gstreamer.Bin
 	eosReceived atomic.Bool
-	close       func() error
-	closeErr    chan error
 }
 
 func NewSink(
@@ -49,120 +47,35 @@ func NewSink(
 	monitor *stats.HandlerMonitor,
 ) (Sink, error) {
 
-	var s Sink
-	var base *sink
 	switch egressType {
 	case types.EgressTypeFile:
-		fileSink, err := NewFileSink(conf, o.(*config.FileConfig), monitor)
-		if err != nil {
-			return nil, err
-		}
-		fileBin, err := builder.BuildFileBin(p, conf)
-		if err != nil {
-			return nil, err
-		}
-		base = &sink{
-			bin:      fileBin,
-			close:    fileSink.close,
-			closeErr: make(chan error, 1),
-		}
-		fileSink.sink = base
-		s = fileSink
+		return newFileSink(p, conf, o.(*config.FileConfig), monitor)
 
 	case types.EgressTypeSegments:
-		segmentSink, err := NewSegmentSink(conf, o.(*config.SegmentConfig), callbacks, monitor)
-		if err != nil {
-			return nil, err
-		}
-		segmentBin, err := builder.BuildSegmentBin(p, conf)
-		if err != nil {
-			return nil, err
-		}
-		base = &sink{
-			bin:      segmentBin,
-			close:    segmentSink.close,
-			closeErr: make(chan error, 1),
-		}
-		segmentSink.sink = base
-		s = segmentSink
+		return newSegmentSink(p, conf, o.(*config.SegmentConfig), callbacks, monitor)
 
 	case types.EgressTypeStream:
-		streamBin, err := builder.BuildStreamBin(p, o.(*config.StreamConfig))
-		if err != nil {
-			return nil, err
-		}
-		streamSink, err := NewStreamSink(streamBin, o.(*config.StreamConfig))
-		if err != nil {
-			return nil, err
-		}
-		base = &sink{
-			bin:      streamBin.Bin,
-			close:    streamSink.close,
-			closeErr: make(chan error, 1),
-		}
-		streamSink.sink = base
-		s = streamSink
+		return newStreamSink(p, o.(*config.StreamConfig))
 
 	case types.EgressTypeWebsocket:
-		websocketSink, err := NewWebsocketSink(o.(*config.StreamConfig), types.MimeTypeRawAudio, callbacks)
-		if err != nil {
-			return nil, err
-		}
-		websocketBin, err := builder.BuildWebsocketBin(p, websocketSink.sinkCallbacks)
-		if err != nil {
-			return nil, err
-		}
-		base = &sink{
-			bin:      websocketBin,
-			close:    websocketSink.close,
-			closeErr: make(chan error, 1),
-		}
-		websocketSink.sink = base
-		s = websocketSink
+		return newWebsocketSink(p, o.(*config.StreamConfig), types.MimeTypeRawAudio, callbacks)
 
 	case types.EgressTypeImages:
-		imageSink, err := NewImageSink(conf, o.(*config.ImageConfig), callbacks, monitor)
-		if err != nil {
-			return nil, err
-		}
-		imageBin, err := builder.BuildImageBin(o.(*config.ImageConfig), p, conf)
-		if err != nil {
-			return nil, err
-		}
-		base = &sink{
-			bin:      imageBin,
-			close:    imageSink.close,
-			closeErr: make(chan error, 1),
-		}
-		imageSink.sink = base
-		s = imageSink
+		return newImageSink(p, conf, o.(*config.ImageConfig), callbacks, monitor)
 
 	default:
-		return nil, nil
+		return nil, errors.ErrInvalidInput("output type")
 	}
-
-	if err := p.AddSinkBin(base.bin); err != nil {
-		return nil, err
-	}
-
-	return s, nil
 }
 
-func (s *sink) AddEOSProbe() {
+func (s *base) AddEOSProbe() {
 	if err := s.bin.AddOnEOSReceived(func() {
-		logger.Debugw("sink received EOS", "bin", s.bin.GetName())
 		s.eosReceived.Store(true)
-		s.closeErr <- s.close()
-		logger.Debugw("sink closed", "bin", s.bin.GetName())
 	}); err != nil {
 		logger.Errorw("failed to add EOS probe", err)
 	}
 }
 
-func (s *sink) EOSReceived() bool {
+func (s *base) EOSReceived() bool {
 	return s.eosReceived.Load()
-}
-
-func (s *sink) Err() chan error {
-	return s.closeErr
 }

--- a/pkg/pipeline/sink/stream.go
+++ b/pkg/pipeline/sink/stream.go
@@ -1,0 +1,109 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sink
+
+import (
+	"sync"
+
+	"github.com/livekit/egress/pkg/config"
+	"github.com/livekit/egress/pkg/errors"
+	"github.com/livekit/egress/pkg/pipeline/builder"
+)
+
+type StreamSink struct {
+	*sink
+
+	mu      sync.RWMutex
+	bin     *builder.StreamBin
+	streams map[string]*builder.Stream
+}
+
+func NewStreamSink(streamBin *builder.StreamBin, o *config.StreamConfig) (*StreamSink, error) {
+	streamSink := &StreamSink{
+		bin:     streamBin,
+		streams: make(map[string]*builder.Stream),
+	}
+
+	var err error
+	o.Streams.Range(func(_, stream any) bool {
+		err = streamSink.AddStream(stream.(*config.Stream))
+		return err == nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return streamSink, nil
+}
+
+func (s *StreamSink) Start() error {
+	return nil
+}
+
+func (s *StreamSink) AddStream(stream *config.Stream) error {
+	ss, err := s.bin.BuildStream(stream)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.streams[stream.Name] = ss
+	s.mu.Unlock()
+
+	return s.bin.Bin.AddSinkBin(ss.Bin)
+}
+
+func (s *StreamSink) GetStream(name string) (*config.Stream, error) {
+	s.mu.Lock()
+	ss, ok := s.streams[name]
+	s.mu.Unlock()
+	if !ok {
+		return nil, errors.ErrStreamNotFound(name)
+	}
+
+	return ss.Conf, nil
+}
+
+func (s *StreamSink) ResetStream(stream *config.Stream, streamErr error) (bool, error) {
+	s.mu.Lock()
+	ss, ok := s.streams[stream.Name]
+	s.mu.Unlock()
+	if !ok {
+		return false, errors.ErrStreamNotFound(stream.RedactedUrl)
+	}
+
+	return ss.Reset(streamErr)
+}
+
+func (s *StreamSink) RemoveStream(stream *config.Stream) error {
+	s.mu.Lock()
+	_, ok := s.streams[stream.Name]
+	if !ok {
+		s.mu.Unlock()
+		return errors.ErrStreamNotFound(stream.RedactedUrl)
+	}
+	delete(s.streams, stream.Name)
+	s.mu.Unlock()
+
+	return s.bin.Bin.RemoveSinkBin(stream.Name)
+}
+
+func (s *StreamSink) UploadManifest(_ string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (s *StreamSink) close() error {
+	return nil
+}


### PR DESCRIPTION
Fixes a bug where an unresponsive RTMP server can freeze rtmp2sink, preventing the pipeline from posting an EOS