### PR TITLE
feat: allow setting GST_DEBUG env at runtime

### DIFF
--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -76,21 +76,27 @@ type SessionLimits struct {
 }
 
 func (c *BaseConfig) initLogger(values ...interface{}) error {
-	var gstDebug []string
-	switch c.Logging.Level {
-	case "debug":
-		gstDebug = []string{"3"}
-	case "info", "warn":
-		gstDebug = []string{"2"}
-	case "error":
-		gstDebug = []string{"1"}
-	}
-	gstDebug = append(gstDebug,
-		"rtmpclient:4",
-		"srtlib:1",
-	)
-	if err := os.Setenv("GST_DEBUG", strings.Join(gstDebug, ",")); err != nil {
-		return err
+	_, exists := os.LookupEnv("GST_DEBUG")
+
+	// If GST_DEBUG is not set, use pre-defined values based on logging level
+	if !exists {
+		var gstDebug []string
+		switch c.Logging.Level {
+		case "debug":
+			gstDebug = []string{"3"}
+		case "info", "warn":
+			gstDebug = []string{"2"}
+		case "error":
+			gstDebug = []string{"1"}
+		}
+		gstDebug = append(gstDebug,
+			"rtmpclient:4",
+			"srtlib:1",
+		)
+
+		if err := os.Setenv("GST_DEBUG", strings.Join(gstDebug, ",")); err != nil {
+			return err
+		}
 	}
 
 	zl, err := logger.NewZapLogger(c.Logging)


### PR DESCRIPTION
GST_DEBUG cannot be set at run time (i.e.: as an env var for the
docker container) since it's always overwritten by the application. This
makes debugging the app with more detailed gstreamer logs a bit more
convoluted - requires building a modified container, etc.

Allow setting the GST_DEBUG flag at runtime. If set by the app's user,
it'll overwrite the application-generated GST_DEBUG entirely. If unset,
the current behavior is preserved.