### PR TITLE
fix: update README yaml config regarding storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ session_limits: # optional egress duration limits - once hit, egress will end wi
 # file upload config - only one of the following. Can be overridden per request
 storage:
   s3:
-    access_key: AWS_ACCESS_KEY_ID env or IAM role can be used instead
-    secret: AWS_SECRET_ACCESS_KEY env or IAM role can be used instead
-    session_token: AWS_SESSION_TOKEN env or IAM role can be used instead
-    region: AWS_DEFAULT_REGION env or IAM role can be used instead
+    access_key: AWS_ACCESS_KEY_ID env or EMPTY if using IAM Role or instance profile
+    secret: AWS_SECRET_ACCESS_KEY env or EMPTY if using IAM Role or instance profile
+    session_token: AWS_SESSION_TOKEN env or EMPTY if using IAM Role or instance profile
+    region: AWS_DEFAULT_REGION env or EMPTY if using IAM Role or instance profile
     endpoint: (optional) custom endpoint
     bucket: bucket to upload files to
     # the following s3 options can only be set in config, *not* per request, they will be added to any per-request options

--- a/README.md
+++ b/README.md
@@ -80,39 +80,40 @@ session_limits: # optional egress duration limits - once hit, egress will end wi
   segment_output_max_duration: 3h
 
 # file upload config - only one of the following. Can be overridden per request
-s3:
-  access_key: AWS_ACCESS_KEY_ID env or IAM role can be used instead
-  secret: AWS_SECRET_ACCESS_KEY env or IAM role can be used instead
-  session_token: AWS_SESSION_TOKEN env or IAM role can be used instead
-  region: AWS_DEFAULT_REGION env or IAM role can be used instead
-  endpoint: (optional) custom endpoint
-  bucket: bucket to upload files to
-  # the following s3 options can only be set in config, *not* per request, they will be added to any per-request options
-  proxy_config:
-    url: (optional) proxy url
-    username: (optional) proxy username
-    password: (optional) proxy password
-  max_retries: (optional, default=3) number or retries to attempt
-  max_retry_delay: (optional, default=5s) max delay between retries (e.g. 5s, 100ms, 1m...)
-  min_retry_delay: (optional, default=500ms) min delay between retries (e.g. 100ms, 1s...)
-  aws_log_level: (optional, default=LogOff) log level for aws sdk (LogDebugWithRequestRetries, LogDebug, ...) 
-azure:
-  account_name: AZURE_STORAGE_ACCOUNT env can be used instead
-  account_key: AZURE_STORAGE_KEY env can be used instead
-  container_name: container to upload files to
-gcp:
-  credentials_json: GOOGLE_APPLICATION_CREDENTIALS env can be used instead
-  bucket: bucket to upload files to
-  proxy_config:
-    url: (optional) proxy url
-    username: (optional) proxy username
-    password: (optional) proxy password
-alioss:
-  access_key: Ali OSS AccessKeyId
-  secret: Ali OSS AccessKeySecret
-  region: Ali OSS region
-  endpoint: (optional) custom endpoint
-  bucket: bucket to upload files to
+storage:
+  s3:
+    access_key: AWS_ACCESS_KEY_ID env or IAM role can be used instead
+    secret: AWS_SECRET_ACCESS_KEY env or IAM role can be used instead
+    session_token: AWS_SESSION_TOKEN env or IAM role can be used instead
+    region: AWS_DEFAULT_REGION env or IAM role can be used instead
+    endpoint: (optional) custom endpoint
+    bucket: bucket to upload files to
+    # the following s3 options can only be set in config, *not* per request, they will be added to any per-request options
+    proxy_config:
+      url: (optional) proxy url
+      username: (optional) proxy username
+      password: (optional) proxy password
+    max_retries: (optional, default=3) number or retries to attempt
+    max_retry_delay: (optional, default=5s) max delay between retries (e.g. 5s, 100ms, 1m...)
+    min_retry_delay: (optional, default=500ms) min delay between retries (e.g. 100ms, 1s...)
+    aws_log_level: (optional, default=LogOff) log level for aws sdk (LogDebugWithRequestRetries, LogDebug, ...) 
+  azure:
+    account_name: AZURE_STORAGE_ACCOUNT env can be used instead
+    account_key: AZURE_STORAGE_KEY env can be used instead
+    container_name: container to upload files to
+  gcp:
+    credentials_json: GOOGLE_APPLICATION_CREDENTIALS env can be used instead
+    bucket: bucket to upload files to
+    proxy_config:
+      url: (optional) proxy url
+      username: (optional) proxy username
+      password: (optional) proxy password
+  alioss:
+    access_key: Ali OSS AccessKeyId
+    secret: Ali OSS AccessKeySecret
+    region: Ali OSS region
+    endpoint: (optional) custom endpoint
+    bucket: bucket to upload files to
 
 # dev/debugging fields
 insecure: can be used to connect to an insecure websocket (default false)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Enhance
- [ ] Documentation Update

## Description

- Livekit v1.9.0 S3 config (and all other storage configs) stopped working due to changes in how the config is parsed:

```go
type BaseConfig struct {
	...
	StorageConfig *StorageConfig          `yaml:"storage,omitempty"` // storage config
	...
}
```
while in the previous release it was 
```go
type StorageConfig struct {
	S3     *S3Config    `yaml:"s3"`
	Azure  *AzureConfig `yaml:"azure"`
	GCP    *GCPConfig   `yaml:"gcp"`
	AliOSS *S3Config    `yaml:"alioss"`
}
```
- The sample config file in the README also mentioned the use of IAM Role for S3 but it wasn't really clear what needed to be done in order to use the IAM Role .
## Related Tickets & Documents

- https://github.com/livekit/egress/issues/843
- https://github.com/livekit/egress/issues/75

## Proposed Changes:
- Changed the yaml config file in README to use the right yaml `storage` key
- Reworded S3 config regarding IAM Role
