### PR TITLE
Align test source output buffer duration with opus frame size

### DIFF
--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -262,6 +262,11 @@ func (b *AudioBin) addAudioTestSrcBin() error {
 		return errors.ErrGstPipelineError(err)
 	}
 
+	// 20 ms @ 48 kHz
+	if err = audioTestSrc.SetProperty("samplesperbuffer", 960); err != nil {
+		return errors.ErrGstPipelineError(err)
+	}
+
 	audioCaps, err := newAudioCapsFilter(b.conf, audioChannelStereo)
 	if err != nil {
 		return err


### PR DESCRIPTION
Makes log analysis easier