### PR TITLE
Revert "remove egressID from all handler prom metrics (#962)"

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -202,7 +202,7 @@ func runHandler(_ context.Context, c *cli.Command) error {
 
 	go func() {
 		sig := <-killChan
-		logger.Infow("process interrupt, stopping recording", "signal", sig)
+		logger.Infow("exit requested, stopping recording and shutting down", "signal", sig)
 		h.Kill()
 	}()
 

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -89,7 +89,7 @@ func New(ctx context.Context, conf *config.PipelineConfig, ipcServiceClient ipc.
 			BuildReady: make(chan struct{}),
 		},
 		sinks:   make(map[types.EgressType][]sink.Sink),
-		monitor: stats.NewHandlerMonitor(conf.NodeID, conf.ClusterID),
+		monitor: stats.NewHandlerMonitor(conf.NodeID, conf.ClusterID, conf.Info.EgressId),
 	}
 	c.callbacks.SetOnError(c.OnError)
 	c.callbacks.SetOnEOSSent(c.onEOSSent)

--- a/pkg/pipeline/sink/segments.go
+++ b/pkg/pipeline/sink/segments.go
@@ -135,11 +135,11 @@ func newSegmentSink(
 	}
 
 	// Register gauges that track the number of segments and playlist updates pending upload
-	monitor.RegisterPlaylistChannelSizeGauge(segmentSink.conf.NodeID, segmentSink.conf.ClusterID,
+	monitor.RegisterPlaylistChannelSizeGauge(segmentSink.conf.NodeID, segmentSink.conf.ClusterID, segmentSink.conf.Info.EgressId,
 		func() float64 {
 			return float64(len(segmentSink.playlistUpdates))
 		})
-	monitor.RegisterSegmentsChannelSizeGauge(segmentSink.conf.NodeID, segmentSink.conf.ClusterID,
+	monitor.RegisterSegmentsChannelSizeGauge(segmentSink.conf.NodeID, segmentSink.conf.ClusterID, segmentSink.conf.Info.EgressId,
 		func() float64 {
 			return float64(len(segmentSink.closedSegments))
 		})

--- a/pkg/service/metrics.go
+++ b/pkg/service/metrics.go
@@ -93,5 +93,33 @@ func deserializeMetrics(egressID string, s string) ([]*dto.MetricFamily, error) 
 		return make([]*dto.MetricFamily, 0), nil // don't return an error, just skip this handler
 	}
 
+	// Add an egress_id label to every metric all the families, if it doesn't already have one
+	applyDefaultLabel(egressID, families)
+
 	return maps.Values(families), nil
+}
+
+func applyDefaultLabel(egressID string, families map[string]*dto.MetricFamily) {
+	egressIDLabel := "egress_id"
+	egressLabelPair := &dto.LabelPair{
+		Name:  &egressIDLabel,
+		Value: &egressID,
+	}
+	for _, family := range families {
+		for _, metric := range family.Metric {
+			if metric.Label == nil {
+				metric.Label = make([]*dto.LabelPair, 0)
+			}
+			found := false
+			for _, label := range metric.Label {
+				if label.GetName() == "egress_id" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				metric.Label = append(metric.Label, egressLabelPair)
+			}
+		}
+	}
 }

--- a/pkg/stats/handler.go
+++ b/pkg/stats/handler.go
@@ -24,10 +24,10 @@ type HandlerMonitor struct {
 	backupCounter       *prometheus.CounterVec
 }
 
-func NewHandlerMonitor(nodeId string, clusterId string) *HandlerMonitor {
+func NewHandlerMonitor(nodeId string, clusterId string, egressId string) *HandlerMonitor {
 	m := &HandlerMonitor{}
 
-	constantLabels := prometheus.Labels{"node_id": nodeId, "cluster_id": clusterId}
+	constantLabels := prometheus.Labels{"node_id": nodeId, "cluster_id": clusterId, "egress_id": egressId}
 
 	m.uploadsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   "livekit",
@@ -75,26 +75,26 @@ func (m *HandlerMonitor) IncBackupStorageWrites(outputType string) {
 	m.backupCounter.With(prometheus.Labels{"output_type": outputType}).Add(1)
 }
 
-func (m *HandlerMonitor) RegisterSegmentsChannelSizeGauge(nodeId string, clusterId string, channelSizeFunction func() float64) {
+func (m *HandlerMonitor) RegisterSegmentsChannelSizeGauge(nodeId string, clusterId string, egressId string, channelSizeFunction func() float64) {
 	segmentsUploadsGauge := prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace:   "livekit",
 			Subsystem:   "egress",
 			Name:        "segments_uploads_channel_size",
 			Help:        "number of segment uploads pending in channel",
-			ConstLabels: prometheus.Labels{"node_id": nodeId, "cluster_id": clusterId},
+			ConstLabels: prometheus.Labels{"node_id": nodeId, "cluster_id": clusterId, "egress_id": egressId},
 		}, channelSizeFunction)
 	prometheus.MustRegister(segmentsUploadsGauge)
 }
 
-func (m *HandlerMonitor) RegisterPlaylistChannelSizeGauge(nodeId string, clusterId string, channelSizeFunction func() float64) {
+func (m *HandlerMonitor) RegisterPlaylistChannelSizeGauge(nodeId string, clusterId string, egressId string, channelSizeFunction func() float64) {
 	playlistUploadsGauge := prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace:   "livekit",
 			Subsystem:   "egress",
 			Name:        "playlist_uploads_channel_size",
 			Help:        "number of playlist updates pending in channel",
-			ConstLabels: prometheus.Labels{"node_id": nodeId, "cluster_id": clusterId},
+			ConstLabels: prometheus.Labels{"node_id": nodeId, "cluster_id": clusterId, "egress_id": egressId},
 		}, channelSizeFunction)
 	prometheus.MustRegister(playlistUploadsGauge)
 }


### PR DESCRIPTION
This reverts commit 5c3aab8316c32248d6017ac2f9cc4172851da779.