### PR TITLE
Handle small audio gaps by the signal time stretching/compression instead of having discontinuities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/livekit/media-sdk v0.0.0-20250518151703-b07af88637c5
 	github.com/livekit/protocol v1.40.0
 	github.com/livekit/psrpc v0.6.1-0.20250726180611-3915e005e741
-	github.com/livekit/server-sdk-go/v2 v2.10.0
+	github.com/livekit/server-sdk-go/v2 v2.9.3-0.20250821102307-e3173cbae52e
 	github.com/livekit/storage v0.0.0-20250711185412-0dabf9984ad7
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pion/rtp v1.8.21

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/livekit/protocol v1.40.0 h1:FzCv17ivkxI4ySE0uFXSPPVPBVepf736Cgnmi054z
 github.com/livekit/protocol v1.40.0/go.mod h1:YlgUxAegtU8jZ0tVXoIV/4fHeHqqLvS+6JnPKDbpFPU=
 github.com/livekit/psrpc v0.6.1-0.20250726180611-3915e005e741 h1:KKL1u94l6dF9u4cBwnnfozk27GH1txWy2SlvkfgmzoY=
 github.com/livekit/psrpc v0.6.1-0.20250726180611-3915e005e741/go.mod h1:AuDC5uOoEjQJEc69v4Li3t77Ocz0e0NdjQEuFfO+vfk=
+github.com/livekit/server-sdk-go/v2 v2.9.3-0.20250821102307-e3173cbae52e h1:2LCHqvzjt/Z0yxGzycEZ0akIHO0hpzR2KTPmJYjphNU=
+github.com/livekit/server-sdk-go/v2 v2.9.3-0.20250821102307-e3173cbae52e/go.mod h1:x9JXFdPeDPr0jdObS7pPfcytxYLdxNQhLk0pK/NcHSg=
 github.com/livekit/server-sdk-go/v2 v2.10.0 h1:RWU0+jb1ey3YouGoy7fojNEq0PCnPfw7b1umIcj9JlY=
 github.com/livekit/server-sdk-go/v2 v2.10.0/go.mod h1:x9JXFdPeDPr0jdObS7pPfcytxYLdxNQhLk0pK/NcHSg=
 github.com/livekit/storage v0.0.0-20250711185412-0dabf9984ad7 h1:r8qCurHAzOlgAa7PLhMyLzSPvPEiN41OwluKGFFH1ps=

--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -28,6 +28,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/livekit/egress/pkg/errors"
+	"github.com/livekit/egress/pkg/pipeline/tempo"
 	"github.com/livekit/egress/pkg/types"
 	"github.com/livekit/protocol/egress"
 	"github.com/livekit/protocol/livekit"
@@ -93,6 +94,7 @@ type TrackSource struct {
 	MimeType        types.MimeType
 	PayloadType     webrtc.PayloadType
 	ClockRate       uint32
+	TempoController *tempo.Controller
 }
 
 type AudioConfig struct {

--- a/pkg/pipeline/source/sdk.go
+++ b/pkg/pipeline/source/sdk.go
@@ -471,7 +471,7 @@ func (s *SDKSource) onTrackSubscribed(track *webrtc.TrackRemote, pub *lksdk.Remo
 		}
 		s.AudioTranscoding = true
 
-		tc := &tempo.Controller{}
+		tc := tempo.NewController()
 		ts.TempoController = tc
 		writer, err := s.createWriter(track, pub, rp, ts, tc)
 		if err != nil {

--- a/pkg/pipeline/source/sdk.go
+++ b/pkg/pipeline/source/sdk.go
@@ -418,9 +418,8 @@ func (s *SDKSource) subscribe(track lksdk.TrackPublication) error {
 
 		logger.Infow("subscribing to track", "trackID", track.SID())
 
-		if s.PipelineConfig.RequestType != types.RequestTypeRoomComposite {
-			pub.OnRTCP(s.sync.OnRTCP)
-		}
+		pub.OnRTCP(s.sync.OnRTCP)
+
 		return pub.SetSubscribed(true)
 	}
 

--- a/pkg/pipeline/tempo/tempo_controller.go
+++ b/pkg/pipeline/tempo/tempo_controller.go
@@ -1,0 +1,78 @@
+package tempo
+
+import (
+	"sync"
+	"time"
+
+	"github.com/livekit/protocol/logger"
+)
+
+type Controller struct {
+	sync.Mutex
+	pendingOffset time.Duration // backlog of SRs generated offsets
+	currentOffset time.Duration
+
+	driftDetectedCallback func(time.Duration)
+}
+
+func (tc *Controller) EnqueueDrift(drift time.Duration) {
+	if drift == 0 {
+		return
+	}
+
+	tc.Lock()
+	var cb func(time.Duration)
+
+	logger.Debugw("tempo controller, adding drift")
+	if tc.currentOffset == 0 {
+		tc.currentOffset = drift
+		if tc.driftDetectedCallback != nil {
+			cb = tc.driftDetectedCallback
+		}
+	} else {
+		tc.pendingOffset += drift
+	}
+
+	tc.Unlock()
+
+	if cb != nil {
+		cb(drift)
+	}
+}
+
+func (tc *Controller) DriftProcessed() {
+	logger.Debugw("controller, drift processed")
+
+	tc.Lock()
+	var currentOffset time.Duration
+	var cb func(time.Duration)
+
+	if tc.pendingOffset != 0 {
+		tc.currentOffset = tc.pendingOffset
+		tc.pendingOffset = 0
+		if tc.driftDetectedCallback != nil {
+			cb = tc.driftDetectedCallback
+			currentOffset = tc.currentOffset
+		}
+	} else {
+		tc.currentOffset = 0
+	}
+	tc.Unlock()
+
+	if cb != nil {
+		cb(currentOffset)
+	}
+}
+
+func (tc *Controller) OnDriftDetectedCallback(cb func(time.Duration)) {
+	logger.Debugw("setting drift detected callback")
+
+	tc.Lock()
+	tc.driftDetectedCallback = cb
+	cw := tc.currentOffset
+	tc.Unlock()
+
+	if cw != 0 {
+		cb(cw)
+	}
+}

--- a/pkg/pipeline/tempo/tempo_controller_test.go
+++ b/pkg/pipeline/tempo/tempo_controller_test.go
@@ -1,0 +1,140 @@
+package tempo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEnqueueStartsWithinBudget(t *testing.T) {
+	tc := NewController()
+
+	var calls []time.Duration
+	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
+
+	tc.EnqueueDrift(30 * time.Millisecond) // > threshold, under budget
+	if len(calls) != 1 || calls[0] != 30*time.Millisecond {
+		t.Fatalf("callback: got %v, want [30ms]", calls)
+	}
+	if got := tc.Processed(); got != 0 {
+		t.Fatalf("processed before DriftProcessed: got %v, want 0", got)
+	}
+}
+
+func TestThresholdAccumulation(t *testing.T) {
+	tc := NewController()
+
+	var calls []time.Duration
+	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
+
+	tc.EnqueueDrift(5 * time.Millisecond) // below threshold → no start
+	tc.EnqueueDrift(6 * time.Millisecond) // total 11ms → start now
+
+	if len(calls) != 1 || calls[0] != 11*time.Millisecond {
+		t.Fatalf("callback: got %v, want [11ms]", calls)
+	}
+}
+
+func TestDriftProcessedStartsNext(t *testing.T) {
+	tc := NewController()
+
+	var calls []time.Duration
+	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
+
+	tc.EnqueueDrift(30 * time.Millisecond) // starts immediately
+	if len(calls) != 1 || calls[0] != 30*time.Millisecond {
+		t.Fatalf("first start: got %v", calls)
+	}
+
+	tc.EnqueueDrift(40 * time.Millisecond) // pending, not started yet
+	if len(calls) != 1 {
+		t.Fatalf("should not start second yet: got %v", calls)
+	}
+
+	tc.DriftProcessed() // finish first → second starts
+	if len(calls) != 2 || calls[1] != 40*time.Millisecond {
+		t.Fatalf("second start: got %v", calls)
+	}
+
+	if got := tc.Processed(); got != 30*time.Millisecond {
+		t.Fatalf("processed after first completion: got %v, want 30ms", got)
+	}
+}
+
+func TestBudgetBlocksAndResumes(t *testing.T) {
+	tc := NewController()
+
+	var calls []time.Duration
+	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
+
+	// Spend most of the budget (1.9s)
+	tc.EnqueueDrift(1900 * time.Millisecond)
+	if len(calls) != 1 || calls[0] != 1900*time.Millisecond {
+		t.Fatalf("start 1.9s: got %v", calls)
+	}
+	tc.DriftProcessed()
+	if got := tc.Processed(); got != 1900*time.Millisecond {
+		t.Fatalf("processed after 1.9s: got %v", got)
+	}
+
+	// +300ms would exceed 2s budget → must NOT start
+	tc.EnqueueDrift(300 * time.Millisecond)
+	if len(calls) != 1 {
+		t.Fatalf("over-budget should not start: got %v", calls)
+	}
+
+	// Add -650ms → pending becomes -350ms → net processed+pending = 1.55s → start
+	tc.EnqueueDrift(-650 * time.Millisecond)
+	if len(calls) != 2 || calls[1] != -350*time.Millisecond {
+		t.Fatalf("start -350ms: got %v", calls)
+	}
+	tc.DriftProcessed()
+	if got := tc.Processed(); got != (1900*time.Millisecond - 350*time.Millisecond) {
+		t.Fatalf("processed signed total: got %v, want 1.55s", got)
+	}
+}
+
+func TestImmediateCallbackOnRegister(t *testing.T) {
+	tc := NewController()
+
+	// Arm a correction before registering callback
+	tc.EnqueueDrift(20 * time.Millisecond)
+
+	var calls []time.Duration
+	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
+
+	// Should fire immediately with current
+	if len(calls) != 1 || calls[0] != 20*time.Millisecond {
+		t.Fatalf("immediate callback: got %v, want [20ms]", calls)
+	}
+}
+
+func TestZeroDriftNoop(t *testing.T) {
+	tc := NewController()
+
+	var calls []time.Duration
+	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
+
+	tc.EnqueueDrift(0)
+	if len(calls) != 0 {
+		t.Fatalf("zero drift should do nothing, got %v", calls)
+	}
+}
+
+func TestSignedProcessedAccumulation(t *testing.T) {
+	tc := NewController()
+
+	var calls []time.Duration
+	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
+
+	tc.EnqueueDrift(30 * time.Millisecond)
+	tc.DriftProcessed()
+	if got := tc.Processed(); got != 30*time.Millisecond {
+		t.Fatalf("after +30ms processed: got %v", got)
+	}
+
+	tc.EnqueueDrift(-10 * time.Millisecond)
+	tc.DriftProcessed()
+	if got := tc.Processed(); got != 20*time.Millisecond {
+		t.Fatalf("after +30-10 processed: got %v, want 20ms", got)
+	}
+}


### PR DESCRIPTION
Using pitch gstreamer element for controlling audio signal tempo that is then driven by a drift detected by RTCP sender reports.
On SRs drifts, app source will continue producing buffers with monotonically increasing PTS. The reported drift will be handled either by slowing down the audio signal (if it's positive) or speeding it up. The pitch element will relatively gently change the rate (by 10%) without affecting pitch.
Pitch elements require F32 on its sink pads so adding caps filters around it to convert from and to S16.
Due to max pipeline latency - accumulated drift (if negative) could only raise up to that value after which we walk off the audio mixer latency cliff - so adding logic to guard against big cumulative drifts. An option for future improvements would be dynamically increasing pipeline latency and buffer sizes in that case but that could also go up to a certain point.

An example of a pipeline:
<img width="12306" height="978" alt="File_1_ParticipantComposite_H264" src="https://github.com/user-attachments/assets/5e79bb88-2faf-4579-a789-9b3b5239b5c4" />
