### PR TITLE
Add content checks to file integration tests - pilot

### DIFF
--- a/test/builder.go
+++ b/test/builder.go
@@ -46,6 +46,8 @@ type testCase struct {
 
 	multi  bool
 	custom func(*testing.T, *testCase)
+
+	contentCheck func(t *testing.T, path string, info *FFProbeInfo)
 }
 
 type publishOptions struct {

--- a/test/file.go
+++ b/test/file.go
@@ -290,11 +290,11 @@ func (r *Runner) verifyFile(t *testing.T, tc *testCase, p *config.PipelineConfig
 	}
 }
 
-// helpper function for the full test content analysis
+// helper function for the full test content analysis
 // analyzes the file for flashes, beeps, and silence
 func (r *Runner) fullContentCheck(t *testing.T, file string, info *FFProbeInfo) {
 	if r.Muting {
-		// support for content check on muted audio tracks to be added later
+		// TODO: support for content check on muted audio tracks to be added later
 		return
 	}
 	flashes, err := extractFlashTimestamps(file, r.FilePrefix)
@@ -339,7 +339,7 @@ func (r *Runner) videoOnlyContentCheck(t *testing.T, file string, info *FFProbeI
 
 func (r *Runner) audioOnlyContentCheck(t *testing.T, file string, info *FFProbeInfo) {
 	if r.Muting {
-		// support for content check on muted audio tracks to be added later
+		// TODO: support for content check on muted audio tracks to be added later
 		return
 	}
 	beeps, err := extractBeepTimestamps(file, testSampleBeepLevel, r.FilePrefix)

--- a/test/file.go
+++ b/test/file.go
@@ -49,6 +49,7 @@ func (r *Runner) testFile(t *testing.T) {
 				fileOptions: &fileOptions{
 					filename: "r_{room_name}_{time}.mp4",
 				},
+				contentCheck: r.fullContentCheck,
 			},
 			{
 				name:        "RoomComposite/VideoOnly",
@@ -63,6 +64,7 @@ func (r *Runner) testFile(t *testing.T) {
 				fileOptions: &fileOptions{
 					filename: "r_{room_name}_video_{time}.mp4",
 				},
+				contentCheck: r.videoOnlyContentCheck,
 			},
 			{
 				name:        "RoomComposite/AudioOnly",
@@ -77,6 +79,7 @@ func (r *Runner) testFile(t *testing.T) {
 					filename: "r_{room_name}_audio_{time}",
 					fileType: livekit.EncodedFileType_OGG,
 				},
+				contentCheck: r.audioOnlyContentCheck,
 			},
 
 			// ---------- Web ----------
@@ -146,6 +149,7 @@ func (r *Runner) testFile(t *testing.T) {
 					filename: "tc_{publisher_identity}_vp8_{time}.mp4",
 					fileType: livekit.EncodedFileType_MP4,
 				},
+				contentCheck: r.fullContentCheck,
 			},
 			{
 				name:        "TrackComposite/VideoOnly",
@@ -158,6 +162,7 @@ func (r *Runner) testFile(t *testing.T) {
 					filename: "tc_{room_name}_video_{time}.mp4",
 					fileType: livekit.EncodedFileType_MP4,
 				},
+				contentCheck: r.videoOnlyContentCheck,
 			},
 
 			// --------- Track ---------
@@ -173,6 +178,7 @@ func (r *Runner) testFile(t *testing.T) {
 					filename:   "t_{track_source}_{time}.ogg",
 					outputType: types.OutputTypeOGG,
 				},
+				contentCheck: r.audioOnlyContentCheck,
 			},
 			{
 				name:        "Track/H264",
@@ -186,6 +192,7 @@ func (r *Runner) testFile(t *testing.T) {
 					filename:   "t_{track_id}_{time}.mp4",
 					outputType: types.OutputTypeMP4,
 				},
+				contentCheck: r.videoOnlyContentCheck,
 			},
 			{
 				name:        "Track/VP8",
@@ -198,6 +205,7 @@ func (r *Runner) testFile(t *testing.T) {
 					filename:   "t_{track_type}_{time}.webm",
 					outputType: types.OutputTypeWebM,
 				},
+				contentCheck: r.videoOnlyContentCheck,
 			},
 			// {
 			// 	name:       "Track/VP9",
@@ -239,10 +247,10 @@ func (r *Runner) runFileTest(t *testing.T, test *testCase) {
 	require.Equal(t, test.requestType != types.RequestTypeTrack && !test.audioOnly, p.VideoEncoding)
 
 	// verify
-	r.verifyFile(t, p, res)
+	r.verifyFile(t, test, p, res)
 }
 
-func (r *Runner) verifyFile(t *testing.T, p *config.PipelineConfig, res *livekit.EgressInfo) {
+func (r *Runner) verifyFile(t *testing.T, tc *testCase, p *config.PipelineConfig, res *livekit.EgressInfo) {
 	// egress info
 	require.Equal(t, res.Error == "", res.Status != livekit.EgressStatus_EGRESS_FAILED)
 	require.NotZero(t, res.StartedAt)
@@ -275,5 +283,77 @@ func (r *Runner) verifyFile(t *testing.T, p *config.PipelineConfig, res *livekit
 	require.NotNil(t, manifest)
 
 	// verify
-	verify(t, localPath, p, res, types.EgressTypeFile, r.Muting, r.sourceFramerate, false)
+	info := verify(t, localPath, p, res, types.EgressTypeFile, r.Muting, r.sourceFramerate, false)
+
+	if tc.contentCheck != nil && info != nil {
+		tc.contentCheck(t, localPath, info)
+	}
+}
+
+// helpper function for the full test content analysis
+// analyzes the file for flashes, beeps, and silence
+func (r *Runner) fullContentCheck(t *testing.T, file string, info *FFProbeInfo) {
+	if r.Muting {
+		// support for content check on muted audio tracks to be added later
+		return
+	}
+	flashes, err := extractFlashTimestamps(file, r.FilePrefix)
+	require.NoError(t, err)
+
+	beeps, err := extractBeepTimestamps(file, testSampleBeepLevel, r.FilePrefix)
+	require.NoError(t, err)
+
+	silenceRanges, err := detectSilence(file, testSampleSilenceLevel, time.Millisecond*100)
+	require.NoError(t, err)
+	require.Empty(t, silenceRanges)
+
+	dur, err := parseFFProbeDuration(info.Format.Duration)
+	require.NoError(t, err)
+
+	require.InDelta(t, len(flashes), len(beeps), 3)
+	require.InDelta(t, len(flashes), dur.Round(time.Second).Seconds(), 3)
+
+	avgFlashSpacing, err := averageSpacing(flashes)
+	require.NoError(t, err)
+	// 200ms is still pretty generous, should be tighter
+	requireDurationInDelta(t, avgFlashSpacing, time.Second, time.Millisecond*200)
+
+	avgBeepSpacing, err := averageSpacing(beeps)
+	require.NoError(t, err)
+	requireDurationInDelta(t, avgBeepSpacing, time.Second, time.Millisecond*200)
+}
+
+func (r *Runner) videoOnlyContentCheck(t *testing.T, file string, info *FFProbeInfo) {
+	flashes, err := extractFlashTimestamps(file, r.FilePrefix)
+	require.NoError(t, err)
+
+	dur, err := parseFFProbeDuration(info.Format.Duration)
+	require.NoError(t, err)
+
+	require.InDelta(t, len(flashes), dur.Round(time.Second).Seconds(), 3)
+	avgFlashSpacing, err := averageSpacing(flashes)
+	require.NoError(t, err)
+	// 200ms is still pretty generous, should be tighter
+	requireDurationInDelta(t, avgFlashSpacing, time.Second, time.Millisecond*200)
+}
+
+func (r *Runner) audioOnlyContentCheck(t *testing.T, file string, info *FFProbeInfo) {
+	if r.Muting {
+		// support for content check on muted audio tracks to be added later
+		return
+	}
+	beeps, err := extractBeepTimestamps(file, testSampleBeepLevel, r.FilePrefix)
+	require.NoError(t, err)
+
+	silenceRanges, err := detectSilence(file, testSampleSilenceLevel, time.Millisecond*100)
+	require.NoError(t, err)
+	require.Empty(t, silenceRanges)
+
+	dur, err := parseFFProbeDuration(info.Format.Duration)
+	require.NoError(t, err)
+	require.InDelta(t, len(beeps), dur.Round(time.Second).Seconds(), 3)
+
+	avgBeepSpacing, err := averageSpacing(beeps)
+	require.NoError(t, err)
+	requireDurationInDelta(t, avgBeepSpacing, time.Second, time.Millisecond*200)
 }

--- a/test/file.go
+++ b/test/file.go
@@ -17,6 +17,7 @@
 package test
 
 import (
+	"fmt"
 	"path"
 	"strings"
 	"testing"
@@ -309,7 +310,8 @@ func (r *Runner) fullContentCheck(t *testing.T, file string, info *FFProbeInfo) 
 
 	silenceRanges, err := detectSilence(file, testSampleSilenceLevel, time.Millisecond*100)
 	require.NoError(t, err)
-	require.True(t, len(silenceRanges) == 0 || silenceRanges[0].start > dur-time.Second*2)
+	require.True(t, len(silenceRanges) == 0 || silenceRanges[0].start > dur-time.Second*2,
+		fmt.Sprintf("unexpected silence ranges: %v", silenceRanges))
 
 	require.InDelta(t, len(flashes), len(beeps), 3)
 	require.InDelta(t, len(flashes), dur.Round(time.Second).Seconds(), 3)
@@ -353,7 +355,8 @@ func (r *Runner) audioOnlyContentCheck(t *testing.T, file string, info *FFProbeI
 	silenceRanges, err := detectSilence(file, testSampleSilenceLevel, time.Millisecond*100)
 	require.NoError(t, err)
 	// sometimes the silence range is at the end of the file, ignore it
-	require.True(t, len(silenceRanges) == 0 || silenceRanges[0].start > dur-time.Second*2)
+	require.True(t, len(silenceRanges) == 0 || silenceRanges[0].start > dur-time.Second*2,
+		fmt.Sprintf("unexpected silence ranges: %v", silenceRanges))
 
 	require.InDelta(t, len(beeps), dur.Round(time.Second).Seconds(), 3)
 

--- a/test/multi.go
+++ b/test/multi.go
@@ -141,7 +141,7 @@ func (r *Runner) runMultiTest(t *testing.T, test *testCase) {
 
 	res := r.stopEgress(t, egressID)
 	if test.fileOptions != nil {
-		r.verifyFile(t, p, res)
+		r.verifyFile(t, test, p, res)
 	}
 	if test.segmentOptions != nil {
 		r.verifySegments(t, p, test.segmentOptions.suffix, res, false)

--- a/test/test_content.go
+++ b/test/test_content.go
@@ -1,0 +1,308 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+//----------------------------------------------------------------------
+// Utilities for checking AV sync for the given audio/video test sample
+// https://github.com/livekit/media-samples/avsync_minmotion_livekit*
+//----------------------------------------------------------------------
+
+const (
+	testSampleSilenceLevel = -38
+	testSampleBeepLevel    = -30.0
+)
+
+var (
+	rePTS  = regexp.MustCompile(`pts_time:([0-9.]+)`)
+	reYAVG = regexp.MustCompile(`lavfi\.signalstats\.YAVG[=:]\s*([0-9.]+)`)
+	reRMS  = regexp.MustCompile(`RMS_level[=:](-?[0-9.infINFNaN]+)`)
+)
+
+func ffmpegVideoStats(videoPath, statsFile string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ffmpeg",
+		"-hide_banner", "-nostats", "-loglevel", "repeat+info",
+		"-i", videoPath,
+		"-map", "0:v:0",
+		"-vf", fmt.Sprintf("crop=w=iw:h=8:x=0:y=0,signalstats,metadata=print:file=%s", statsFile),
+		"-f", "null", "-")
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("ffmpeg video stats timeout after 15s")
+		}
+		return fmt.Errorf("ffmpeg video stats extraction failed: %w\nstdout:\n%s\nstderr:\n%s",
+			err, outBuf.String(), errBuf.String())
+	}
+	return nil
+}
+
+func ffmpegAudioStats(audioPath, statsFile string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ffmpeg",
+		"-hide_banner", "-nostats", "-loglevel", "repeat+info",
+		"-i", audioPath,
+		"-af", fmt.Sprintf("pan=mono|c0=0.5*c0+0.5*c1,astats=metadata=1:reset=1,ametadata=print:key=lavfi.astats.Overall.RMS_level:file=%s", statsFile),
+		"-f", "null", "-")
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("ffmpeg audio stats timeout after 15s")
+		}
+		return fmt.Errorf("ffmpeg audio stats extraction failed: %w\nstdout:\n%s\nstderr:\n%s",
+			err, outBuf.String(), errBuf.String())
+	}
+	return nil
+}
+
+func ffmpegSilenceStats(audioPath string, noiseLevel int, minDuration float64) (*bytes.Buffer, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ffmpeg",
+		"-hide_banner", "-nostats", "-loglevel", "info",
+		"-i", audioPath,
+		"-af", "silencedetect=noise="+fmt.Sprintf("%d", noiseLevel)+"dB:d="+strconv.FormatFloat(minDuration, 'f', -1, 64),
+		"-f", "null", "-")
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("ffmpeg silence stats timeout after 15s")
+		}
+		return nil, fmt.Errorf("ffmpeg silence stats extraction failed: %w\nstderr:\n%s",
+			err, stderr.String())
+	}
+	return &stderr, nil
+}
+
+// extractFlashTimestamps runs ffmpeg + signalstats on the top stripe
+// and returns one timestamp per flash event (YAVG >= 130, spaced ≥0.2s).
+func extractFlashTimestamps(videoPath, outPath string) ([]time.Duration, error) {
+	logFile := filepath.Join(outPath, "video_flash.log")
+
+	err := ffmpegVideoStats(videoPath, logFile)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(logFile)
+	if err != nil {
+		return nil, fmt.Errorf("ffmpeg video stats failed to open log file: %w", err)
+	}
+	defer file.Close()
+
+	const flashThreshold = 130.0
+	const minGap = 200 * time.Millisecond
+
+	var (
+		flashes   []time.Duration
+		lastFlash = -999 * time.Second
+		curPTS    time.Duration
+	)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if m := rePTS.FindStringSubmatch(line); len(m) == 2 {
+			// PTS is logged as seconds (float); convert to duration
+			if d, perr := parsePTSSecondsToDuration(m[1]); perr == nil {
+				curPTS = d
+			}
+			continue
+		}
+
+		if m := reYAVG.FindStringSubmatch(line); len(m) == 2 {
+			y, _ := strconv.ParseFloat(m[1], 64)
+			if y >= flashThreshold && curPTS-lastFlash > minGap {
+				flashes = append(flashes, curPTS)
+				lastFlash = curPTS
+			}
+		}
+	}
+	return flashes, scanner.Err()
+}
+
+// extractBeepTimestamps runs ffmpeg + astats to find beeps.
+// A beep is when RMS_level > beepThreshold, debounced by 0.2s.
+func extractBeepTimestamps(audioPath string, beepThreshold float64, outPath string) ([]time.Duration, error) {
+	logFile := filepath.Join(outPath, "audio_beep.log")
+
+	err := ffmpegAudioStats(audioPath, logFile)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(logFile)
+	if err != nil {
+		return nil, fmt.Errorf("ffmpeg audio stats failed to open log file: %w", err)
+	}
+	defer file.Close()
+
+	const minGap = 200 * time.Millisecond
+
+	var (
+		beeps  []time.Duration
+		last   = -999 * time.Second
+		curPTS time.Duration
+	)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if m := rePTS.FindStringSubmatch(line); len(m) == 2 {
+			if d, perr := parsePTSSecondsToDuration(m[1]); perr == nil {
+				curPTS = d
+			}
+			continue
+		}
+
+		if m := reRMS.FindStringSubmatch(line); len(m) == 2 {
+			val := m[1]
+			if strings.Contains(val, "inf") || strings.Contains(val, "nan") {
+				continue // skip silence or invalid
+			}
+			lvl, _ := strconv.ParseFloat(val, 64)
+			if lvl > beepThreshold && curPTS-last > minGap {
+				beeps = append(beeps, curPTS)
+				last = curPTS
+			}
+		}
+	}
+	return beeps, scanner.Err()
+}
+
+// silenceRange represents one silence segment in durations.
+type silenceRange struct {
+	start    time.Duration
+	end      time.Duration
+	duration time.Duration
+}
+
+// detectSilence runs ffmpeg silencedetect and returns all silence ranges.
+func detectSilence(audioPath string, noiseLevel int, minDuration time.Duration) ([]silenceRange, error) {
+	stderr, err := ffmpegSilenceStats(audioPath, noiseLevel, minDuration.Seconds())
+	if err != nil {
+		return nil, err
+	}
+
+	var ranges []silenceRange
+	var current silenceRange
+	inSilence := false
+
+	reStart := regexp.MustCompile(`silence_start:\s*([0-9.]+)`)
+	reEnd := regexp.MustCompile(`silence_end:\s*([0-9.]+)\s*\|\s*silence_duration:\s*([0-9.]+)`)
+
+	scanner := bufio.NewScanner(stderr)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if m := reStart.FindStringSubmatch(line); len(m) == 2 {
+			if start, perr := strconv.ParseFloat(m[1], 64); perr == nil {
+				current = silenceRange{start: secondsToDuration(start)}
+				inSilence = true
+			}
+		}
+
+		if m := reEnd.FindStringSubmatch(line); len(m) == 3 {
+			if inSilence {
+				end, _ := strconv.ParseFloat(m[1], 64)
+				dur, _ := strconv.ParseFloat(m[2], 64)
+				current.end = secondsToDuration(end)
+				current.duration = secondsToDuration(dur)
+				ranges = append(ranges, current)
+				inSilence = false
+			}
+		}
+	}
+
+	return ranges, scanner.Err()
+}
+
+func secondsToDuration(f float64) time.Duration {
+	return time.Duration(f * float64(time.Second))
+}
+
+func parsePTSSecondsToDuration(s string) (time.Duration, error) {
+	f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(f * float64(time.Second)), nil
+}
+
+func averageSpacing(ts []time.Duration) (time.Duration, error) {
+	if len(ts) < 2 {
+		return 0, fmt.Errorf("need at least 2 timestamps (got %d)", len(ts))
+	}
+
+	var sum time.Duration
+	var gaps int
+	for i := 1; i < len(ts); i++ {
+		d := ts[i] - ts[i-1]
+		if d <= 0 {
+			// skip non-positive gaps (duplicates or out-of-order anomalies)
+			continue
+		}
+		sum += d
+		gaps++
+	}
+	if gaps == 0 {
+		return 0, fmt.Errorf("no positive gaps to compute spacing")
+	}
+	return time.Duration(int64(sum) / int64(gaps)), nil
+}
+
+func requireDurationInDelta(t *testing.T, expected, actual, delta time.Duration, msgAndArgs ...interface{}) {
+	require.InDelta(t,
+		expected.Nanoseconds(),
+		actual.Nanoseconds(),
+		float64(delta.Nanoseconds()),
+		msgAndArgs...)
+}


### PR DESCRIPTION
Adding utilities for extracting visual cues (white stripe) and audio beeps from the new test output and using these to build content check functions for file integration tests (others to follow with minor or even without modifications). Covering first cases without muting and re-publishing. Each ouput is checked for presence of properly spaced visual and audio beep occurances and for absence of silence gaps.