### PR TITLE
Enabling PLC for opus decoder

### DIFF
--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -38,7 +38,7 @@ const (
 	leakyQueue    = true
 	blockingQueue = false
 
-	opusPlcMaxFrames         = 4
+	opusPlcMaxFrames         = 5
 	opusDecStatsPollInterval = time.Second * 5
 	opusDecPlcMaxJitter      = 3 * time.Millisecond
 )
@@ -468,7 +468,7 @@ func installOpusParseSrcProbe(opusParse *gst.Element, opusDec *gst.Element) {
 				logger.Debugw("opusdec stats: parse error", "err", err)
 				return gst.PadProbeOK
 			}
-			postOpusStatsMessage(opusDec, stats)
+			postOpusDecStatsMessage(opusDec, stats)
 			lastPoll = time.Now()
 		}
 

--- a/pkg/pipeline/builder/audio_stats.go
+++ b/pkg/pipeline/builder/audio_stats.go
@@ -1,0 +1,129 @@
+package builder
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/go-gst/go-glib/glib"
+	"github.com/go-gst/go-gst/gst"
+	"github.com/livekit/protocol/logger"
+)
+
+const (
+	OpusStatsStructName       = "livekit-opus-plc-stats"
+	OpusStatsKeyPlcDurationNs = "plc-duration-ns"
+	OpusStatsKeyPlcNumSamples = "plc-num-samples"
+	OpusStatsKeyNumGap        = "num-gap"
+	OpusStatsKeyNumPushed     = "num-pushed"
+)
+
+var (
+	reU64 = map[string]*regexp.Regexp{
+		"num-pushed":      regexp.MustCompile(`\bnum-pushed=\(g?uint64\)(\d+)`),
+		"num-gap":         regexp.MustCompile(`\bnum-gap=\(g?uint64\)(\d+)`),
+		"plc-num-samples": regexp.MustCompile(`\bplc-num-samples=\(g?uint64\)(\d+)`),
+		"plc-duration":    regexp.MustCompile(`\bplc-duration=\(g?uint64\)(\d+)`), // ns
+	}
+	reU32 = map[string]*regexp.Regexp{
+		"sample-rate": regexp.MustCompile(`\bsample-rate=\(uint\)(\d+)`),
+		"channels":    regexp.MustCompile(`\bchannels=\(uint\)(\d+)`),
+	}
+)
+
+type OpusDecStats struct {
+	NumPushed     uint64
+	NumGap        uint64
+	PlcNumSamples uint64
+	PlcDuration   time.Duration // ns
+	SampleRate    uint32
+	Channels      uint32
+}
+
+func serializeOpusStats(opusdec *gst.Element) (string, bool) {
+	gvAny, err := opusdec.GetProperty("stats")
+	if err != nil {
+		log.Printf("opusdec stats: get failed: %v", err)
+		return "", false
+	}
+	switch v := gvAny.(type) {
+	case *gst.Structure:
+		return v.String(), true
+	case *glib.Value:
+		return gst.ValueSerialize(v), true
+	case string:
+		return v, true
+	default:
+		log.Printf("opusdec stats: unexpected type %T", gvAny)
+		return "", false
+	}
+}
+
+/*** minimal parser for the serialized GstStructure ***/
+
+func parseStatsString(s string) (OpusDecStats, error) {
+	var st OpusDecStats
+
+	getU64 := func(k string) (uint64, error) {
+		if m := reU64[k].FindStringSubmatch(s); len(m) == 2 {
+			return strconv.ParseUint(m[1], 10, 64)
+		}
+		return 0, fmt.Errorf("missing %s", k)
+	}
+	getU32 := func(k string) (uint32, error) {
+		if m := reU32[k].FindStringSubmatch(s); len(m) == 2 {
+			v, _ := strconv.ParseUint(m[1], 10, 32)
+			return uint32(v), nil
+		}
+		return 0, fmt.Errorf("missing %s", k)
+	}
+
+	// Required
+	if v, err := getU64("num-pushed"); err == nil {
+		st.NumPushed = v
+	}
+	if v, err := getU64("num-gap"); err == nil {
+		st.NumGap = v
+	}
+	if v, err := getU64("plc-num-samples"); err == nil {
+		st.PlcNumSamples = v
+	}
+	if v, err := getU64("plc-duration"); err == nil {
+		st.PlcDuration = time.Duration(v) * time.Nanosecond
+	}
+
+	// Optional
+	if v, err := getU32("sample-rate"); err == nil {
+		st.SampleRate = v
+	}
+	if v, err := getU32("channels"); err == nil {
+		st.Channels = v
+	}
+	return st, nil
+}
+
+func getOpusDecStats(opusdec *gst.Element) (OpusDecStats, error) {
+	ser, ok := serializeOpusStats(opusdec)
+	if !ok {
+		return OpusDecStats{}, fmt.Errorf("serialize error")
+	}
+	return parseStatsString(ser)
+}
+
+func postOpusStatsMessage(src *gst.Element, stats OpusDecStats) {
+	s := gst.NewStructureFromString(
+		fmt.Sprintf("%s, %s=(guint64)%d, %s=(guint64)%d, %s=(guint64)%d, %s=(guint64)%d",
+			OpusStatsStructName,
+			OpusStatsKeyPlcDurationNs, stats.PlcDuration.Nanoseconds(),
+			OpusStatsKeyPlcNumSamples, stats.PlcNumSamples,
+			OpusStatsKeyNumGap, stats.NumGap,
+			OpusStatsKeyNumPushed, stats.NumPushed,
+		))
+	msg := gst.NewElementMessage(src, s)
+	sent := src.PostMessage(msg)
+	if !sent {
+		logger.Debugw("failed to send opusdec PLC stats", "sent", sent)
+	}
+}

--- a/pkg/pipeline/builder/audio_stats.go
+++ b/pkg/pipeline/builder/audio_stats.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	OpusStatsStructName       = "livekit-opus-plc-stats"
-	OpusStatsKeyPlcDurationNs = "plc-duration-ns"
-	OpusStatsKeyPlcNumSamples = "plc-num-samples"
-	OpusStatsKeyNumGap        = "num-gap"
-	OpusStatsKeyNumPushed     = "num-pushed"
+	OpusDecStatsStructName       = "livekit-opus-plc-stats"
+	OpusDecStatsKeyPlcDurationNs = "plc-duration-ns"
+	OpusDecStatsKeyPlcNumSamples = "plc-num-samples"
+	OpusDecStatsKeyNumGap        = "num-gap"
+	OpusDecStatsKeyNumPushed     = "num-pushed"
 )
 
 var (
@@ -112,18 +112,18 @@ func getOpusDecStats(opusdec *gst.Element) (OpusDecStats, error) {
 	return parseStatsString(ser)
 }
 
-func postOpusStatsMessage(src *gst.Element, stats OpusDecStats) {
+func postOpusDecStatsMessage(src *gst.Element, stats OpusDecStats) {
 	s := gst.NewStructureFromString(
 		fmt.Sprintf("%s, %s=(guint64)%d, %s=(guint64)%d, %s=(guint64)%d, %s=(guint64)%d",
-			OpusStatsStructName,
-			OpusStatsKeyPlcDurationNs, stats.PlcDuration.Nanoseconds(),
-			OpusStatsKeyPlcNumSamples, stats.PlcNumSamples,
-			OpusStatsKeyNumGap, stats.NumGap,
-			OpusStatsKeyNumPushed, stats.NumPushed,
+			OpusDecStatsStructName,
+			OpusDecStatsKeyPlcDurationNs, stats.PlcDuration.Nanoseconds(),
+			OpusDecStatsKeyPlcNumSamples, stats.PlcNumSamples,
+			OpusDecStatsKeyNumGap, stats.NumGap,
+			OpusDecStatsKeyNumPushed, stats.NumPushed,
 		))
 	msg := gst.NewElementMessage(src, s)
 	sent := src.PostMessage(msg)
 	if !sent {
-		logger.Debugw("failed to send opusdec PLC stats", "sent", sent)
+		logger.Debugw("failed to send opusdec PLC stats")
 	}
 }

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -73,6 +73,11 @@ type Controller struct {
 type controllerStats struct {
 	droppedAudioBuffers  atomic.Uint64
 	droppedAudioDuration atomic.Duration
+	// opusdec stats
+	opusDecPLCDuration   atomic.Duration
+	opusDecPLCSamples    atomic.Uint64
+	opusDecPacketsPushed atomic.Uint64
+	opusDecGapPackets    atomic.Uint64
 }
 
 func New(ctx context.Context, conf *config.PipelineConfig, ipcServiceClient ipc.EgressServiceClient) (*Controller, error) {
@@ -177,6 +182,10 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 		logger.Debugw("Audio QoS stats",
 			"audio buffers dropped", c.stats.droppedAudioBuffers.Load(),
 			"total audio duration dropped", c.stats.droppedAudioDuration.Load(),
+			"opusdec PLC duration", c.stats.opusDecPLCDuration.Load(),
+			"opusdec PLC samples", c.stats.opusDecPLCSamples.Load(),
+			"opusdec gap packets", c.stats.opusDecGapPackets.Load(),
+			"opusdec packets pushed", c.stats.opusDecPacketsPushed.Load(),
 		)
 	}()
 

--- a/pkg/pipeline/watch.go
+++ b/pkg/pipeline/watch.go
@@ -317,8 +317,8 @@ func (c *Controller) handleMessageElement(msg *gst.Message) error {
 			if err != nil {
 				return err
 			}
-		case builder.OpusStatsStructName:
-			c.handleOpusStats(s)
+		case builder.OpusDecStatsStructName:
+			c.handleOpusDecStats(s)
 		}
 	}
 
@@ -342,8 +342,8 @@ func (c *Controller) handleAudioMixerQoS(qosValues *gst.QoSValues) {
 	c.stats.droppedAudioDuration.Add(qosValues.Duration)
 }
 
-func (c *Controller) handleOpusStats(s *gst.Structure) {
-	dur, err := s.GetValue(builder.OpusStatsKeyPlcDurationNs)
+func (c *Controller) handleOpusDecStats(s *gst.Structure) {
+	dur, err := s.GetValue(builder.OpusDecStatsKeyPlcDurationNs)
 	if err != nil {
 		return
 	}
@@ -351,7 +351,7 @@ func (c *Controller) handleOpusStats(s *gst.Structure) {
 	if !ok {
 		return
 	}
-	numSamples, err := s.GetValue(builder.OpusStatsKeyPlcNumSamples)
+	numSamples, err := s.GetValue(builder.OpusDecStatsKeyPlcNumSamples)
 	if err != nil {
 		return
 	}
@@ -359,7 +359,7 @@ func (c *Controller) handleOpusStats(s *gst.Structure) {
 	if !ok {
 		return
 	}
-	numGap, err := s.GetValue(builder.OpusStatsKeyNumGap)
+	numGap, err := s.GetValue(builder.OpusDecStatsKeyNumGap)
 	if err != nil {
 		return
 	}
@@ -367,7 +367,7 @@ func (c *Controller) handleOpusStats(s *gst.Structure) {
 	if !ok {
 		return
 	}
-	pushed, err := s.GetValue(builder.OpusStatsKeyNumPushed)
+	pushed, err := s.GetValue(builder.OpusDecStatsKeyNumPushed)
 	if err != nil {
 		return
 	}
@@ -375,7 +375,11 @@ func (c *Controller) handleOpusStats(s *gst.Structure) {
 	if !ok {
 		return
 	}
-	logger.Debugw("opusdec PLC stats", "plcDurationNs", plcDurationNs, "plcNumSamples", plcNumSamples, "numGap", plcNumGap, "numPushed", plcNumPushed)
+
+	c.stats.opusDecPLCDuration.Store(time.Duration(plcDurationNs) * time.Nanosecond)
+	c.stats.opusDecPLCSamples.Store(plcNumSamples)
+	c.stats.opusDecGapPackets.Store(plcNumGap)
+	c.stats.opusDecPacketsPushed.Store(plcNumPushed)
 }
 
 // Debug info comes in the following format:

--- a/pkg/pipeline/watch.go
+++ b/pkg/pipeline/watch.go
@@ -317,6 +317,8 @@ func (c *Controller) handleMessageElement(msg *gst.Message) error {
 			if err != nil {
 				return err
 			}
+		case builder.OpusStatsStructName:
+			c.handleOpusStats(s)
 		}
 	}
 
@@ -338,6 +340,42 @@ func (c *Controller) handleMessageQoS(msg *gst.Message) {
 func (c *Controller) handleAudioMixerQoS(qosValues *gst.QoSValues) {
 	c.stats.droppedAudioBuffers.Inc()
 	c.stats.droppedAudioDuration.Add(qosValues.Duration)
+}
+
+func (c *Controller) handleOpusStats(s *gst.Structure) {
+	dur, err := s.GetValue(builder.OpusStatsKeyPlcDurationNs)
+	if err != nil {
+		return
+	}
+	plcDurationNs, ok := dur.(uint64)
+	if !ok {
+		return
+	}
+	numSamples, err := s.GetValue(builder.OpusStatsKeyPlcNumSamples)
+	if err != nil {
+		return
+	}
+	plcNumSamples, ok := numSamples.(uint64)
+	if !ok {
+		return
+	}
+	numGap, err := s.GetValue(builder.OpusStatsKeyNumGap)
+	if err != nil {
+		return
+	}
+	plcNumGap, ok := numGap.(uint64)
+	if !ok {
+		return
+	}
+	pushed, err := s.GetValue(builder.OpusStatsKeyNumPushed)
+	if err != nil {
+		return
+	}
+	plcNumPushed, ok := pushed.(uint64)
+	if !ok {
+		return
+	}
+	logger.Debugw("opusdec PLC stats", "plcDurationNs", plcDurationNs, "plcNumSamples", plcNumSamples, "numGap", plcNumGap, "numPushed", plcNumPushed)
 }
 
 // Debug info comes in the following format:


### PR DESCRIPTION
Adding opuseparse element before the opus decoder in order to be able to determine buffer durations before the decoder and have ability to signal gaps should it results in smaller (up to 5 frames) gaps. In order to make the PLC logic effective a gap event needs to be signaled to the decoder in addition to enabling its `plc` property.
A periodic poll of opus decoder stats is also added and exposed as an element message used to update audio qos metrics.