### PR TITLE
Speed up build time

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -40,7 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: build/test/fetch-media-samples.sh
-      
+ 
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -81,6 +81,10 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.docker-md.outputs.tags }}
           labels: ${{ steps.docker-md.outputs.labels }}
+          build-args: |
+            DEADLOCK=1
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   test:
     needs: build

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -98,8 +98,9 @@ jobs:
           build-args: |
             DEADLOCK=1
             TEMPLATE_TAG=${{ steps.template-tag.outputs.template_tag }}
-          cache-from: type=registry,ref=livekit/egress-integration:buildcache
-          cache-to:   type=registry,ref=livekit/egress-integration:buildcache,mode=max,ignore-error=true
+          # TODO: Enable caching once registry periodic cleanup is implemented
+          #cache-from: type=registry,ref=livekit/egress-integration:buildcache
+          #cache-to:   type=registry,ref=livekit/egress-integration:buildcache,mode=max,ignore-error=true
 
   test:
     needs: build

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -91,8 +91,9 @@ jobs:
           labels: ${{ steps.docker-md.outputs.labels }}
           build-args: |
             DEADLOCK=1
+          github-token: ${{ github.token }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
   test:
     needs: build

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -41,15 +41,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: build/test/fetch-media-samples.sh
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-            ~/.cache
-          key: egress-integration-${{ hashFiles('**/go.sum') }}
-          restore-keys: egress-integration
-
       - name: Docker metadata
         id: docker-md
         uses: docker/metadata-action@v5
@@ -57,14 +48,6 @@ jobs:
           images: livekit/egress-integration
           tags: |
             type=sha
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.22.1
-
-      - name: Download Go modules
-        run: go mod download
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -91,9 +74,8 @@ jobs:
           labels: ${{ steps.docker-md.outputs.labels }}
           build-args: |
             DEADLOCK=1
-          github-token: ${{ github.token }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=registry,ref=livekit/egress-integration:buildcache
+          cache-to:   type=registry,ref=livekit/egress-integration:buildcache,mode=max,ignore-error=true
 
   test:
     needs: build

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -40,6 +40,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: build/test/fetch-media-samples.sh
+      
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+            ~/.cache
+          key: egress-integration-${{ hashFiles('**/go.sum') }}
+          restore-keys: egress-integration
 
       - name: Docker metadata
         id: docker-md

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -72,9 +72,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          install: true
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./build/test/Dockerfile
           push: true

--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# syntax=docker/dockerfile:1.6
+
 FROM livekit/gstreamer:1.24.12-dev
 
 WORKDIR /workspace
 
 ARG TARGETPLATFORM
+
+# Deadlock 0 = off, 1 = on
+ARG DEADLOCK=0
 
 # install go
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
@@ -25,13 +30,15 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd
     tar -C /usr/local -xzf go1.22.1.linux-${GOARCH}.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-# copy media samples
-COPY media-samples /workspace/media-samples
+ENV GOMODCACHE=/go/pkg/mod \
+    GOCACHE=/go/build-cache
 
 # download go modules
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
+    --mount=type=cache,target=/go/build-cache \
+    go mod download
 
 # copy source
 COPY cmd/ cmd/
@@ -44,11 +51,17 @@ COPY --from=livekit/egress-templates workspace/build/ cmd/server/templates/
 COPY --from=livekit/egress-templates workspace/build/ test/templates/
 
 # build (service tests will need to launch the handler)
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on GODEBUG=disablethp=1 go build -a -o egress ./cmd/server
+RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
+    --mount=type=cache,target=/go/build-cache \
+    if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
+    TAGS=""; \
+    if [ "${DEADLOCK:-0}" = "1" ]; then TAGS="deadlock"; fi; \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GODEBUG=disablethp=1 go build ${TAGS:+-tags} ${TAGS:+"$TAGS"} -o egress ./cmd/server
 
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go test -c -v -race --tags=integration ./test
+RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
+    --mount=type=cache,target=/go/build-cache \
+    if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} go test -c -v -race --tags=integration ./test
 
 
 FROM livekit/gstreamer:1.24.12-prod
@@ -71,10 +84,7 @@ RUN apt-get update && \
         gstreamer1.0-plugins-base-
 
 # install go
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
-    wget https://go.dev/dl/go1.22.1.linux-${GOARCH}.tar.gz && \
-    rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go1.22.1.linux-${GOARCH}.tar.gz
+COPY --from=0 /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # install chrome
@@ -104,7 +114,7 @@ RUN pip install --break-system-packages --no-cache-dir -r /agents/requirements.t
 COPY test/ /workspace/test/
 COPY --from=0 /workspace/egress /bin/
 COPY --from=0 /workspace/test.test .
-COPY --from=0 /workspace/media-samples /media-samples
+COPY media-samples /media-samples
 COPY --from=0 /workspace/test/agents /agents
 COPY build/test/entrypoint.sh .
 

--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -88,7 +88,7 @@ RUN apt-get update && \
         gstreamer1.0-plugins-base-
 
 # install go
-COPY --from=0 /usr/local/go /usr/local/go
+COPY --from=1 /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # install chrome

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/googleapis/gax-go/v2 v2.14.2
 	github.com/gorilla/websocket v1.5.3
+	github.com/linkdata/deadlock v0.5.5
 	github.com/livekit/livekit-server v1.8.4
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/media-sdk v0.0.0-20250518151703-b07af88637c5
@@ -120,6 +121,7 @@ require (
 	github.com/nats-io/nkeys v0.4.11 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ory/dockertest/v3 v3.12.0 // indirect
+	github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe // indirect
 	github.com/pion/datachannel v1.5.10 // indirect
 	github.com/pion/dtls/v3 v3.0.7 // indirect
 	github.com/pion/ice/v4 v4.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kULo2bwGEkFvCePZ3qHDDTC3/J9Swo=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
+github.com/linkdata/deadlock v0.5.5 h1:d6O+rzEqasSfamGDA8u7bjtaq7hOX8Ha4Zn36Wxrkvo=
+github.com/linkdata/deadlock v0.5.5/go.mod h1:tXb28stzAD3trzEEK0UJWC+rZKuobCoPktPYzebb1u0=
 github.com/lithammer/shortuuid/v4 v4.2.0 h1:LMFOzVB3996a7b8aBuEXxqOBflbfPQAiVzkIcHO0h8c=
 github.com/lithammer/shortuuid/v4 v4.2.0/go.mod h1:D5noHZ2oFw/YaKCfGy0YxyE7M0wMbezmMjPdhyEFe6Y=
 github.com/livekit/gst-go v0.0.0-20250701011214-e7f61abd14cb h1:1Vjk6NaXJZQiCvXGlKv38ossk4mNKHy5ob+eZygewdw=
@@ -292,6 +294,8 @@ github.com/ory/dockertest/v3 v3.12.0 h1:3oV9d0sDzlSQfHtIaB5k6ghUCVMVLpAY8hwrqoCy
 github.com/ory/dockertest/v3 v3.12.0/go.mod h1:aKNDTva3cp8dwOWwb9cWuX84aH5akkxXRvO7KCwWVjE=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
+github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe h1:vHpqOnPlnkba8iSxU4j/CvDSS9J4+F4473esQsYLGoE=
+github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
 github.com/pion/datachannel v1.5.10 h1:ly0Q26K1i6ZkGf42W7D4hQYR90pZwzFOjTq5AuCKk4o=
 github.com/pion/datachannel v1.5.10/go.mod h1:p/jJfC9arb29W7WrxyKbepTU20CFgyx5oLo8Rs4Py/M=
 github.com/pion/dtls/v3 v3.0.7 h1:bItXtTYYhZwkPFk4t1n3Kkf5TDrfj6+4wG+CZR8uI9Q=

--- a/magefile.go
+++ b/magefile.go
@@ -110,7 +110,7 @@ func Integration(configFile string) error {
 	defer os.Unsetenv("DOCKER_BUILDKIT")
 
 	if err := mageutil.Run(ctx,
-		`docker build --build-arg TEMPLATE_TAG=%s --build-arg DEADLOCK=1 -t egress-test -f build/test/Dockerfile .`,
+		fmt.Sprintf("docker build --build-arg TEMPLATE_TAG=%s --build-arg DEADLOCK=1 -t egress-test -f build/test/Dockerfile .", version.TemplateVersion),
 	); err != nil {
 		return err
 	}

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -17,8 +17,9 @@ package config
 import (
 	"bytes"
 	"encoding/json"
-	"sync"
 	"time"
+
+	"github.com/linkdata/deadlock"
 )
 
 type Manifest struct {
@@ -35,7 +36,7 @@ type Manifest struct {
 	AudioTrackID      string `json:"audio_track_id,omitempty"`
 	VideoTrackID      string `json:"video_track_id,omitempty"`
 
-	mu        sync.Mutex
+	mu        deadlock.Mutex
 	Files     []*File     `json:"files,omitempty"`
 	Playlists []*Playlist `json:"playlists,omitempty"`
 	Images    []*Image    `json:"images,omitempty"`
@@ -47,7 +48,7 @@ type File struct {
 }
 
 type Playlist struct {
-	mu       sync.Mutex
+	mu       deadlock.Mutex
 	Location string     `json:"location,omitempty"`
 	Segments []*Segment `json:"segments,omitempty"`
 }

--- a/pkg/gstreamer/bin.go
+++ b/pkg/gstreamer/bin.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-gst/go-glib/glib"
 	"github.com/go-gst/go-gst/gst"
+	"github.com/linkdata/deadlock"
 	"go.uber.org/atomic"
 
 	"github.com/livekit/egress/pkg/errors"
@@ -33,7 +34,7 @@ type Bin struct {
 	*StateManager
 
 	pipeline *gst.Pipeline
-	mu       sync.Mutex
+	mu       deadlock.Mutex
 	bin      *gst.Bin
 	latency  time.Duration
 

--- a/pkg/gstreamer/callbacks.go
+++ b/pkg/gstreamer/callbacks.go
@@ -15,14 +15,13 @@
 package gstreamer
 
 import (
-	"sync"
-
+	"github.com/linkdata/deadlock"
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
 )
 
 type Callbacks struct {
-	mu         sync.RWMutex
+	mu         deadlock.RWMutex
 	GstReady   chan struct{}
 	BuildReady chan struct{}
 

--- a/pkg/gstreamer/state.go
+++ b/pkg/gstreamer/state.go
@@ -16,8 +16,8 @@ package gstreamer
 
 import (
 	"fmt"
-	"sync"
 
+	"github.com/linkdata/deadlock"
 	"github.com/livekit/protocol/logger"
 )
 
@@ -33,7 +33,7 @@ const (
 )
 
 type StateManager struct {
-	lock  sync.RWMutex
+	lock  deadlock.RWMutex
 	state State
 }
 

--- a/pkg/info/io.go
+++ b/pkg/info/io.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"hash/fnv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/frostbyte73/core"
+	"github.com/linkdata/deadlock"
 	"go.uber.org/atomic"
 
 	"github.com/livekit/egress/pkg/config"
@@ -60,7 +60,7 @@ type ioClient struct {
 }
 
 type worker struct {
-	mu       sync.Mutex
+	mu       deadlock.Mutex
 	creating map[string]*update
 	updates  map[string]*update
 	queue    chan string

--- a/pkg/logging/s3.go
+++ b/pkg/logging/s3.go
@@ -17,16 +17,16 @@ package logging
 import (
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/aws/smithy-go/logging"
+	"github.com/linkdata/deadlock"
 
 	"github.com/livekit/protocol/logger"
 )
 
 // S3Logger only logs aws messages on upload failure
 type S3Logger struct {
-	mu   sync.Mutex
+	mu   deadlock.Mutex
 	msgs []string
 	idx  int
 }

--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -535,7 +535,7 @@ func (ab *AudioBin) addAudioConvertWithPitch(b *gstreamer.Bin, p *config.Pipelin
 	return b.AddElements(q, ac1, ar1, f32caps, rate, pitch, ac2, s16caps)
 }
 
-// F32 caps used only around `pitch`
+// F32 caps used only around pitch
 func newAudioFloatCapsFilter(p *config.PipelineConfig, channel int) (*gst.Element, error) {
 	var channelCaps string
 	if channel == audioChannelStereo {

--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -16,10 +16,10 @@ package builder
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/go-gst/go-gst/gst"
+	"github.com/linkdata/deadlock"
 	"go.uber.org/atomic"
 
 	"github.com/livekit/egress/pkg/config"
@@ -46,7 +46,7 @@ type AudioBin struct {
 	bin  *gstreamer.Bin
 	conf *config.PipelineConfig
 
-	mu          sync.Mutex
+	mu          deadlock.Mutex
 	nextID      int
 	nextChannel int
 	names       map[string]string

--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -534,7 +534,7 @@ func (ab *AudioBin) addAudioConvertWithPitch(b *gstreamer.Bin, p *config.Pipelin
 	return b.AddElements(rate, q, ac1, ar1, f32caps, pitch, ac2, s16caps)
 }
 
-// F32 caps used only around pitch
+// F32 caps used only around `pitch`
 func newAudioFloatCapsFilter(p *config.PipelineConfig, channel int) (*gst.Element, error) {
 	var channelCaps string
 	if channel == audioChannelStereo {

--- a/pkg/pipeline/builder/stream.go
+++ b/pkg/pipeline/builder/stream.go
@@ -16,7 +16,6 @@ package builder
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/go-gst/go-gst/gst"
@@ -35,9 +34,7 @@ type StreamBin struct {
 	Bin        *gstreamer.Bin
 	OutputType types.OutputType
 
-	latency  time.Duration
-	mu       sync.RWMutex
-	pipeline *gstreamer.Pipeline
+	latency time.Duration
 }
 
 type Stream struct {

--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -17,10 +17,10 @@ package builder
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-gst/go-gst/gst"
+	"github.com/linkdata/deadlock"
 
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
@@ -38,7 +38,7 @@ type VideoBin struct {
 	bin  *gstreamer.Bin
 	conf *config.PipelineConfig
 
-	mu          sync.Mutex
+	mu          deadlock.Mutex
 	nextID      int
 	selectedPad string
 	lastPTS     uint64

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"sync"
 	"time"
 
 	"github.com/frostbyte73/core"
 	"github.com/go-gst/go-gst/gst"
+	"github.com/linkdata/deadlock"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
@@ -59,7 +59,7 @@ type Controller struct {
 	sinks     map[types.EgressType][]sink.Sink
 
 	// internal
-	mu          sync.Mutex
+	mu          deadlock.Mutex
 	monitor     *stats.HandlerMonitor
 	limitTimer  *time.Timer
 	playing     core.Fuse

--- a/pkg/pipeline/sink/segments.go
+++ b/pkg/pipeline/sink/segments.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"path"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/frostbyte73/core"
+	"github.com/linkdata/deadlock"
 
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
@@ -51,9 +51,9 @@ type SegmentSink struct {
 	playlist     m3u8.PlaylistWriter
 	livePlaylist m3u8.PlaylistWriter
 
-	segmentLock  sync.Mutex
-	infoLock     sync.Mutex
-	playlistLock sync.Mutex
+	segmentLock  deadlock.Mutex
+	infoLock     deadlock.Mutex
+	playlistLock deadlock.Mutex
 
 	initialized           bool
 	startTime             time.Time

--- a/pkg/pipeline/sink/stream.go
+++ b/pkg/pipeline/sink/stream.go
@@ -15,10 +15,10 @@
 package sink
 
 import (
-	"sync"
 	"time"
 
 	"github.com/frostbyte73/core"
+	"github.com/linkdata/deadlock"
 
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
@@ -36,7 +36,7 @@ type StreamSink struct {
 	bin    *builder.StreamBin
 	closed core.Fuse
 
-	mu      sync.RWMutex
+	mu      deadlock.RWMutex
 	streams map[string]*builder.Stream
 	loggers map[string]*logging.CSVLogger[logging.StreamStats]
 }

--- a/pkg/pipeline/sink/websocket.go
+++ b/pkg/pipeline/sink/websocket.go
@@ -19,12 +19,12 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-gst/go-gst/gst"
 	"github.com/go-gst/go-gst/gst/app"
 	"github.com/gorilla/websocket"
+	"github.com/linkdata/deadlock"
 	"go.uber.org/atomic"
 
 	"github.com/livekit/egress/pkg/config"
@@ -41,7 +41,7 @@ const pingPeriod = time.Second * 30
 type WebsocketSink struct {
 	*base
 
-	mu            sync.Mutex
+	mu            deadlock.Mutex
 	conn          *websocket.Conn
 	sinkCallbacks *app.SinkCallbacks
 	closed        atomic.Bool

--- a/pkg/pipeline/source/sdk.go
+++ b/pkg/pipeline/source/sdk.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/frostbyte73/core"
 	"github.com/go-gst/go-gst/gst"
 	"github.com/go-gst/go-gst/gst/app"
+	"github.com/linkdata/deadlock"
 	"github.com/pion/webrtc/v4"
 	"go.uber.org/atomic"
 
@@ -51,13 +51,13 @@ type SDKSource struct {
 	room *lksdk.Room
 	sync *synchronizer.Synchronizer
 
-	mu                   sync.RWMutex
+	mu                   deadlock.RWMutex
 	initialized          core.Fuse
 	filenameReplacements map[string]string
 	subs                 chan *subscriptionResult
 
 	writers map[string]*sdk.AppWriter
-	subLock sync.RWMutex
+	subLock deadlock.RWMutex
 	active  atomic.Int32
 	closed  core.Fuse
 

--- a/pkg/pipeline/tempo/controller.go
+++ b/pkg/pipeline/tempo/controller.go
@@ -1,8 +1,9 @@
 package tempo
 
 import (
-	"sync"
 	"time"
+
+	"github.com/linkdata/deadlock"
 )
 
 const (
@@ -11,7 +12,7 @@ const (
 )
 
 type Controller struct {
-	mu sync.Mutex
+	mu deadlock.Mutex
 
 	pending   time.Duration // accumulated, not yet started
 	current   time.Duration // currently being corrected

--- a/pkg/service/metrics.go
+++ b/pkg/service/metrics.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"net/http"
 	"strings"
-	"sync"
 
+	"github.com/linkdata/deadlock"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
@@ -33,7 +33,7 @@ import (
 type MetricsService struct {
 	pm *ProcessManager
 
-	mu             sync.Mutex
+	mu             deadlock.Mutex
 	pendingMetrics []*dto.MetricFamily
 }
 

--- a/pkg/service/process.go
+++ b/pkg/service/process.go
@@ -19,11 +19,11 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"sync"
 	"syscall"
 	"time"
 
 	"github.com/frostbyte73/core"
+	"github.com/linkdata/deadlock"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
@@ -38,7 +38,7 @@ import (
 const launchTimeout = 10 * time.Second
 
 type ProcessManager struct {
-	mu             sync.RWMutex
+	mu             deadlock.RWMutex
 	activeHandlers map[string]*Process
 }
 

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -17,9 +17,9 @@ package stats
 import (
 	"fmt"
 	"sort"
-	"sync"
 	"time"
 
+	"github.com/linkdata/deadlock"
 	"github.com/pbnjay/memory"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
@@ -63,7 +63,7 @@ type Monitor struct {
 	pendingPulseClients atomic.Int32
 	pendingMemoryUsage  atomic.Float64
 
-	mu              sync.Mutex
+	mu              deadlock.Mutex
 	highCPUDuration int
 	pending         map[string]*processStats
 	procStats       map[int]*processStats


### PR DESCRIPTION
Contains following changes
- use linkdata/deadlock - does the same thing as existing manual logic of adding/removing go-deadlock
- use go mod and go build cache
- optimizing Docker file for tests to avoid frequent cache busting
- using docker registry for build cache for CI

Major improvements are with incremental builds where the speed up is 10x (from 240s to 25s).