### PR TITLE
Enable sync OnRTCP callback in any case

### DIFF
--- a/pkg/pipeline/source/sdk.go
+++ b/pkg/pipeline/source/sdk.go
@@ -93,7 +93,7 @@ func NewSDKSource(ctx context.Context, p *config.PipelineConfig, callbacks *gstr
 		// to avoid gaps in the audio stream
 		opts = append(opts, synchronizer.WithAudioPTSAdjustmentDisabled())
 		if p.AudioTempoController.Enabled {
-			logger.Debugw("audio tempo controller enabled", "adjustment rate", p.AudioTempoController.AdjustmentRate)
+			logger.Debugw("audio tempo controller enabled", "adjustmentRate", p.AudioTempoController.AdjustmentRate)
 		}
 	}
 

--- a/pkg/pipeline/source/sdk.go
+++ b/pkg/pipeline/source/sdk.go
@@ -88,11 +88,13 @@ func NewSDKSource(ctx context.Context, p *config.PipelineConfig, callbacks *gstr
 			s.startRecording.Break()
 		}),
 	}
-	if p.AudioTempoController.Enabled {
-		// perform signal time comression/steatching instead of timestamp manipulation
-		// on RTCP sender reports
-		logger.Debugw("audio tempo controller enabled", "adjustment rate", p.AudioTempoController.AdjustmentRate)
+	if p.RequestType == types.RequestTypeRoomComposite || p.AudioTempoController.Enabled {
+		// in case of room composite don't adjust audio timestamps on RTCP sender reports,
+		// to avoid gaps in the audio stream
 		opts = append(opts, synchronizer.WithAudioPTSAdjustmentDisabled())
+		if p.AudioTempoController.Enabled {
+			logger.Debugw("audio tempo controller enabled", "adjustment rate", p.AudioTempoController.AdjustmentRate)
+		}
 	}
 
 	s.sync = synchronizer.NewSynchronizerWithOptions(
@@ -425,10 +427,7 @@ func (s *SDKSource) subscribe(track lksdk.TrackPublication) error {
 
 		logger.Infow("subscribing to track", "trackID", track.SID())
 
-		if s.PipelineConfig.RequestType != types.RequestTypeRoomComposite ||
-			s.PipelineConfig.AudioTempoController.Enabled {
-			pub.OnRTCP(s.sync.OnRTCP)
-		}
+		pub.OnRTCP(s.sync.OnRTCP)
 
 		return pub.SetSubscribed(true)
 	}


### PR DESCRIPTION
Room composites and cases where audio tempo controller is enabled are handled WithAudioPTSAdjustmentDisabled sync option which effectively disables PTS adjustments but has a nice effect of the callback still being invoked, offset being calculated and logged.