### PR TITLE
Skip dummy video packets

### DIFF
--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -222,6 +222,10 @@ func (w *AppWriter) readNext() {
 		w.handleReadError(err)
 		return
 	}
+	// skip dummy packets
+	if len(pkt.Payload) == 0 {
+		return
+	}
 
 	// initialize on first packet
 	if w.lastReceived.Load().IsZero() {


### PR DESCRIPTION
They could cause PTS jump if used for track initialization as their ts doesn't increase. The first ts of the real video packet causes re-adjustment and declares itself as being close to 0 which essentially causes audio  to be delayed.

Suggested by @boks1971 