### PR TITLE
Extend max allowed RTP timestamps diff

### DIFF
--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -46,7 +46,7 @@ const (
 	defaultJitterBufferLatency = time.Second * 2
 	defaultAudioMixerLatency   = time.Millisecond * 2750
 	defaultPipelineLatency     = time.Second * 3
-	defaultRTPMaxAllowedTsDiff = time.Second
+	defaultRTPMaxAllowedTsDiff = time.Second * 5
 
 	defaultAudioTempoControllerAdjustmentRate = 0.05
 


### PR DESCRIPTION
I was initially sceptical of increasing this but  it's still safe to do it.
In addition to this IMO we should be dropping packets falling out if this window instead of rebasing them on the estimated time. We can think about that togeher with other sync based changes (as there are quite some edge cases to be tackled)
Audio mixer operates on the pipeline clock (using egress instance system clock). Even if one track marches forward compared to others (e.g bursty arrival) - it won't push audio mixer timeline, it's pad is going to buffer some data and wait on the right moment. In a meantime back preassure will start mounting for that branch but that's still fine - in the worst case scenario we start dropping packets in jitter buffer. If a track lags behind increasing the ts diff won't help but also won't hurt.