### PR TITLE
Put back blocking queue in front of the mixer

### DIFF
--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -286,7 +286,7 @@ func (b *AudioBin) addAudioAppSrcBin(ts *config.TrackSource) error {
 		addAudioConvertFunc = b.addAudioConvertWithPitch
 	}
 
-	if err := addAudioConvertFunc(appSrcBin, b.conf, b.getChannel(ts), leakyQueue); err != nil {
+	if err := addAudioConvertFunc(appSrcBin, b.conf, b.getChannel(ts), blockingQueue); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Comment I made here wasn't correct:
https://github.com/livekit/egress/pull/1016#issuecomment-3347069662

Appologies for confusion - I kept thinking about this and added a sample to test it:
https://github.com/livekit/gst-scaletempo-demo/blob/main/cmd/blocking-queue-demo/queue_demo.go

If PTS pushed from the queue to the mixer are behind the mixer latency they will be discared immediatelly (not at real-time) - which means there is no point in having leaky queues at that stage.