### PR TITLE
VP9 - Drop a frame with an invalid PTS and wait for key frame 

### DIFF
--- a/pkg/pipeline/builder/vp9_probe.go
+++ b/pkg/pipeline/builder/vp9_probe.go
@@ -104,7 +104,6 @@ func (p *vp9ParseProbe) onSrcBuffer(_ *gst.Pad, info *gst.PadProbeInfo) gst.PadP
 
 	p.handleValidPTS(buffer, pts)
 	if p.keyframePending.Load() {
-		p.logger.Debugw("keyframe pending, rejecting buffer")
 		return gst.PadProbeDrop
 	}
 	return gst.PadProbeOK


### PR DESCRIPTION
Another attempt to fix the corrupted stream issue after vp9parse produces an invalid PTS. The suggested solution will drop the invalid buffer and all subsequent buffers until the next key frame is received.
Tested it by simulating an invalid packet on src pad probe periodically.
If the stream got corrupted due to the state corruption inside the muxer this has a fair chance to fix it (at the expense of missing signal until the next frame)