### PR TITLE
Adding a workaround for baseparse gstreamer bugs which could produce buffer with no valid PTS

### DIFF
--- a/pkg/pipeline/builder/pts_fixer.go
+++ b/pkg/pipeline/builder/pts_fixer.go
@@ -41,13 +41,6 @@ func newPTSFixer(elementName, context string) (*ptsFixer, error) {
 	return fixer, nil
 }
 
-func (f *ptsFixer) GetElement() *gst.Element {
-	if f == nil {
-		return nil
-	}
-	return f.Element
-}
-
 func (f *ptsFixer) onBuffer(_ *gst.Pad, info *gst.PadProbeInfo) gst.PadProbeReturn {
 	buf := info.GetBuffer()
 	if buf == nil {

--- a/pkg/pipeline/builder/segment.go
+++ b/pkg/pipeline/builder/segment.go
@@ -45,7 +45,7 @@ func BuildSegmentBin(pipeline *gstreamer.Pipeline, p *config.PipelineConfig) (*g
 			return nil, err
 		}
 
-		if err = b.AddElements(h264ParseFixer.GetElement()); err != nil {
+		if err = b.AddElements(h264ParseFixer.Element); err != nil {
 			return nil, errors.ErrGstPipelineError(err)
 		}
 	}
@@ -109,7 +109,7 @@ func BuildSegmentBin(pipeline *gstreamer.Pipeline, p *config.PipelineConfig) (*g
 		if name == audioBinName {
 			return sink.GetRequestPad("audio_%u")
 		} else if h264ParseFixer != nil {
-			return h264ParseFixer.GetElement().GetStaticPad("sink")
+			return h264ParseFixer.Element.GetStaticPad("sink")
 		}
 		// Should never happen
 		return nil

--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -345,7 +345,7 @@ func (b *VideoBin) buildAppSrcBin(ts *config.TrackSource, name string) (*gstream
 				return nil, err
 			}
 
-			if err = appSrcBin.AddElement(h264ParseFixer.GetElement()); err != nil {
+			if err = appSrcBin.AddElement(h264ParseFixer.Element); err != nil {
 				return nil, err
 			}
 
@@ -409,7 +409,7 @@ func (b *VideoBin) buildAppSrcBin(ts *config.TrackSource, name string) (*gstream
 			if err != nil {
 				return nil, err
 			}
-			vp9Parse := vp9ParseFixer.GetElement()
+			vp9Parse := vp9ParseFixer.Element
 
 			vp9Caps, err := gst.NewElement("capsfilter")
 			if err != nil {


### PR DESCRIPTION
Gstreamer baseparse has bugs causing it to sometimes produce a buffer without a valid PTS. That could cause problems in downstream elements (e.g muxer) leading to stream corruption or stopping.
Suggested workaround is adding a tiny wrapper around parse elements which auto installs probe which observes PTS sequence and in case of missing PTS, uses the latest seen PTS.

The existing VP9 workaround is replaced by this - hopefully more general approach, but its code is kept until we confirm that the change fixes the problem.
