### PR TITLE
Fix filename templating in case of multi output

### DIFF
--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -592,13 +592,14 @@ func (p *PipelineConfig) getRoomCompositeRequestType(req *livekit.RoomCompositeE
 
 // used for sdk input source
 func (p *PipelineConfig) UpdateInfoFromSDK(identifier string, replacements map[string]string, w, h uint32) error {
+	var err error
 	for egressType, c := range p.Outputs {
 		if len(c) == 0 {
 			continue
 		}
 		switch egressType {
 		case types.EgressTypeFile:
-			return c[0].(*FileConfig).updateFilepath(p, identifier, replacements)
+			err = c[0].(*FileConfig).updateFilepath(p, identifier, replacements)
 
 		case types.EgressTypeSegments:
 			o := c[0].(*SegmentConfig)
@@ -635,7 +636,7 @@ func (p *PipelineConfig) UpdateInfoFromSDK(identifier string, replacements map[s
 		}
 	}
 
-	return nil
+	return err
 }
 
 func (p *PipelineConfig) GetEncodedOutputs() []OutputConfig {

--- a/test/multi.go
+++ b/test/multi.go
@@ -79,10 +79,14 @@ func (r *Runner) testMulti(t *testing.T) {
 					videoDelay:     time.Second * 5,
 				},
 				fileOptions: &fileOptions{
-					filename: "participant_multiple_{time}",
+					filename: "participant_{publisher_identity}_multi_{time}.mp4",
 				},
 				streamOptions: &streamOptions{
 					outputType: types.OutputTypeRTMP,
+				},
+				segmentOptions: &segmentOptions{
+					prefix:   "participant_{publisher_identity}_multi_{time}",
+					playlist: "participant_{publisher_identity}_multi_{time}.m3u8",
 				},
 				multi: true,
 			},
@@ -144,6 +148,17 @@ func (r *Runner) runMultiTest(t *testing.T, test *testCase) {
 		r.verifyFile(t, test, p, res)
 	}
 	if test.segmentOptions != nil {
+		require.Len(t, res.GetSegmentResults(), 1)
+		segments := res.GetSegmentResults()[0]
+		require.Greater(t, segments.Size, int64(0))
+		require.NotContains(t, segments.PlaylistName, "{")
+		require.NotContains(t, segments.PlaylistLocation, "{")
+		if segments.LivePlaylistName != "" {
+			require.NotContains(t, segments.LivePlaylistName, "{")
+		}
+		if segments.LivePlaylistLocation != "" {
+			require.NotContains(t, segments.LivePlaylistLocation, "{")
+		}
 		r.verifySegments(t, test, p, test.segmentOptions.suffix, res, false)
 	}
 	if test.imageOptions != nil {


### PR DESCRIPTION
Due to a premature return if muliple outputs are specified, for all outputs after the one for file, filename templates aren't replaced.

The change fixes it by alowing processing all outputs before returning. Fix for:
https://github.com/livekit/egress/issues/956