### PR TITLE
Ensure pipeline is at least in PAUSED state before pushing data to app sources

### DIFF
--- a/pkg/gstreamer/callbacks.go
+++ b/pkg/gstreamer/callbacks.go
@@ -15,6 +15,7 @@
 package gstreamer
 
 import (
+	"github.com/frostbyte73/core"
 	"github.com/linkdata/deadlock"
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
@@ -36,6 +37,8 @@ type Callbacks struct {
 	onTrackUnmuted []func(string)
 	onTrackRemoved []func(string)
 	onEOSSent      func()
+
+	pipelinePaused core.Fuse
 }
 
 func (c *Callbacks) SetOnError(f func(error)) {
@@ -68,6 +71,14 @@ func (c *Callbacks) OnDebugDotRequest(reason string) {
 	if onDebugDotRequest != nil {
 		onDebugDotRequest(reason)
 	}
+}
+
+func (c *Callbacks) PipelinePaused() <-chan struct{} {
+	return c.pipelinePaused.Watch()
+}
+
+func (c *Callbacks) OnPipelinePaused() {
+	c.pipelinePaused.Break()
 }
 
 func (c *Callbacks) AddOnStop(f func() error) {

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -62,6 +62,7 @@ type Controller struct {
 	mu          deadlock.Mutex
 	monitor     *stats.HandlerMonitor
 	limitTimer  *time.Timer
+	paused      core.Fuse
 	playing     core.Fuse
 	eosSent     core.Fuse
 	eosTimer    *time.Timer

--- a/pkg/pipeline/watch.go
+++ b/pkg/pipeline/watch.go
@@ -237,20 +237,31 @@ func (c *Controller) handleMessageError(gErr *gst.GError) error {
 
 func (c *Controller) handleMessageStateChanged(msg *gst.Message) {
 	_, newState := msg.ParseStateChanged()
+	s := msg.Source()
+	if s == pipelineName {
+		if newState == gst.StatePaused {
+			c.paused.Once(func() {
+				logger.Infow("pipeline paused")
+				c.callbacks.OnPipelinePaused()
+			})
+		}
+		if newState == gst.StatePlaying {
+			c.playing.Once(func() {
+				logger.Infow("pipeline playing")
+				c.updateStartTime(c.src.GetStartedAt())
+			})
+		}
+		return
+	}
+
 	if newState != gst.StatePlaying {
 		return
 	}
 
-	s := msg.Source()
-	if s == pipelineName {
-		c.playing.Once(func() {
-			logger.Infow("pipeline playing")
-			c.updateStartTime(c.src.GetStartedAt())
-		})
-	} else if strings.HasPrefix(s, "app_") {
-		s = s[4:]
-		logger.Infow(fmt.Sprintf("%s playing", s))
-		c.src.(*source.SDKSource).Playing(s)
+	if strings.HasPrefix(s, "app_") {
+		trackID := s[4:]
+		logger.Infow(fmt.Sprintf("%s playing", trackID))
+		c.src.(*source.SDKSource).Playing(trackID)
 	}
 }
 


### PR DESCRIPTION
In very rare occasions it could happen that app sources start pushing packets before all pads are activated which causes the appsrc pad task to switch to paused state - preventing any future flow, effectively dropping all packets for the affected track. The issue might be due to pipeline not reaching at least PAUSED state before sources are in PLAYING state. The main goal of this change is to ensure app writers are waiting until the gst pipeline is in PAUSED state.
Pipeline graph taken at the moment the problem occurred:
<img width="10169" height="904" alt="flush" src="https://github.com/user-attachments/assets/abe293c1-c571-45d3-b5dd-4d5b6ca4b2ff" />
(note `[t]` on the src pad for one of the sources - indicated the task that pushes data is paused) 