### PR TITLE
Drain audio tracks before removing their appsource

### DIFF
--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -624,6 +624,10 @@ func (w *AppWriter) shouldHandleDiscontinuity() bool {
 	return w.track.Kind() == webrtc.RTPCodecTypeAudio && w.conf.AudioTempoController.Enabled
 }
 
+func (w *AppWriter) TrackKind() webrtc.RTPCodecType {
+	return w.track.Kind()
+}
+
 func isDiscontinuity(lastPTS time.Duration, pts time.Duration) bool {
 	return pts > lastPTS+discontinuityTolerance
 }


### PR DESCRIPTION
Adjusting the fix introduced in #1008  to be more targeted (to video tracks). For audio tracks keep draining before removal to prevent some final audio bits from being discarded.