### PR TITLE
Fix for data race inside monitor

### DIFF
--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -94,6 +94,8 @@ func NewMonitor(conf *config.ServiceConfig, svc Service) (*Monitor, error) {
 		procStats:     make(map[int]*processStats),
 	}
 
+	m.initPrometheus()
+
 	procStats, err := hwstats.NewProcMonitor(m.updateEgressStats)
 	if err != nil {
 		return nil, err
@@ -103,8 +105,6 @@ func NewMonitor(conf *config.ServiceConfig, svc Service) (*Monitor, error) {
 	if err = m.validateCPUConfig(); err != nil {
 		return nil, err
 	}
-
-	m.initPrometheus()
 
 	return m, nil
 }


### PR DESCRIPTION
Reordered monitor initialization to set up prom metrics before starting the hwstats process monitor, so the callback can’t hit m.promCPULoad while it’s still being created

```
==================
WARNING: DATA RACE
Read at 0x00c0004e8168 by goroutine 68:
github.com/livekit/egress/pkg/stats.(*Monitor).updateEgressStats()
/workspace/pkg/stats/monitor.go:436 +0xa4
github.com/livekit/egress/pkg/stats.(*Monitor).updateEgressStats-fm()
<autogenerated>:1 +0x3c
github.com/livekit/protocol/utils/hwstats.(*CPUStats).monitorProcesses()
/go/pkg/mod/github.com/livekit/protocol@v1.43.3-0.20251202235353-eec8df247cf9/utils/hwstats/cpu.go:231 +0x684
github.com/livekit/protocol/utils/hwstats.NewProcMonitor.gowrap1()
/go/pkg/mod/github.com/livekit/protocol@v1.43.3-0.20251202235353-eec8df247cf9/utils/hwstats/cpu.go:83 +0x34

Previous write at 0x00c0004e8168 by goroutine 24:
github.com/livekit/egress/pkg/stats.(*Monitor).initPrometheus()
/workspace/pkg/stats/monitor_prom.go:53 +0xa7c
github.com/livekit/egress/pkg/stats.NewMonitor()
/workspace/pkg/stats/monitor.go:107 +0x344
github.com/livekit/egress/pkg/server.NewServer()
/workspace/pkg/server/server.go:81 +0x36c
github.com/livekit/egress/test.TestEgress()
/workspace/test/integration_test.go:51 +0x17c
testing.tRunner()
/usr/local/go/src/testing/testing.go:1792 +0x180
testing.(*T).Run.gowrap1()
/usr/local/go/src/testing/testing.go:1851 +0x40

Goroutine 68 (running) created at:
github.com/livekit/protocol/utils/hwstats.NewProcMonitor()
/go/pkg/mod/github.com/livekit/protocol@v1.43.3-0.20251202235353-eec8df247cf9/utils/hwstats/cpu.go:83 +0x2b8
github.com/livekit/egress/pkg/stats.NewMonitor()
/workspace/pkg/stats/monitor.go:97 +0x2c8
github.com/livekit/egress/pkg/server.NewServer()
/workspace/pkg/server/server.go:81 +0x36c
github.com/livekit/egress/test.TestEgress()
/workspace/test/integration_test.go:51 +0x17c
testing.tRunner()
/usr/local/go/src/testing/testing.go:1792 +0x180
testing.(*T).Run.gowrap1()
/usr/local/go/src/testing/testing.go:1851 +0x40

Goroutine 24 (running) created at:
testing.(*T).Run()
/usr/local/go/src/testing/testing.go:1851 +0x684
testing.runTests.func1()
/usr/local/go/src/testing/testing.go:2279 +0x7c
testing.tRunner()
/usr/local/go/src/testing/testing.go:1792 +0x180
testing.runTests()
/usr/local/go/src/testing/testing.go:2277 +0x77c
testing.(*M).Run()
/usr/local/go/src/testing/testing.go:2142 +0xb68
main.main()
_testmain.go:45 +0x110
==================
WARNING: DATA RACE
Write at 0x00c000781f40 by goroutine 68:
??()
-:0 +0x29ea16c
sync/atomic.StoreUint64()
<autogenerated>:1 +0x14
github.com/livekit/egress/pkg/stats.(*Monitor).updateEgressStats()
/workspace/pkg/stats/monitor.go:436 +0xd0
github.com/livekit/egress/pkg/stats.(*Monitor).updateEgressStats-fm()
<autogenerated>:1 +0x3c
github.com/livekit/protocol/utils/hwstats.(*CPUStats).monitorProcesses()
/go/pkg/mod/github.com/livekit/protocol@v1.43.3-0.20251202235353-eec8df247cf9/utils/hwstats/cpu.go:231 +0x684
github.com/livekit/protocol/utils/hwstats.NewProcMonitor.gowrap1()
/go/pkg/mod/github.com/livekit/protocol@v1.43.3-0.20251202235353-eec8df247cf9/utils/hwstats/cpu.go:83 +0x34

Previous write at 0x00c000781f40 by goroutine 24:
github.com/prometheus/client_golang/prometheus.NewGauge()
/go/pkg/mod/github.com/prometheus/client_golang@v1.22.0/prometheus/gauge.go:85 +0xd8
github.com/livekit/egress/pkg/stats.(*Monitor).initPrometheus()
/workspace/pkg/stats/monitor_prom.go:53 +0xa6c
github.com/livekit/egress/pkg/stats.NewMonitor()
/workspace/pkg/stats/monitor.go:107 +0x344
github.com/livekit/egress/pkg/server.NewServer()
/workspace/pkg/server/server.go:81 +0x36c
github.com/livekit/egress/test.TestEgress()
/workspace/test/integration_test.go:51 +0x17c
testing.tRunner()
/usr/local/go/src/testing/testing.go:1792 +0x180
testing.(*T).Run.gowrap1()
/usr/local/go/src/testing/testing.go:1851 +0x40

Goroutine 68 (running) created at:
github.com/livekit/protocol/utils/hwstats.NewProcMonitor()
/go/pkg/mod/github.com/livekit/protocol@v1.43.3-0.20251202235353-eec8df247cf9/utils/hwstats/cpu.go:83 +0x2b8
github.com/livekit/egress/pkg/stats.NewMonitor()
/workspace/pkg/stats/monitor.go:97 +0x2c8
github.com/livekit/egress/pkg/server.NewServer()
/workspace/pkg/server/server.go:81 +0x36c
github.com/livekit/egress/test.TestEgress()
/workspace/test/integration_test.go:51 +0x17c
testing.tRunner()
/usr/local/go/src/testing/testing.go:1792 +0x180
testing.(*T).Run.gowrap1()
/usr/local/go/src/testing/testing.go:1851 +0x40

Goroutine 24 (running) created at:
testing.(*T).Run()
/usr/local/go/src/testing/testing.go:1851 +0x684
testing.runTests.func1()
/usr/local/go/src/testing/testing.go:2279 +0x7c
testing.tRunner()
/usr/local/go/src/testing/testing.go:1792 +0x180
testing.runTests()
/usr/local/go/src/testing/testing.go:2277 +0x77c
testing.(*M).Run()
/usr/local/go/src/testing/testing.go:2142 +0xb68
main.main()
_testmain.go:45 +0x110
```