### PR TITLE
Change the log level for the "PTS in the past..." message

### DIFF
--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -550,7 +550,7 @@ func (w *AppWriter) maybeCheckPipelineLag(pts time.Duration) {
 	}
 
 	if pts < pipelineTime-w.conf.Latency.AudioMixerLatency {
-		w.logger.Errorw(
+		w.logger.Warnw(
 			"packet PTS too far in the past compared to the pipeline, mixer will drop the buffer!",
 			nil,
 			"pts", pts,


### PR DESCRIPTION
This is something not fully controlable on egress side, egress has a few mechanisms to cope with lagging streams. Error level for this log is being too noisy, changing it to warn.