### PR TITLE
Fix for x264 encoder errors causing egress failures at the end of the recording

### DIFF
--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -347,7 +347,7 @@ func (w *AppWriter) handleReadError(err error) {
 		if !errors.Is(err, io.EOF) {
 			w.logger.Errorw("could not read packet", err)
 		} else {
-			w.logger.Debugw("read EOF, signalling end of stream")
+			w.logger.Debugw("read EOF, signaling end of stream")
 		}
 		w.draining.Break()
 		w.endStreamSignaled.Break()


### PR DESCRIPTION
The original fix for the issue was to make sure video track is removed (and input selector switched to to the testsrc for video track) before appwriter sends EOS. However there is an escape path in case of read errors (handleReadError) - it will cause the EOS to get to the selector while the video track is still connected to it - later on, on onTrackUnsubscribed/onTrackFinished selector input will be switched but by that time it's already too late as the encoder has seen EOS and will complain the same way when test source starts pushing data which will cause egress to be marked as failed just at the end. The fix is to make sure the src is removed before drain for this case as well.