### PR TITLE
Log file upload stats (size, duration)

### DIFF
--- a/pkg/pipeline/sink/file.go
+++ b/pkg/pipeline/sink/file.go
@@ -90,7 +90,7 @@ func (s *FileSink) Close() error {
 
 	s.FileInfo.Location = location
 	s.FileInfo.Size = size
-	logger.Infow("file upload completed",
+	logger.Debugw("file upload completed",
 		"bytes", size,
 		"duration", time.Since(start))
 


### PR DESCRIPTION
In some edge cases file upload operation could take a while - adding more logging to be able to isolate these and check upload bitrate.