### PR TITLE
Don’t count room composite SDK source against Pulse limits

### DIFF
--- a/pkg/server/server_rpc.go
+++ b/pkg/server/server_rpc.go
@@ -55,7 +55,7 @@ func (s *Server) StartEgress(ctx context.Context, req *rpc.StartEgressRequest) (
 		s.activeRequests.Dec()
 		return nil, errors.ErrEgressAlreadyExists
 	}
-	if err := s.monitor.AcceptRequest(req); err != nil {
+	if err := s.monitor.AcceptRequest(req, s.conf.EnableRoomCompositeSDKSource); err != nil {
 		s.activeRequests.Dec()
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (s *Server) processEnded(req *rpc.StartEgressRequest, info *livekit.EgressI
 }
 
 func (s *Server) StartEgressAffinity(_ context.Context, req *rpc.StartEgressRequest) float32 {
-	if s.IsDisabled() || !s.monitor.CanAcceptRequest(req) {
+	if s.IsDisabled() || !s.monitor.CanAcceptRequest(req, s.conf.EnableRoomCompositeSDKSource) {
 		// cannot accept
 		return -1
 	}

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -78,10 +78,11 @@ type processStats struct {
 	lastCPU    float64
 	allowedCPU float64
 
-	totalCPU   float64
-	cpuCounter int
-	maxCPU     float64
-	maxMemory  int
+	totalCPU     float64
+	cpuCounter   int
+	maxCPU       float64
+	maxMemory    int
+	countedAsWeb bool
 }
 
 func NewMonitor(conf *config.ServiceConfig, svc Service) (*Monitor, error) {
@@ -148,9 +149,9 @@ func (m *Monitor) validateCPUConfig() error {
 	return nil
 }
 
-func (m *Monitor) CanAcceptRequest(req *rpc.StartEgressRequest) bool {
+func (m *Monitor) CanAcceptRequest(req *rpc.StartEgressRequest, sdkRoomCompositeEnabled bool) bool {
 	m.mu.Lock()
-	fields, canAccept := m.canAcceptRequestLocked(req)
+	fields, canAccept := m.canAcceptRequestLocked(req, sdkRoomCompositeEnabled)
 	m.mu.Unlock()
 
 	logger.Debugw("cpu check", fields...)
@@ -164,7 +165,7 @@ func (m *Monitor) CanAcceptWebRequest() bool {
 	return m.canAcceptWebLocked()
 }
 
-func (m *Monitor) canAcceptRequestLocked(req *rpc.StartEgressRequest) ([]interface{}, bool) {
+func (m *Monitor) canAcceptRequestLocked(req *rpc.StartEgressRequest, sdkRoomCompositeEnabled bool) ([]interface{}, bool) {
 	total, available, pending, used := m.getCPUUsageLocked()
 	fields := []interface{}{
 		"total", total,
@@ -186,7 +187,8 @@ func (m *Monitor) canAcceptRequestLocked(req *rpc.StartEgressRequest) ([]interfa
 	required := req.EstimatedCpu
 	switch r := req.Request.(type) {
 	case *rpc.StartEgressRequest_RoomComposite:
-		if !m.canAcceptWebLocked() {
+		useSDK := config.RoomCompositeUsesSDKSource(r.RoomComposite, sdkRoomCompositeEnabled)
+		if !useSDK && !m.canAcceptWebLocked() {
 			fields = append(fields, "canAccept", false, "reason", "pulse clients")
 			return fields, false
 		}
@@ -243,14 +245,14 @@ func (m *Monitor) canAcceptWebLocked() bool {
 	return clients+int(m.pendingPulseClients.Load())+pulseClientHold <= m.cpuCostConfig.MaxPulseClients
 }
 
-func (m *Monitor) AcceptRequest(req *rpc.StartEgressRequest) error {
+func (m *Monitor) AcceptRequest(req *rpc.StartEgressRequest, sdkRoomCompositeEnabled bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if m.pending[req.EgressId] != nil {
 		return errors.ErrEgressAlreadyExists
 	}
-	if _, ok := m.canAcceptRequestLocked(req); !ok {
+	if _, ok := m.canAcceptRequestLocked(req, sdkRoomCompositeEnabled); !ok {
 		logger.Warnw("can not accept request", nil)
 		return errors.ErrNotEnoughCPU
 	}
@@ -258,18 +260,25 @@ func (m *Monitor) AcceptRequest(req *rpc.StartEgressRequest) error {
 	m.requests.Inc()
 	var cpuHold float64
 	var pulseClients int32
+	var countedAsWeb bool
+
 	switch r := req.Request.(type) {
 	case *rpc.StartEgressRequest_RoomComposite:
-		m.webRequests.Inc()
-		pulseClients = pulseClientHold
+		useSDK := config.RoomCompositeUsesSDKSource(r.RoomComposite, sdkRoomCompositeEnabled)
+		if !useSDK {
+			m.webRequests.Inc()
+			countedAsWeb = true
+			pulseClients = pulseClientHold
+		}
 		if r.RoomComposite.AudioOnly {
 			cpuHold = m.cpuCostConfig.AudioRoomCompositeCpuCost
 		} else {
 			cpuHold = m.cpuCostConfig.RoomCompositeCpuCost
 		}
 	case *rpc.StartEgressRequest_Web:
-		m.webRequests.Inc()
 		pulseClients = pulseClientHold
+		m.webRequests.Inc()
+		countedAsWeb = true
 		if r.Web.AudioOnly {
 			cpuHold = m.cpuCostConfig.AudioWebCpuCost
 		} else {
@@ -284,9 +293,10 @@ func (m *Monitor) AcceptRequest(req *rpc.StartEgressRequest) error {
 	}
 
 	ps := &processStats{
-		egressID:   req.EgressId,
-		pendingCPU: cpuHold,
-		allowedCPU: cpuHold,
+		egressID:     req.EgressId,
+		pendingCPU:   cpuHold,
+		allowedCPU:   cpuHold,
+		countedAsWeb: countedAsWeb,
 	}
 
 	m.pendingMemoryUsage.Add(m.cpuCostConfig.MemoryCost)
@@ -321,6 +331,7 @@ func (m *Monitor) UpdatePID(egressID string, pid int) {
 		ps.maxCPU = existing.maxCPU
 		ps.totalCPU = existing.totalCPU
 		ps.cpuCounter = existing.cpuCounter
+		ps.countedAsWeb = existing.countedAsWeb
 	}
 	m.procStats[pid] = ps
 }
@@ -344,11 +355,14 @@ func (m *Monitor) EgressAborted(req *rpc.StartEgressRequest) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	ps := m.pending[req.EgressId]
 	delete(m.pending, req.EgressId)
 	m.requests.Dec()
 	switch req.Request.(type) {
 	case *rpc.StartEgressRequest_RoomComposite, *rpc.StartEgressRequest_Web:
-		m.webRequests.Dec()
+		if ps != nil && ps.countedAsWeb {
+			m.webRequests.Dec()
+		}
 	}
 }
 
@@ -356,10 +370,24 @@ func (m *Monitor) EgressEnded(req *rpc.StartEgressRequest) (float64, float64, in
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	var countedAsWeb bool
+	if ps := m.pending[req.EgressId]; ps != nil {
+		countedAsWeb = ps.countedAsWeb
+	} else {
+		for _, s := range m.procStats {
+			if s.egressID == req.EgressId {
+				countedAsWeb = s.countedAsWeb
+				break
+			}
+		}
+	}
+
 	switch req.Request.(type) {
 	case *rpc.StartEgressRequest_RoomComposite:
 		m.requestGauge.With(prometheus.Labels{"type": types.RequestTypeRoomComposite}).Sub(1)
-		m.webRequests.Dec()
+		if countedAsWeb {
+			m.webRequests.Dec()
+		}
 	case *rpc.StartEgressRequest_Web:
 		m.requestGauge.With(prometheus.Labels{"type": types.RequestTypeWeb}).Sub(1)
 		m.webRequests.Dec()

--- a/pkg/stats/monitor_prom.go
+++ b/pkg/stats/monitor_prom.go
@@ -78,7 +78,7 @@ func (m *Monitor) promCanAcceptRequest() float64 {
 	m.mu.Lock()
 	_, canAccept := m.canAcceptRequestLocked(&rpc.StartEgressRequest{
 		Request: &rpc.StartEgressRequest_Web{Web: &livekit.WebEgressRequest{}},
-	})
+	}, false)
 	m.mu.Unlock()
 
 	if !m.svc.IsDisabled() && canAccept {


### PR DESCRIPTION
Previously, all room composite requests were treated as Web for admission and capacity, so SDK room composite could be rejected when Pulse was at capacity and could consume Pulse capacity it doesn’t use.