### PR TITLE
Allow 2 tracks with the same trackID to co-exist for some time

### DIFF
--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -92,6 +92,7 @@ type SDKSourceParams struct {
 
 type TrackSource struct {
 	TrackID            string
+	WriterKey          string
 	TrackKind          lksdk.TrackKind
 	ParticipantKind    lksdk.ParticipantKind
 	AppSrc             *app.Source

--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -165,26 +165,26 @@ func (b *AudioBin) onTrackAdded(ts *config.TrackSource) {
 	}
 
 	if ts.TrackKind == lksdk.TrackKindAudio {
-		logger.Debugw("adding audio app src bin", "trackID", ts.TrackID)
+		logger.Debugw("adding audio app src bin", "writerKey", ts.WriterKey)
 		if err := b.addAudioAppSrcBin(ts); err != nil {
-			logger.Errorw("failed to add audio app src bin", err, "trackID", ts.TrackID)
+			logger.Errorw("failed to add audio app src bin", err, "writerKey", ts.WriterKey)
 			b.bin.OnError(err)
 		}
 	}
 }
 
-func (b *AudioBin) onTrackRemoved(trackID string) {
+func (b *AudioBin) onTrackRemoved(writerKey string) {
 	if b.bin.GetState() > gstreamer.StateRunning {
 		return
 	}
 
 	b.mu.Lock()
-	name, ok := b.names[trackID]
+	name, ok := b.names[writerKey]
 	if !ok {
 		b.mu.Unlock()
 		return
 	}
-	delete(b.names, trackID)
+	delete(b.names, writerKey)
 	b.mu.Unlock()
 
 	if err := b.bin.RemoveSourceBin(name); err != nil {
@@ -241,9 +241,9 @@ func (b *AudioBin) addAudioAppSrcBin(ts *config.TrackSource) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	name := fmt.Sprintf("%s_%d", ts.TrackID, b.nextID)
+	name := fmt.Sprintf("%s_%d", ts.WriterKey, b.nextID)
 	b.nextID++
-	b.names[ts.TrackID] = name
+	b.names[ts.WriterKey] = name
 
 	appSrcBin := b.bin.NewBin(name)
 	appSrcBin.SetEOSFunc(func() bool {

--- a/pkg/pipeline/watch.go
+++ b/pkg/pipeline/watch.go
@@ -267,9 +267,9 @@ func (c *Controller) handleMessageStateChanged(msg *gst.Message) {
 	}
 
 	if strings.HasPrefix(s, "app_") {
-		trackID := s[4:]
-		logger.Infow(fmt.Sprintf("%s playing", trackID))
-		c.src.(*source.SDKSource).Playing(trackID)
+		writerKey := s[4:]
+		logger.Infow(fmt.Sprintf("%s playing", writerKey))
+		c.src.(*source.SDKSource).Playing(writerKey)
 	}
 }
 


### PR DESCRIPTION
Aim to handle situation where unsubscribed event is followed by subscribed for the same trackID (publisher reconnecting or being migrated). Previous track draining might still be in progress when new subscribed event comes in

Not intending to merge it - opening it to exchange ideas. I don't particularly like usage of poion pointers here