### PR TITLE
Logging adjustments

### DIFF
--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -346,7 +346,6 @@ func (w *AppWriter) handleReadError(err error) {
 		w.notifyPushSamples()
 
 	case errors.As(err, &netErr) && netErr.Timeout():
-		w.logger.Debugw("read timeout", "error", err)
 		lastRecv := w.lastReceived.Load()
 		if lastRecv.IsZero() {
 			lastRecv = w.startTime

--- a/pkg/pipeline/source/track_worker.go
+++ b/pkg/pipeline/source/track_worker.go
@@ -350,7 +350,6 @@ func (s *SDKSource) processIdleOp(w *trackWorker, trackID string, state *workerS
 	case OpSetTimeProvider:
 		logger.Warnw("invalid op in IDLE", nil, "trackID", trackID, "op", op.Type.String())
 	case OpClose:
-		logger.Warnw("invalid op in IDLE", nil, "trackID", trackID, "op", op.Type.String())
 		return true
 	case OpUnsubscribe, OpFinished:
 		logger.Warnw("invalid op in IDLE", nil, "trackID", trackID, "op", op.Type.String())


### PR DESCRIPTION
Close could come after track was already unsubscribed, don't log that as a warning.
Pipeline stop after track has been already unsubscribed will hit that. It's harmless and no need to log the warning there.

In addition - removing read timeout logging (too noisy)