### PR TITLE
Reverting the fix for pipeline frozen error

### DIFF
--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -100,7 +100,6 @@ type AppWriter struct {
 	lastPushed               atomic.Time
 	playing                  core.Fuse
 	srcNeedsData             core.Fuse
-	addedToPipeline          core.Fuse
 	draining                 core.Fuse
 	unsubscribed             core.Fuse
 	endStreamSignaled        core.Fuse
@@ -262,7 +261,7 @@ func (w *AppWriter) start() {
 	}
 
 	// clean up
-	if w.addedToPipeline.IsBroken() {
+	if w.playing.IsBroken() {
 		w.callbacks.OnEOSSent()
 		if flow := w.src.EndStream(); flow != gst.FlowOK && flow != gst.FlowFlushing {
 			w.logger.Warnw("unexpected flow return", nil, "flowReturn", flow.String())
@@ -645,12 +644,6 @@ func (w *AppWriter) OnUnsubscribed() {
 // Finished returns a channel that is closed when the writer has finished.
 func (w *AppWriter) Finished() <-chan struct{} {
 	return w.finished.Watch()
-}
-
-// MarkAddedToPipeline signals that the appsrc has been linked to the GStreamer pipeline.
-// This is used to determine if EOS must be sent during cleanup.
-func (w *AppWriter) MarkAddedToPipeline() {
-	w.addedToPipeline.Break()
 }
 
 func (w *AppWriter) logStats() {

--- a/pkg/pipeline/source/track_worker.go
+++ b/pkg/pipeline/source/track_worker.go
@@ -314,7 +314,6 @@ func (s *SDKSource) handleSubscribe(w *trackWorker, trackID string, state *worke
 		s.callbacks.OnTrackAdded(ts)
 	}
 
-	writer.MarkAddedToPipeline()
 	return writer
 }
 


### PR DESCRIPTION
The sequence which could lead to panics:
```
c.p.Stop() at controller.go:450 is called on a nil c.p because BuildPipeline() hadn't finished yet.

The race:
  1. Source init → track subscribes → writer goroutine starts (before BuildPipeline completes)
  2. Track gets EOF immediately (1ms after being added to pipeline)
  3. Writer cleanup → OnEOSSent() → SendEOS() → c.p.Stop()
  4. But c.p = p (line 201) hasn't executed yet — BuildPipeline() was still in the middle of adding bins
```
The pipeline frozen fix needs refinement - for now the safest option is just to revert it.