### PR TITLE
Log appsrc state

### DIFF
--- a/pkg/pipeline/watch.go
+++ b/pkg/pipeline/watch.go
@@ -265,8 +265,7 @@ func (c *Controller) handleMessageStateChanged(msg *gst.Message) {
 
 	if strings.HasPrefix(s, "app_") {
 		trackID := s[4:]
-		logger.Debugw(fmt.Sprintf("%s state change", trackID),
-			"oldState", oldState.String(), "newState", newState.String())
+		logger.Debugw("appsrc state change", "trackID", trackID, "oldState", oldState.String(), "newState", newState.String())
 		if newState == gst.StatePlaying {
 			c.src.(*source.SDKSource).Playing(trackID)
 		}


### PR DESCRIPTION
Continuing the hunt for the source of the issue where a track packets could end up not pushed to the pipeline at all due to a flushing error - indicating that either streaming thread from appsrc hit a pad which isn't activated or it was stopped for some reason. Since the state propagation inside a bin for upward state transitions (NULL->READY->PAUSED->PLAYING) follows sink-source elements order - when the app source hits PLAYING state, all other elements in the src bin should be in that state as well which likely means it wasn't hitting a deactivated pad that was issue here but rather streaming thread stopping. It could stop on downward state transition PAUSED->READY - so one plausible theory is that it was somehow caused by 2 concurrent state transition processes - one global pipeline transition to PLAYING operation and an explicit operation to set the its state to PLAYING after linking it to the pipeline (inside bin.go). One could be driving state to PLAYING much faster and when other starts - it might want to go through the same sequence of state - basically regressing it and maybe stopping the streaming thread. Adding logs to test that theory - if this is the case - we will see states going up and down.