### PR TITLE
Use github runners instead of buildjet

### DIFF
--- a/.github/workflows/publish-egress.yaml
+++ b/.github/workflows/publish-egress.yaml
@@ -23,7 +23,7 @@ on:
       - 'v*.*.*'
 jobs:
   docker:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: namespace-profile-8vcpu-cache
     steps:
       - uses: actions/checkout@v6
 
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.5
+          go-version: 1.25.8
 
       - name: Download Go modules
         run: go mod download

--- a/.github/workflows/publish-gstreamer.yaml
+++ b/.github/workflows/publish-gstreamer.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/publish-gstreamer-base.yaml
     with:
       version: ${{ inputs.version }}
-      buildjet-runs-on: buildjet-8vcpu-ubuntu-2204
+      buildjet-runs-on: namespace-profile-8vcpu-cache
       arch: amd64
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/publish-template.yaml
+++ b/.github/workflows/publish-template.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   docker:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: namespace-profile-8vcpu-cache
     steps:
       - uses: actions/checkout@v6
         # for pull requests, need to checkout head for EndBug/add-and-commit to work

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: namespace-profile-8vcpu-cache
     outputs:
       image: ${{ steps.docker-md.outputs.tags }}
     steps:
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.5
+          go-version: 1.25.8
 
       - name: Download Go modules
         run: go mod download
@@ -108,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         integration_type: [file, stream, segments, images, multi, edge]
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: namespace-profile-8vcpu-cache
     steps:
       - uses: shogo82148/actions-setup-redis@v1
         with:


### PR DESCRIPTION
Also update the minor version of go being installed with the setup go action