### PR TITLE
Don't log error on manifest upload failure if backup storage wasn't used

### DIFF
--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -909,7 +909,11 @@ func (c *Controller) uploadManifest() {
 		for _, s := range si {
 			location, uploaded, err := s.UploadManifest(manifestPath)
 			if err != nil {
-				logger.Errorw("failed to upload manifest", err)
+				if c.Info.BackupStorageUsed {
+					logger.Errorw("failed to upload manifest", err)
+				} else {
+					logger.Warnw("failed to upload manifest", err)
+				}
 				continue
 			}
 


### PR DESCRIPTION
This should reduce error level logs noise for cases where it's not relevant - there should be no functional impact on this failure if backup storage isn't used.