### PR TITLE
Fix MP3 duration metadata and CBR encoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/lithammer/shortuuid/v4 v4.2.0 // indirect
 	github.com/livekit/mediatransportutil v0.0.0-20260113174415-2e8ba344fca3 // indirect
+	github.com/llehouerou/go-mp3 v1.2.0 // indirect
 	github.com/mackerelio/go-osstat v0.2.6 // indirect
 	github.com/magefile/mage v1.15.0 // indirect
 	github.com/mattn/go-ieproxy v0.0.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/livekit/server-sdk-go/v2 v2.16.2-0.20260401161108-50e969e2961f h1:xSU
 github.com/livekit/server-sdk-go/v2 v2.16.2-0.20260401161108-50e969e2961f/go.mod h1:oQbYijcbPzfjBAOzoq7tz9Ktqur8JNRCd923VP8xOQQ=
 github.com/livekit/storage v0.0.0-20251113154014-aa1f4d0ce057 h1:6XTEL0cSGkDPWYl1nAS/3cNOK1QoIo11C/O4pc4vPMg=
 github.com/livekit/storage v0.0.0-20251113154014-aa1f4d0ce057/go.mod h1:m+EDdiNremMNJbggvfj5mY8w7nbzVGtZka5Jhj4pg0g=
+github.com/llehouerou/go-mp3 v1.2.0 h1:2WN/bjCGhfPZAQbSSF35DxNKS/+HPnJ76TakA7Kyscs=
+github.com/llehouerou/go-mp3 v1.2.0/go.mod h1:/Rl7E/VQpWTQDTJgr69iYVSkS1BZEh4X/ABV1XvIpHA=
 github.com/mackerelio/go-osstat v0.2.6 h1:gs4U8BZeS1tjrL08tt5VUliVvSWP26Ai2Ob8Lr7f2i0=
 github.com/mackerelio/go-osstat v0.2.6/go.mod h1:lRy8V9ZuHpuRVZh+vyTkODeDPl3/d5MgXHtLSaqG8bA=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=

--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -505,10 +505,13 @@ func (b *AudioBin) addEncoder() error {
 		if err != nil {
 			return errors.ErrGstPipelineError(err)
 		}
-		if err = mp3enc.SetProperty("bitrate", int(b.conf.AudioBitrate)); err != nil {
+		// target=bitrate is required for cbr and bitrate to take effect;
+		// without it lamemp3enc defaults to quality-based VBR.
+		mp3enc.SetArg("target", "bitrate")
+		if err = mp3enc.SetProperty("cbr", true); err != nil {
 			return errors.ErrGstPipelineError(err)
 		}
-		if err = mp3enc.SetProperty("cbr", true); err != nil {
+		if err = mp3enc.SetProperty("bitrate", int(b.conf.AudioBitrate)); err != nil {
 			return errors.ErrGstPipelineError(err)
 		}
 		return b.bin.AddElement(mp3enc)

--- a/pkg/pipeline/builder/muxer.go
+++ b/pkg/pipeline/builder/muxer.go
@@ -22,7 +22,7 @@ import (
 )
 
 // muxer captures the minimal behavior builders need from a muxing element, allowing
-// us to swap between real gst muxers and light-weight shims (e.g. identity for MP3).
+// us to swap between real gst muxers and light-weight shims (e.g. xingmux for MP3).
 type muxer interface {
 	GetRequestPad(name string) *gst.Pad
 	GetElement() *gst.Element
@@ -58,21 +58,23 @@ func (m *muxerImpl) GetElement() *gst.Element {
 	return m.Element
 }
 
-// mp3Muxer makes the identity element look like a muxer so audio-only MP3 outputs
+// mp3Muxer wraps xingmux as a muxer so audio-only MP3 outputs
 // can reuse the same linking logic as containerised formats.
 type mp3Muxer struct {
 	muxerImpl
 }
 
-// newMP3Muxer provides a muxer-compatible wrapper around gst identity.
+// newMP3Muxer provides a muxer-compatible wrapper around gst xingmux.
+// xingmux inserts a Xing header containing total frame and byte counts,
+// allowing players to determine the file duration without scanning every frame.
 func newMP3Muxer() (*mp3Muxer, error) {
-	identity, err := gst.NewElement("identity")
+	xing, err := gst.NewElement("xingmux")
 	if err != nil {
 		return nil, err
 	}
 	return &mp3Muxer{
 		muxerImpl: muxerImpl{
-			Element: identity,
+			Element: xing,
 		},
 	}, nil
 }

--- a/test/ffprobe.go
+++ b/test/ffprobe.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -29,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/llehouerou/go-mp3/lameinfo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/livekit/egress/pkg/config"
@@ -182,6 +184,12 @@ func verify(t *testing.T, in string, p *config.PipelineConfig, res *livekit.Egre
 		require.InDelta(t, expected, actual, 4.1)
 	}
 
+	// verify Xing/Info header for MP3 files
+	if egressType == types.EgressTypeFile && p.AudioOutCodec == types.MimeTypeMP3 {
+		fpDuration, _ := strconv.ParseFloat(info.Format.Duration, 64)
+		verifyXingHeader(t, in, int(p.AudioFrequency), fpDuration)
+	}
+
 	// check stream info
 	var hasAudio, hasVideo bool
 	for _, stream := range info.Streams {
@@ -200,6 +208,17 @@ func verify(t *testing.T, in string, p *config.PipelineConfig, res *livekit.Egre
 				require.Equal(t, "opus", stream.CodecName)
 				require.Equal(t, "48000", stream.SampleRate)
 				require.Equal(t, "stereo", stream.ChannelLayout)
+
+			case types.MimeTypeMP3:
+				require.Equal(t, "mp3", stream.CodecName)
+				require.Equal(t, fmt.Sprint(p.AudioFrequency), stream.SampleRate)
+				require.Equal(t, "stereo", stream.ChannelLayout)
+
+				// verify CBR: stream bitrate should match configured bitrate
+				bitrate, err := strconv.Atoi(stream.BitRate)
+				require.NoError(t, err)
+				require.InDelta(t, int(p.AudioBitrate)*1000, bitrate, 5000,
+					"MP3 bitrate %d bps not close to configured %d kbps", bitrate, p.AudioBitrate)
 
 			case types.MimeTypeRawAudio:
 				require.Equal(t, "pcm_s16le", stream.CodecName)
@@ -328,4 +347,30 @@ func parseFFProbeDuration(s string) (time.Duration, error) {
 		return 0, fmt.Errorf("invalid seconds format %q: %w", s, err)
 	}
 	return time.Duration(f * float64(time.Second)), nil
+}
+
+// verifyXingHeader checks that an MP3 file contains a valid Xing/Info header
+// and that the duration derived from its frame count matches ffprobe.
+func verifyXingHeader(t *testing.T, filepath string, sampleRate int, ffprobeDuration float64) {
+	t.Helper()
+
+	f, err := os.Open(filepath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	xi, err := lameinfo.ParseFromReader(f)
+	require.NoError(t, err, "MP3 file missing Xing/Info header")
+
+	require.True(t, xi.HasFrameCount(), "Xing header missing frame count")
+	require.NotZero(t, xi.FrameCount, "Xing header has zero frame count")
+
+	require.True(t, xi.HasTOC(), "Xing header missing TOC seek table")
+
+	// MPEG1 Layer 3: 1152 samples per frame.
+	// Cross-check Xing frame count against ffprobe duration.
+	const samplesPerFrame = 1152
+	xingDuration := float64(xi.FrameCount) * samplesPerFrame / float64(sampleRate)
+	require.InDelta(t, ffprobeDuration, xingDuration, 0.1,
+		"Xing duration (%0.3fs from %d frames) does not match ffprobe duration (%0.3fs)",
+		xingDuration, xi.FrameCount, ffprobeDuration)
 }


### PR DESCRIPTION
lamemp3enc doesn't produce cbr (even when setting cbr to true and the bitrate) unless the target property is set to bitrate (quality is default).  For that reason semantics of the passed bitrate is wrong as is. Adding xing header so players could read duration without parsing the entire file (e.g in its absence VLC player will keep updating duration as playback goes). With CBR fixed, it's not strictly needed but doesn't hurt to have it for e.g more efficient seeking.

Adding checks to ensure the header is written and that cbr is used.