### PR TITLE
K8s requests read support

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/livekit/protocol/logger"
 	lkredis "github.com/livekit/protocol/redis"
 	"github.com/livekit/protocol/rpc"
+	_ "github.com/livekit/protocol/utils/hwstats/maxprocs"
 	"github.com/livekit/psrpc"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/livekit/livekit-server v1.9.12
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/media-sdk v0.0.0-20260422170315-2c3eed337496
-	github.com/livekit/protocol v1.45.4-0.20260414223210-8e21dbcaa110
+	github.com/livekit/protocol v1.45.6
 	github.com/livekit/psrpc v0.7.1
 	github.com/livekit/server-sdk-go/v2 v2.16.2-0.20260401161108-50e969e2961f
 	github.com/livekit/storage v0.0.0-20251113154014-aa1f4d0ce057

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/livekit/media-sdk v0.0.0-20260422170315-2c3eed337496 h1:yIEbXERsObyjG
 github.com/livekit/media-sdk v0.0.0-20260422170315-2c3eed337496/go.mod h1:7ssWiG+U4xnbvLih9WiZbhQP6zIKMjgXdUtIE1bm/E8=
 github.com/livekit/mediatransportutil v0.0.0-20260113174415-2e8ba344fca3 h1:v1Xc/q/547TjLX7Nw5y2vXNnmV0XYFAbhTJrtErQeDA=
 github.com/livekit/mediatransportutil v0.0.0-20260113174415-2e8ba344fca3/go.mod h1:QBx/KHV6Vv00ggibg/WrOlqrkTciEA2Hc9DGWYr3Q9U=
-github.com/livekit/protocol v1.45.4-0.20260414223210-8e21dbcaa110 h1:sOh0nauOcsyYZJG96O/iLWNyA687lHmJulmrFxBYMVM=
-github.com/livekit/protocol v1.45.4-0.20260414223210-8e21dbcaa110/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
+github.com/livekit/protocol v1.45.6 h1:E+wKxs8ckKNYYTNyHm5nR1ShGLJ5DmA+WCEb5AJG11A=
+github.com/livekit/protocol v1.45.6/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/livekit/server-sdk-go/v2 v2.16.2-0.20260401161108-50e969e2961f h1:xSUtbUe3wBIFG/Ki3KEIsmjkOcfbpSOYJh2xxwJEllg=


### PR DESCRIPTION
Package maxprocs caps GOMAXPROCS to the Kubernetes CPU request so the Go scheduler doesn't create more OS threads than the pod is guaranteed.

# Why not CPU limits / automaxprocs

Real-time media workloads (egress, ingress) intentionally omit CPU limits to avoid CFS throttling — even brief throttle events cause audio glitches and video frame drops. Without a limit the cgroup quota is "max", so libraries like uber/automaxprocs fall back to runtime.NumCPU (the full node). This package uses the CPU request instead, which reflects what the Kubernetes scheduler actually guarantees to the pod.

When a CPU limit IS set, the cgroup quota gives a tighter bound and Go (or automaxprocs) already derives GOMAXPROCS from it. This package still works in that case — it caps GOMAXPROCS down to the request but never increases it, so the stricter of (limit, request) wins.

# Usage

 The CPU request is read from the LIVEKIT_CPU_REQUEST environment variable,  which should be populated e.g via the Kubernetes Downward API:
```
	env:
	  - name: LIVEKIT_CPU_REQUEST
	    valueFrom:
	      resourceFieldRef:
	        containerName: <name>
	        resource: requests.cpu
```
Egress benefits from this as request admission CPU checks are based on cores requested vs cores available. GOMAXPROCS is also gauged based on it which could prevent frequent context switches if number of available CPU cores on a node exceeds requested by high margin.