### PR TITLE
Set time provider only after pipeline reaches playing state

### DIFF
--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -234,9 +234,6 @@ func (c *Controller) BuildPipeline() error {
 	p.UpgradeState(gstreamer.StateStarted)
 
 	c.p = p
-	if timeAware, ok := c.src.(source.TimeAware); ok {
-		timeAware.SetTimeProvider(p)
-	}
 	close(c.callbacks.BuildReady)
 	return nil
 }

--- a/pkg/pipeline/watch.go
+++ b/pkg/pipeline/watch.go
@@ -274,6 +274,11 @@ func (c *Controller) handleMessageStateChanged(msg *gst.Message) {
 
 				logger.Infow("pipeline playing", "timeToPlaying", timeToPlaying)
 				c.updateStartTime(c.src.GetStartedAt())
+
+				// base_time is only valid after the pipeline reaches PLAYING
+				if timeAware, ok := c.src.(source.TimeAware); ok {
+					timeAware.SetTimeProvider(c.p)
+				}
 			})
 		}
 		return


### PR DESCRIPTION
RunningTime() returns system uptime before pipeline reaches PLAYING, poisoning track synchronizer deadline if callback invoked before the pipeline transitioned to playing. When the GStreamer pipeline transitions to PLAYING, appsrc elements reach PLAYING state before the pipeline itself completes the transition and sets base_time. The pushSamples playing gate (appwriter.go:497) is signaled by the appsrc state change (watch.go:285), not the pipeline state change, so packets begin flowing through GetPTS while Pipeline.RunningTime() still computes clockTime - (unset base_time) = node monotonic uptime. getExternalMediaDeadline() in the synchronizer caches externalMediaStartTime on its first successful RunningTime() call and never corrects it. Once poisoned with a value like ~208,767 seconds (58h node uptime), the deadline is permanently ~58 hours ahead of the actual track PTS. After cMaxTimelyPacketAge (10s) of every packet being "behind" this impossible deadline, the synchronizer fires the "correcting PTS to pull the track forward" path, producing a correctedPTS equal to the node uptime rather than a sane media timestamp.

Was thinking about automation testing but it would require significant test code addition to simulate this edge case of an edge case so consciously skipping to avoid blowing the complexity out of proportion.