### PR TITLE
Fix deps svc logging

### DIFF
--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -132,7 +132,7 @@ func (c *BaseConfig) initLogger(values ...interface{}) error {
 	l := zl.WithValues(values...)
 
 	logger.SetLogger(l, "egress")
-	lksdk.SetLogger(medialogutils.NewOverrideLogger(nil))
+	lksdk.SetLogger(medialogutils.NewOverrideLogger(logger.GetLogger().WithComponent("lksdk")))
 	return nil
 }
 

--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -132,7 +132,7 @@ func (c *BaseConfig) initLogger(values ...interface{}) error {
 	l := zl.WithValues(values...)
 
 	logger.SetLogger(l, "egress")
-	lksdk.SetLogger(medialogutils.NewOverrideLogger(l.WithComponent("lksdk")))
+	lksdk.SetLogger(medialogutils.NewOverrideLogger(nil))
 	return nil
 }
 


### PR DESCRIPTION
The SDK logger was initialized with the base logger before SetLogger applied the service name, causing pion logs to appear as lksdk.pion.ice instead of  egress.pion.ice.
Matches with ingress.