### PR TITLE
Export InitLogger with configurable service name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ media-samples/
 test/output/*
 test/*.yaml
 !test/config-sample.yaml
+agents/

--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -100,7 +100,7 @@ type AudioTempoController struct {
 	AdjustmentRate float64 `yaml:"adjustment_rate"` // rate at which to adjust the tempo to compensate for PTS drift
 }
 
-func (c *BaseConfig) initLogger(values ...interface{}) error {
+func (c *BaseConfig) InitLogger(serviceName string, values ...interface{}) error {
 	_, exists := os.LookupEnv("GST_DEBUG")
 
 	// If GST_DEBUG is not set, use pre-defined values based on logging level
@@ -131,7 +131,7 @@ func (c *BaseConfig) initLogger(values ...interface{}) error {
 
 	l := zl.WithValues(values...)
 
-	logger.SetLogger(l, "egress")
+	logger.SetLogger(l, serviceName)
 	lksdk.SetLogger(medialogutils.NewOverrideLogger(logger.GetLogger().WithComponent("lksdk")))
 	return nil
 }

--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -167,7 +167,7 @@ func NewPipelineConfig(confString string, req *rpc.StartEgressRequest) (*Pipelin
 		return nil, errors.ErrCouldNotParseConfig(err)
 	}
 
-	if err := p.initLogger(
+	if err := p.InitLogger("egress",
 		"nodeID", p.NodeID,
 		"handlerID", p.HandlerID,
 		"clusterID", p.ClusterID,

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -121,7 +121,7 @@ func NewServiceConfig(confString string) (*ServiceConfig, error) {
 
 	rpc.InitPSRPCStats(prometheus.Labels{"node_id": conf.NodeID, "node_type": "EGRESS"})
 
-	if err := conf.initLogger("nodeID", conf.NodeID, "clusterID", conf.ClusterID); err != nil {
+	if err := conf.InitLogger("egress", "nodeID", conf.NodeID, "clusterID", conf.ClusterID); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Exported InitLogger and added a serviceName parameter so downstream consumers can reuse it with their own service name instead of duplicating the logger initialization logic.