### PR TITLE
Update media-samples to pull in the fix for PTS extraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/linkdata/deadlock v0.5.5
 	github.com/livekit/livekit-server v1.9.12
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
-	github.com/livekit/media-samples/avsync v0.0.0-20260513155343-b600ce6e281d
+	github.com/livekit/media-samples/avsync v0.0.0-20260518111213-3ede4e1aa1a4
 	github.com/livekit/media-sdk v0.0.0-20260422170315-2c3eed337496
 	github.com/livekit/protocol v1.45.6
 	github.com/livekit/psrpc v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/livekit/livekit-server v1.9.12 h1:VsPJAL2EbiBKt5SIhZWazNUSkEUZi/8P8kt
 github.com/livekit/livekit-server v1.9.12/go.mod h1:Xh2ocHdH+z/D2u00GulDVVIDdgAlck1miHT0Ab2Skvg=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5ATTo469PQPkqzdoU7be46ryiCDO3boc=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/media-samples/avsync v0.0.0-20260513155343-b600ce6e281d h1:BCtrBIhGA+2LzWy9nbPn/jJZuZQyKIA1r+9WL14EG3M=
-github.com/livekit/media-samples/avsync v0.0.0-20260513155343-b600ce6e281d/go.mod h1:ABnDYmOwSChrFXHj6F3dwNOlEAL45xR0S4uhSwRxOn0=
+github.com/livekit/media-samples/avsync v0.0.0-20260518111213-3ede4e1aa1a4 h1:CKQ87sXM6dNmbuwpq2GRpDtb9jwk8VlNfoIwoJHlW7g=
+github.com/livekit/media-samples/avsync v0.0.0-20260518111213-3ede4e1aa1a4/go.mod h1:ABnDYmOwSChrFXHj6F3dwNOlEAL45xR0S4uhSwRxOn0=
 github.com/livekit/media-sdk v0.0.0-20260422170315-2c3eed337496 h1:yIEbXERsObyjGGoTnv7Bf37pQfAHrxRmPAN//tgzwJU=
 github.com/livekit/media-sdk v0.0.0-20260422170315-2c3eed337496/go.mod h1:7ssWiG+U4xnbvLih9WiZbhQP6zIKMjgXdUtIE1bm/E8=
 github.com/livekit/mediatransportutil v0.0.0-20260113174415-2e8ba344fca3 h1:v1Xc/q/547TjLX7Nw5y2vXNnmV0XYFAbhTJrtErQeDA=


### PR DESCRIPTION
ffmpeg 6.x doesn't preserve original video PTS when complex filter is used in combo with mpeg-ts muxer for some reason. Update contains fix for using simple filter and separating labels and flashes runs.