### PR TITLE
Fix deadlock when AbortProcess/KillProcess call kill() under pm.mu lock

### DIFF
--- a/pkg/service/process.go
+++ b/pkg/service/process.go
@@ -16,9 +16,11 @@ package service
 
 import (
 	"context"
+	"maps"
 	"os"
 	"os/exec"
 	"path"
+	"slices"
 	"syscall"
 	"time"
 
@@ -190,10 +192,7 @@ func (pm *processManager) GetGRPCClient(egressID string) (ipc.EgressHandlerClien
 
 func (pm *processManager) KillAll() {
 	pm.mu.RLock()
-	handlers := make([]*Process, 0, len(pm.activeHandlers))
-	for _, h := range pm.activeHandlers {
-		handlers = append(handlers, h)
-	}
+	handlers := slices.Collect(maps.Values(pm.activeHandlers))
 	pm.mu.RUnlock()
 
 	for _, h := range handlers {

--- a/pkg/service/process.go
+++ b/pkg/service/process.go
@@ -190,9 +190,13 @@ func (pm *processManager) GetGRPCClient(egressID string) (ipc.EgressHandlerClien
 
 func (pm *processManager) KillAll() {
 	pm.mu.RLock()
-	defer pm.mu.RUnlock()
-
+	handlers := make([]*Process, 0, len(pm.activeHandlers))
 	for _, h := range pm.activeHandlers {
+		handlers = append(handlers, h)
+	}
+	pm.mu.RUnlock()
+
+	for _, h := range handlers {
 		h.kill(errors.ErrShuttingDown)
 	}
 }
@@ -200,13 +204,16 @@ func (pm *processManager) KillAll() {
 func (pm *processManager) AbortProcess(egressID string, err error) {
 	logger.Infow("aborting egress", err, "egressID", egressID)
 	pm.mu.Lock()
-	defer pm.mu.Unlock()
+	h, ok := pm.activeHandlers[egressID]
+	if ok {
+		delete(pm.activeHandlers, egressID)
+	}
+	pm.mu.Unlock()
 
-	if h, ok := pm.activeHandlers[egressID]; ok {
+	if ok {
 		logger.Warnw("aborting handler", err, "egressID", egressID)
 		h.kill(err)
 		h.ipcHandlerClient.Close()
-		delete(pm.activeHandlers, egressID)
 	}
 	logger.Infow("aborting egress completed", "egressID", egressID)
 }
@@ -214,9 +221,10 @@ func (pm *processManager) AbortProcess(egressID string, err error) {
 func (pm *processManager) KillProcess(egressID string, err error) {
 	logger.Infow("killing egress", err, "egressID", egressID)
 	pm.mu.RLock()
-	defer pm.mu.RUnlock()
+	h, ok := pm.activeHandlers[egressID]
+	pm.mu.RUnlock()
 
-	if h, ok := pm.activeHandlers[egressID]; ok {
+	if ok {
 		logger.Errorw("killing handler", err, "egressID", egressID)
 		h.kill(err)
 	}


### PR DESCRIPTION
When cloud-io CreateEgress fails after the handler process has already launched, AbortProcess is called which acquires pm.mu (write lock) and then calls kill(). kill() makes a synchronous gRPC KillEgress call to the handler over a Unix domain socket with  no timeout. If the handler is dead or stuck (e.g. inside pipeline.New()), the gRPC call blocks forever while holding the lock.

This causes a cascading deadlock:
  - ProcessFinished (from cmd.Wait()) needs the write lock to clean up — blocked
  - Prometheus scrapes (GetGatherers), new StartEgress RPCs (AlreadyExists), handler IPC calls (GetContext), and health checks (GetStatus) all need the read lock — blocked because Go's RWMutex is writer-preferring and ProcessFinished is waiting for the write lock

KillProcess and KillAll have the same issue — although they use RLock, a hung kill() still blocks ProcessFinished from acquiring the write lock, which then blocks all subsequent readers.

Fix consists of grabbing the handler reference under the lock, release the lock, then call kill() outside. This is safe because:
  - AbortProcess deletes the handler from the map before releasing the lock, so ProcessFinished will no-op
  - kill() uses core.Fuse.Once, so concurrent calls are idempotent
  - for KillProcess/KillAll, if ProcessFinished races and calls closed.Break() first, Once won't fire