### PR TITLE
two-tiered pacer

### DIFF
--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -312,7 +312,7 @@ func (b *AudioBin) addAudioAppSrcBinLocked(ts *config.TrackSource) error {
 				// Hard tier means the pacer cannot absorb drift fast enough even with
 				// boosting; downstream is approaching mixer alignment-threshold and
 				// will start dropping
-				logger.Errorw("audio drift exceeded hard budget",
+				logger.Warnw("audio drift exceeded hard budget",
 					errors.New("uncorrected drift above hard budget"),
 					"trackID", trackID, "tier", tier)
 				pacer.boost()

--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -292,12 +292,8 @@ func (b *AudioBin) addAudioAppSrcBinLocked(ts *config.TrackSource) error {
 	}
 
 	if pacer != nil && ts.TempoController != nil {
-		ts.TempoController.OnDriftDetectedCallback(func(drift time.Duration) {
-			if pacer.pitch != nil {
-				logger.Debugw("starting audio pacer to cover the drift", "drift", drift)
-				pacer.start(drift)
-			}
-		})
+		// tc must be set before callbacks: both replay current state synchronously.
+		pacer.tc = ts.TempoController
 		trackID := ts.TrackID
 		ts.TempoController.OnTierChange(func(tier tempo.Tier) {
 			switch tier {
@@ -318,7 +314,10 @@ func (b *AudioBin) addAudioAppSrcBinLocked(ts *config.TrackSource) error {
 				pacer.boost()
 			}
 		})
-		pacer.tc = ts.TempoController
+		ts.TempoController.OnDriftDetectedCallback(func(drift time.Duration) {
+			logger.Debugw("starting audio pacer to cover the drift", "drift", drift)
+			pacer.start(drift)
+		})
 	}
 
 	return nil
@@ -538,10 +537,6 @@ func addAudioConverter(b *gstreamer.Bin, p *config.PipelineConfig, channel livek
 }
 
 func installPitchProbes(pacer *audioPacer) {
-	if pacer.pitch == nil {
-		return
-	}
-
 	// Sink pad: accumulate input buffer durations.
 	if sinkPad := pacer.pitch.GetStaticPad("sink"); sinkPad != nil {
 		sinkPad.AddProbe(gst.PadProbeTypeBuffer, func(_ *gst.Pad, info *gst.PadProbeInfo) gst.PadProbeReturn {

--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -21,11 +21,11 @@ import (
 	"github.com/go-gst/go-gst/gst"
 	"github.com/go-gst/go-gst/gst/app"
 	"github.com/linkdata/deadlock"
-	"go.uber.org/atomic"
 
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
 	"github.com/livekit/egress/pkg/gstreamer"
+	"github.com/livekit/egress/pkg/pipeline/tempo"
 	"github.com/livekit/egress/pkg/types"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -48,102 +48,6 @@ type AudioBin struct {
 	nextID      int
 	nextChannel livekit.AudioChannel
 	names       map[string]string
-}
-
-type driftProcessNotifier interface {
-	DriftProcessed(actual time.Duration)
-	CancelInFlight()
-}
-
-// pacerSnapshot is the per-correction baseline captured at start(). It is
-// stored atomically as a unit so the probe never observes a torn snapshot
-// even if start() is mis-invoked while a correction is still active. The
-// active check in start() prevents this today, but treating the snapshot as
-// an atomic value removes the implicit ordering dependency between
-// active.Store and the snapshot field writes.
-type pacerSnapshot struct {
-	inputAtStart  int64
-	outputAtStart int64
-	targetDrift   time.Duration
-}
-
-type audioPacer struct {
-	pitch               *gst.Element
-	active              atomic.Bool
-	tc                  driftProcessNotifier
-	tempoAdjustmentRate float64
-
-	// Continuous accumulators for measuring actual compensation.
-	// Compensation = outputAccum - inputAccum (relative to snapshots at start).
-	inputAccum  atomic.Int64 // cumulative input buffer durations (nanoseconds)
-	outputAccum atomic.Int64 // cumulative output buffer durations (nanoseconds)
-
-	// snapshot is the active correction's baseline. nil when idle.
-	snapshot atomic.Pointer[pacerSnapshot]
-}
-
-func (a *audioPacer) start(drift time.Duration) {
-	if a.pitch == nil || drift == 0 {
-		return
-	}
-	if a.active.Load() {
-		logger.Errorw(
-			"starting audio pacer, but it's already active",
-			errors.New("tempo controller bug"),
-		)
-		return
-	}
-
-	rate := 1 + a.tempoAdjustmentRate
-	if drift > 0 {
-		rate = 1 - a.tempoAdjustmentRate
-	}
-
-	// Publish the snapshot before active=true so the probe — which reads
-	// active first, then snapshot — never sees active without a snapshot.
-	a.snapshot.Store(&pacerSnapshot{
-		inputAtStart:  a.inputAccum.Load(),
-		outputAtStart: a.outputAccum.Load(),
-		targetDrift:   drift,
-	})
-
-	logger.Debugw("starting audio pacer", "targetDrift", drift, "rate", rate)
-	a.pitch.SetArg("tempo", fmt.Sprintf("%.2f", rate))
-	a.active.Store(true)
-}
-
-// stop is the success path used by the src-pad probe when the in-flight
-// correction has reached its target. Returns true if this call won the
-// transition from active to idle; the caller must then notify the controller
-// via DriftProcessed. Concurrent stop / cancelOnFlush calls coalesce: only
-// one wins the Swap, the others see false and do nothing.
-func (a *audioPacer) stop() bool {
-	if a.pitch == nil {
-		return false
-	}
-	if !a.active.Swap(false) {
-		return false
-	}
-	a.pitch.SetArg("tempo", fmt.Sprintf("%.1f", 1.0))
-	return true
-}
-
-// cancelOnFlush is the abort path used when downstream is about to discard
-// the audio the in-flight correction has been applying to. The measurement
-// in inputAccum / outputAccum cannot be trusted across the flush boundary,
-// so the correction is abandoned: tempo returns to 1.0, the controller's
-// in-flight target is cleared (without crediting any compensation), and the
-// next SR drives a fresh correction. Returns true if this call won the
-// transition.
-func (a *audioPacer) cancelOnFlush() bool {
-	if a.pitch == nil {
-		return false
-	}
-	if !a.active.Swap(false) {
-		return false
-	}
-	a.pitch.SetArg("tempo", fmt.Sprintf("%.1f", 1.0))
-	return true
 }
 
 func BuildAudioBin(pipeline *gstreamer.Pipeline, p *config.PipelineConfig) error {
@@ -394,6 +298,26 @@ func (b *AudioBin) addAudioAppSrcBinLocked(ts *config.TrackSource) error {
 				pacer.start(drift)
 			}
 		})
+		trackID := ts.TrackID
+		ts.TempoController.OnTierChange(func(tier tempo.Tier) {
+			switch tier {
+			case tempo.TierNormal:
+				logger.Infow("audio drift back inside soft budget", "trackID", trackID, "tier", tier)
+				pacer.brake()
+			case tempo.TierSoft:
+				logger.Warnw("audio drift exceeded soft budget, boosting pacer rate", nil,
+					"trackID", trackID, "tier", tier)
+				pacer.boost()
+			case tempo.TierHard:
+				// Hard tier means the pacer cannot absorb drift fast enough even with
+				// boosting; downstream is approaching mixer alignment-threshold and
+				// will start dropping
+				logger.Errorw("audio drift exceeded hard budget",
+					errors.New("uncorrected drift above hard budget"),
+					"trackID", trackID, "tier", tier)
+				pacer.boost()
+			}
+		})
 		pacer.tc = ts.TempoController
 	}
 
@@ -432,6 +356,7 @@ func (b *AudioBin) resetAudioAppSrcBin(ts *config.TrackSource) error {
 	// and the controller arms fresh against the current state.
 	if ts.TempoController != nil {
 		ts.TempoController.OnDriftDetectedCallback(nil)
+		ts.TempoController.OnTierChange(nil)
 		ts.TempoController.CancelInFlight()
 	}
 
@@ -747,9 +672,17 @@ func (b *AudioBin) addAudioConvertWithPitch(bin *gstreamer.Bin, p *config.Pipeli
 		return nil, err
 	}
 
+	// Boosted rate kicks in when the controller signals soft-budget exceeded.
+	// 2x the base rate, capped at the same 0.2 ceiling enforced for AdjustmentRate.
+	boostedRate := 2 * p.AudioTempoController.AdjustmentRate
+	if boostedRate > 0.2 {
+		boostedRate = 0.2
+	}
+
 	pacer := &audioPacer{
 		pitch:               pitch,
 		tempoAdjustmentRate: p.AudioTempoController.AdjustmentRate,
+		boostedRate:         boostedRate,
 	}
 
 	installPitchProbes(pacer)

--- a/pkg/pipeline/builder/audio_pacer.go
+++ b/pkg/pipeline/builder/audio_pacer.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/go-gst/go-gst/gst"
+	"github.com/linkdata/deadlock"
 	"go.uber.org/atomic"
 
 	"github.com/livekit/egress/pkg/errors"
@@ -33,21 +34,19 @@ type driftProcessNotifier interface {
 }
 type audioPacer struct {
 	pitch               *gst.Element
-	active              atomic.Bool
 	tc                  driftProcessNotifier
 	tempoAdjustmentRate float64
 	boostedRate         float64
 
-	// Continuous accumulators for measuring actual compensation.
-	// Compensation = outputAccum - inputAccum (relative to snapshots at start).
+	// mu serializes writers; probe reads active/snapshot without it.
+	mu       deadlock.Mutex
+	active   atomic.Bool
+	snapshot atomic.Pointer[pacerSnapshot]
+
 	inputAccum  atomic.Int64 // cumulative input buffer durations (nanoseconds)
 	outputAccum atomic.Int64 // cumulative output buffer durations (nanoseconds)
-
-	// snapshot is the active correction's baseline. nil when idle.
-	snapshot atomic.Pointer[pacerSnapshot]
 }
 
-// pacerSnapshot is the per-correction baseline captured at start()
 type pacerSnapshot struct {
 	inputAtStart  int64
 	outputAtStart int64
@@ -55,9 +54,13 @@ type pacerSnapshot struct {
 }
 
 func (a *audioPacer) start(drift time.Duration) {
-	if a.pitch == nil || drift == 0 {
+	if drift == 0 {
 		return
 	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	if a.active.Load() {
 		logger.Errorw(
 			"starting audio pacer, but it's already active",
@@ -66,17 +69,14 @@ func (a *audioPacer) start(drift time.Duration) {
 		return
 	}
 
-	// If we're already past the soft budget, start boosted so we don't burn a
-	// full correction cycle at the base rate before the tier-change callback
-	// catches up.
+	// OnTierChange fires only on transitions; check Tier() to start boosted on a stable elevated state.
 	adjustment := a.tempoAdjustmentRate
 	if a.tc != nil && a.tc.Tier() >= tempo.TierSoft {
 		adjustment = a.boostedRate
 	}
 	rate := pacerRate(drift, adjustment)
 
-	// Publish the snapshot before active=true so the probe — which reads
-	// active first, then snapshot — never sees active without a snapshot.
+	// snapshot before active: probe reads active first.
 	a.snapshot.Store(&pacerSnapshot{
 		inputAtStart:  a.inputAccum.Load(),
 		outputAtStart: a.outputAccum.Load(),
@@ -88,11 +88,14 @@ func (a *audioPacer) start(drift time.Duration) {
 	a.active.Store(true)
 }
 
-// boost switches the pitch element to a more aggressive rate
 func (a *audioPacer) boost() {
-	if a.pitch == nil || !a.active.Load() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if !a.active.Load() {
 		return
 	}
+
 	snap := a.snapshot.Load()
 	if snap == nil {
 		return
@@ -101,11 +104,14 @@ func (a *audioPacer) boost() {
 	a.pitch.SetArg("tempo", fmt.Sprintf("%.2f", rate))
 }
 
-// brake restores the base rate when drift falls back inside the soft budget
 func (a *audioPacer) brake() {
-	if a.pitch == nil || !a.active.Load() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if !a.active.Load() {
 		return
 	}
+
 	snap := a.snapshot.Load()
 	if snap == nil {
 		return
@@ -114,15 +120,11 @@ func (a *audioPacer) brake() {
 	a.pitch.SetArg("tempo", fmt.Sprintf("%.2f", rate))
 }
 
-// stop is the success path used by the src-pad probe when the in-flight
-// correction has reached its target. Returns true if this call won the
-// transition from active to idle; the caller must then notify the controller
-// via DriftProcessed. Concurrent stop / cancelOnFlush calls coalesce: only
-// one wins the Swap, the others see false and do nothing.
+// Returns true on the active→idle transition; caller then notifies the controller.
 func (a *audioPacer) stop() bool {
-	if a.pitch == nil {
-		return false
-	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	if !a.active.Swap(false) {
 		return false
 	}
@@ -130,17 +132,11 @@ func (a *audioPacer) stop() bool {
 	return true
 }
 
-// cancelOnFlush is the abort path used when downstream is about to discard
-// the audio the in-flight correction has been applying to. The measurement
-// in inputAccum / outputAccum cannot be trusted across the flush boundary,
-// so the correction is abandoned: tempo returns to 1.0, the controller's
-// in-flight target is cleared (without crediting any compensation), and the
-// next SR drives a fresh correction. Returns true if this call won the
-// transition.
+// Accumulators can't be trusted across the flush boundary; abandon without crediting compensation.
 func (a *audioPacer) cancelOnFlush() bool {
-	if a.pitch == nil {
-		return false
-	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	if !a.active.Swap(false) {
 		return false
 	}
@@ -148,9 +144,7 @@ func (a *audioPacer) cancelOnFlush() bool {
 	return true
 }
 
-// pacerRate computes the tempo property value for the given drift direction
-// at the given per-step adjustment rate. drift>0 means audio is ahead of wall
-// clock, so tempo<1 (slow down); drift<0 means audio is behind, so tempo>1.
+// drift>0 → audio ahead → tempo<1 (slow); drift<0 → tempo>1 (speed up).
 func pacerRate(drift time.Duration, adjustment float64) float64 {
 	if drift > 0 {
 		return 1 - adjustment

--- a/pkg/pipeline/builder/audio_pacer.go
+++ b/pkg/pipeline/builder/audio_pacer.go
@@ -1,0 +1,164 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-gst/go-gst/gst"
+	"go.uber.org/atomic"
+
+	"github.com/livekit/egress/pkg/errors"
+	"github.com/livekit/egress/pkg/pipeline/tempo"
+	"github.com/livekit/protocol/logger"
+)
+
+type driftProcessNotifier interface {
+	DriftProcessed(actual time.Duration)
+	CancelInFlight()
+	Tier() tempo.Tier
+}
+type audioPacer struct {
+	pitch               *gst.Element
+	active              atomic.Bool
+	tc                  driftProcessNotifier
+	tempoAdjustmentRate float64
+	boostedRate         float64
+
+	// Continuous accumulators for measuring actual compensation.
+	// Compensation = outputAccum - inputAccum (relative to snapshots at start).
+	inputAccum  atomic.Int64 // cumulative input buffer durations (nanoseconds)
+	outputAccum atomic.Int64 // cumulative output buffer durations (nanoseconds)
+
+	// snapshot is the active correction's baseline. nil when idle.
+	snapshot atomic.Pointer[pacerSnapshot]
+}
+
+// pacerSnapshot is the per-correction baseline captured at start(). It is
+// stored atomically as a unit so the probe never observes a torn snapshot
+// even if start() is mis-invoked while a correction is still active. The
+// active check in start() prevents this today, but treating the snapshot as
+// an atomic value removes the implicit ordering dependency between
+// active.Store and the snapshot field writes.
+type pacerSnapshot struct {
+	inputAtStart  int64
+	outputAtStart int64
+	targetDrift   time.Duration
+}
+
+func (a *audioPacer) start(drift time.Duration) {
+	if a.pitch == nil || drift == 0 {
+		return
+	}
+	if a.active.Load() {
+		logger.Errorw(
+			"starting audio pacer, but it's already active",
+			errors.New("tempo controller bug"),
+		)
+		return
+	}
+
+	// If we're already past the soft budget, start boosted so we don't burn a
+	// full correction cycle at the base rate before the tier-change callback
+	// catches up.
+	adjustment := a.tempoAdjustmentRate
+	if a.tc != nil && a.tc.Tier() >= tempo.TierSoft {
+		adjustment = a.boostedRate
+	}
+	rate := pacerRate(drift, adjustment)
+
+	// Publish the snapshot before active=true so the probe — which reads
+	// active first, then snapshot — never sees active without a snapshot.
+	a.snapshot.Store(&pacerSnapshot{
+		inputAtStart:  a.inputAccum.Load(),
+		outputAtStart: a.outputAccum.Load(),
+		targetDrift:   drift,
+	})
+
+	logger.Debugw("starting audio pacer", "targetDrift", drift, "rate", rate)
+	a.pitch.SetArg("tempo", fmt.Sprintf("%.2f", rate))
+	a.active.Store(true)
+}
+
+// boost switches the pitch element to a more aggressive rate
+func (a *audioPacer) boost() {
+	if a.pitch == nil || !a.active.Load() {
+		return
+	}
+	snap := a.snapshot.Load()
+	if snap == nil {
+		return
+	}
+	rate := pacerRate(snap.targetDrift, a.boostedRate)
+	a.pitch.SetArg("tempo", fmt.Sprintf("%.2f", rate))
+}
+
+// brake restores the base rate when drift falls back inside the soft budget
+func (a *audioPacer) brake() {
+	if a.pitch == nil || !a.active.Load() {
+		return
+	}
+	snap := a.snapshot.Load()
+	if snap == nil {
+		return
+	}
+	rate := pacerRate(snap.targetDrift, a.tempoAdjustmentRate)
+	a.pitch.SetArg("tempo", fmt.Sprintf("%.2f", rate))
+}
+
+// stop is the success path used by the src-pad probe when the in-flight
+// correction has reached its target. Returns true if this call won the
+// transition from active to idle; the caller must then notify the controller
+// via DriftProcessed. Concurrent stop / cancelOnFlush calls coalesce: only
+// one wins the Swap, the others see false and do nothing.
+func (a *audioPacer) stop() bool {
+	if a.pitch == nil {
+		return false
+	}
+	if !a.active.Swap(false) {
+		return false
+	}
+	a.pitch.SetArg("tempo", fmt.Sprintf("%.1f", 1.0))
+	return true
+}
+
+// cancelOnFlush is the abort path used when downstream is about to discard
+// the audio the in-flight correction has been applying to. The measurement
+// in inputAccum / outputAccum cannot be trusted across the flush boundary,
+// so the correction is abandoned: tempo returns to 1.0, the controller's
+// in-flight target is cleared (without crediting any compensation), and the
+// next SR drives a fresh correction. Returns true if this call won the
+// transition.
+func (a *audioPacer) cancelOnFlush() bool {
+	if a.pitch == nil {
+		return false
+	}
+	if !a.active.Swap(false) {
+		return false
+	}
+	a.pitch.SetArg("tempo", fmt.Sprintf("%.1f", 1.0))
+	return true
+}
+
+// pacerRate computes the tempo property value for the given drift direction
+// at the given per-step adjustment rate. drift>0 means audio is ahead of wall
+// clock, so tempo<1 (slow down); drift<0 means audio is behind, so tempo>1.
+func pacerRate(drift time.Duration, adjustment float64) float64 {
+	if drift > 0 {
+		return 1 - adjustment
+	}
+	return 1 + adjustment
+}

--- a/pkg/pipeline/builder/audio_pacer.go
+++ b/pkg/pipeline/builder/audio_pacer.go
@@ -47,12 +47,7 @@ type audioPacer struct {
 	snapshot atomic.Pointer[pacerSnapshot]
 }
 
-// pacerSnapshot is the per-correction baseline captured at start(). It is
-// stored atomically as a unit so the probe never observes a torn snapshot
-// even if start() is mis-invoked while a correction is still active. The
-// active check in start() prevents this today, but treating the snapshot as
-// an atomic value removes the implicit ordering dependency between
-// active.Store and the snapshot field writes.
+// pacerSnapshot is the per-correction baseline captured at start()
 type pacerSnapshot struct {
 	inputAtStart  int64
 	outputAtStart int64

--- a/pkg/pipeline/source/track_worker.go
+++ b/pkg/pipeline/source/track_worker.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/frostbyte73/core"
+
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/errors"
 	"github.com/livekit/egress/pkg/gstreamer"
@@ -485,7 +486,7 @@ func (s *SDKSource) createWriterForOp(op Operation) (*sdk.AppWriter, *config.Tra
 	switch ts.MimeType {
 	case types.MimeTypeOpus, types.MimeTypePCMU, types.MimeTypePCMA:
 		if s.AudioTempoController.Enabled {
-			c := tempo.NewController()
+			c := tempo.NewController(s.Latency.AudioMixerLatency)
 			ts.TempoController = c
 			tc = c
 		}

--- a/pkg/pipeline/tempo/controller.go
+++ b/pkg/pipeline/tempo/controller.go
@@ -58,13 +58,17 @@ func (tc *Controller) Tier() Tier {
 	return tc.tier
 }
 
-// OnTierChange sets a callback fired whenever the tier transitions (up or down).
-// Independent of OnDriftDetectedCallback: tier transitions fire even when a
-// correction is already in flight, so the pacer can escalate without restart.
+// OnTierChange sets the callback. If the tier is already above TierNormal,
+// it's invoked immediately with the current tier.
 func (tc *Controller) OnTierChange(cb func(Tier)) {
 	tc.mu.Lock()
 	tc.tierCB = cb
+	cur := tc.tier
 	tc.mu.Unlock()
+
+	if cb != nil && cur != TierNormal {
+		cb(cur)
+	}
 }
 
 // tierFor returns the tier for the given effective drift. Caller-side helper;

--- a/pkg/pipeline/tempo/controller.go
+++ b/pkg/pipeline/tempo/controller.go
@@ -11,6 +11,16 @@ const (
 	DefaultThreshold = 10 * time.Millisecond
 )
 
+// Tier indicates how far effective drift has grown relative to the configured
+// budgets. The pacer / caller wires escalation behavior to tier transitions.
+type Tier int
+
+const (
+	TierNormal Tier = iota // |effective drift| < soft budget
+	TierSoft               // soft budget exceeded; pacer should boost
+	TierHard               // hard budget exceeded; caller should reset
+)
+
 // Controller tracks the current drift between a sender's clock and the
 // receiver's clock and drives tempo adjustments to close the gap.
 //
@@ -24,10 +34,64 @@ type Controller struct {
 	corrected time.Duration // sum of all corrections applied by the pacer
 	current   time.Duration // correction currently in progress (0 if idle)
 
-	cb func(time.Duration) // invoked with correction amount to apply
+	softCap    time.Duration
+	hardCap    time.Duration
+	maxLatency time.Duration
+	tier       Tier
+
+	cb     func(time.Duration) // invoked with correction amount to apply
+	tierCB func(Tier)          // invoked on tier transitions
 }
 
-func NewController() *Controller { return &Controller{} }
+func NewController(maxLatency time.Duration) *Controller {
+	return &Controller{
+		softCap:    maxLatency / 2,
+		hardCap:    maxLatency * 3 / 4,
+		maxLatency: maxLatency,
+	}
+}
+
+// Tier returns the current tier based on the latest observed effective drift.
+func (tc *Controller) Tier() Tier {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	return tc.tier
+}
+
+// OnTierChange sets a callback fired whenever the tier transitions (up or down).
+// Independent of OnDriftDetectedCallback: tier transitions fire even when a
+// correction is already in flight, so the pacer can escalate without restart.
+func (tc *Controller) OnTierChange(cb func(Tier)) {
+	tc.mu.Lock()
+	tc.tierCB = cb
+	tc.mu.Unlock()
+}
+
+// tierFor returns the tier for the given effective drift. Caller-side helper;
+// does not touch state.
+func (tc *Controller) tierFor(effective time.Duration) Tier {
+	abs := effective.Abs()
+	switch {
+	case abs >= tc.hardCap:
+		return TierHard
+	case abs >= tc.softCap:
+		return TierSoft
+	default:
+		return TierNormal
+	}
+}
+
+// updateTierLocked recomputes the tier from effective drift and returns
+// (changed, newTier, callback). Caller must hold tc.mu and invoke the callback
+// after releasing it.
+func (tc *Controller) updateTierLocked(effective time.Duration) (bool, Tier, func(Tier)) {
+	next := tc.tierFor(effective)
+	if next == tc.tier {
+		return false, next, nil
+	}
+	tc.tier = next
+	return true, next, tc.tierCB
+}
 
 // SetDrift updates the current observed drift. If no correction is active
 // and the effective (uncorrected) drift exceeds the threshold, a new
@@ -36,19 +100,24 @@ func (tc *Controller) SetDrift(drift time.Duration) {
 	tc.mu.Lock()
 	tc.drift = drift
 
+	effective := drift - tc.corrected
+
 	var toStart time.Duration
 	if tc.current == 0 {
-		effective := drift - tc.corrected
 		if effective.Abs() >= DefaultThreshold {
 			toStart = effective
 			tc.current = effective
 		}
 	}
+	tierChanged, newTier, tierCB := tc.updateTierLocked(effective)
 	cb := tc.cb
 	tc.mu.Unlock()
 
 	if toStart != 0 && cb != nil {
 		cb(toStart)
+	}
+	if tierChanged && tierCB != nil {
+		tierCB(newTier)
 	}
 }
 
@@ -73,11 +142,15 @@ func (tc *Controller) DriftProcessed(actual time.Duration) {
 		toStart = effective
 		tc.current = effective
 	}
+	tierChanged, newTier, tierCB := tc.updateTierLocked(effective)
 	cb := tc.cb
 	tc.mu.Unlock()
 
 	if toStart != 0 && cb != nil {
 		cb(toStart)
+	}
+	if tierChanged && tierCB != nil {
+		tierCB(newTier)
 	}
 }
 

--- a/pkg/pipeline/tempo/controller_test.go
+++ b/pkg/pipeline/tempo/controller_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestSetDriftStartsAboveThreshold(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -21,7 +21,7 @@ func TestSetDriftStartsAboveThreshold(t *testing.T) {
 }
 
 func TestBelowThresholdNoop(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -33,7 +33,7 @@ func TestBelowThresholdNoop(t *testing.T) {
 }
 
 func TestThresholdCrossing(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -47,7 +47,7 @@ func TestThresholdCrossing(t *testing.T) {
 }
 
 func TestNoNewCorrectionWhileActive(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -61,7 +61,7 @@ func TestNoNewCorrectionWhileActive(t *testing.T) {
 }
 
 func TestDriftProcessedStartsNext(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -81,7 +81,7 @@ func TestDriftProcessedStartsNext(t *testing.T) {
 }
 
 func TestDriftProcessedNoFollowUp(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -98,7 +98,7 @@ func TestDriftProcessedNoFollowUp(t *testing.T) {
 }
 
 func TestNegativeDrift(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -111,7 +111,7 @@ func TestNegativeDrift(t *testing.T) {
 
 func TestOngoingDriftCorrection(t *testing.T) {
 	// Simulate clock skew: drift grows by 10ms per SR
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -124,7 +124,7 @@ func TestOngoingDriftCorrection(t *testing.T) {
 		t.Fatalf("second correction: got %v", calls)
 	}
 
-	tc.SetDrift(30 * time.Millisecond) // drift grew again
+	tc.SetDrift(30 * time.Millisecond)       // drift grew again
 	tc.DriftProcessed(10 * time.Millisecond) // effective = 30-20 = 10ms → starts 10ms
 	if len(calls) != 3 || calls[2] != 10*time.Millisecond {
 		t.Fatalf("third correction: got %v", calls)
@@ -136,7 +136,7 @@ func TestOngoingDriftCorrection(t *testing.T) {
 }
 
 func TestImmediateCallbackOnRegister(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	// Arm a correction before registering callback
 	tc.SetDrift(20 * time.Millisecond)
@@ -153,12 +153,12 @@ func TestImmediateCallbackOnRegister(t *testing.T) {
 func TestOvershootDoesNotFlipDirection(t *testing.T) {
 	// Probe trips at first buffer past target; reported actual will overshoot.
 	// Controller must not interpret that as a sign reversal and counter-correct.
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
 
-	tc.SetDrift(15 * time.Millisecond) // starts 15ms correction
+	tc.SetDrift(15 * time.Millisecond)       // starts 15ms correction
 	tc.DriftProcessed(25 * time.Millisecond) // overshoots target by 10ms
 
 	if len(calls) != 1 {
@@ -171,7 +171,7 @@ func TestOvershootDoesNotFlipDirection(t *testing.T) {
 
 func TestOvershootThenDriftReverses(t *testing.T) {
 	// After overshoot clamps corrected to drift, a real reversal must still fire.
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -186,7 +186,7 @@ func TestOvershootThenDriftReverses(t *testing.T) {
 }
 
 func TestNegativeOvershootDoesNotFlipDirection(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -203,7 +203,7 @@ func TestNegativeOvershootDoesNotFlipDirection(t *testing.T) {
 }
 
 func TestZeroDriftNoop(t *testing.T) {
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	var calls []time.Duration
 	tc.OnDriftDetectedCallback(func(d time.Duration) { calls = append(calls, d) })
@@ -220,7 +220,7 @@ func TestCancelInFlightClearsCurrent(t *testing.T) {
 	// target. This is the load-bearing property for the source-bin-reset
 	// path: when the audio downstream of the pacer is discarded, the partial
 	// compensation cannot be re-applied by a fresh pacer with the same target.
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	cb1Calls := []time.Duration{}
 	tc.OnDriftDetectedCallback(func(d time.Duration) { cb1Calls = append(cb1Calls, d) })
@@ -259,7 +259,7 @@ func TestCancelInFlightClearsCurrent(t *testing.T) {
 func TestCancelInFlightWhenIdleIsNoop(t *testing.T) {
 	// Calling CancelInFlight when no correction is in flight must not corrupt
 	// state. resetAudioAppSrcBin calls it unconditionally.
-	tc := NewController()
+	tc := NewController(1200 * time.Millisecond)
 
 	tc.CancelInFlight()
 	if got := tc.Processed(); got != 0 {
@@ -271,5 +271,127 @@ func TestCancelInFlightWhenIdleIsNoop(t *testing.T) {
 	tc.SetDrift(20 * time.Millisecond)
 	if len(calls) != 1 || calls[0] != 20*time.Millisecond {
 		t.Fatalf("controller must still arm after idle CancelInFlight: got %v", calls)
+	}
+}
+
+func TestTierNormalBelowSoftBudget(t *testing.T) {
+	tc := NewController(1200 * time.Millisecond)
+
+	var tiers []Tier
+	tc.OnTierChange(func(tier Tier) { tiers = append(tiers, tier) })
+
+	tc.SetDrift(100 * time.Millisecond) // well below 500ms soft budget
+
+	if got := tc.Tier(); got != TierNormal {
+		t.Fatalf("tier: got %v, want TierNormal", got)
+	}
+	if len(tiers) != 0 {
+		t.Fatalf("no tier change expected, got %v", tiers)
+	}
+}
+
+func TestTierCrossSoftBudget(t *testing.T) {
+	tc := NewController(1200 * time.Millisecond)
+
+	var tiers []Tier
+	tc.OnTierChange(func(tier Tier) { tiers = append(tiers, tier) })
+
+	tc.SetDrift(600 * time.Millisecond) // above 500ms soft budget
+
+	if got := tc.Tier(); got != TierSoft {
+		t.Fatalf("tier: got %v, want TierSoft", got)
+	}
+	if len(tiers) != 1 || tiers[0] != TierSoft {
+		t.Fatalf("tier transitions: got %v, want [TierSoft]", tiers)
+	}
+}
+
+func TestTierCrossHardBudget(t *testing.T) {
+	tc := NewController(1200 * time.Millisecond)
+
+	var tiers []Tier
+	tc.OnTierChange(func(tier Tier) { tiers = append(tiers, tier) })
+
+	tc.SetDrift(2500 * time.Millisecond) // above 2s hard budget
+
+	if got := tc.Tier(); got != TierHard {
+		t.Fatalf("tier: got %v, want TierHard", got)
+	}
+	if len(tiers) == 0 || tiers[len(tiers)-1] != TierHard {
+		t.Fatalf("tier transitions should end at TierHard: got %v", tiers)
+	}
+}
+
+func TestTierDropsBackToNormalAfterCorrection(t *testing.T) {
+	tc := NewController(1200 * time.Millisecond)
+
+	var tiers []Tier
+	tc.OnTierChange(func(tier Tier) { tiers = append(tiers, tier) })
+
+	tc.SetDrift(600 * time.Millisecond)       // soft
+	tc.DriftProcessed(600 * time.Millisecond) // effective = 0, back to normal
+
+	if got := tc.Tier(); got != TierNormal {
+		t.Fatalf("tier after correction: got %v, want TierNormal", got)
+	}
+	if len(tiers) != 2 || tiers[0] != TierSoft || tiers[1] != TierNormal {
+		t.Fatalf("tier transitions: got %v, want [TierSoft, TierNormal]", tiers)
+	}
+}
+
+func TestTierFollowsEffectiveDrift(t *testing.T) {
+	// Tier depends on |drift - corrected|, not raw drift.
+	tc := NewController(1200 * time.Millisecond)
+
+	tc.SetDrift(600 * time.Millisecond)
+	tc.DriftProcessed(500 * time.Millisecond) // effective = 100ms, below soft
+
+	if got := tc.Tier(); got != TierNormal {
+		t.Fatalf("tier: got %v, want TierNormal (effective drift below budget)", got)
+	}
+}
+
+func TestTierNegativeDrift(t *testing.T) {
+	tc := NewController(1200 * time.Millisecond)
+
+	tc.SetDrift(-600 * time.Millisecond)
+	if got := tc.Tier(); got != TierSoft {
+		t.Fatalf("tier with negative drift: got %v, want TierSoft", got)
+	}
+}
+
+func TestTierChangeFiresMidCorrection(t *testing.T) {
+	// Drift growing past a budget while a correction is in flight must still
+	// fire OnTierChange — the pacer needs to escalate even though no new
+	// correction starts (current != 0 blocks the OnDriftDetectedCallback path).
+	tc := NewController(1200 * time.Millisecond)
+
+	var tiers []Tier
+	tc.OnTierChange(func(tier Tier) { tiers = append(tiers, tier) })
+
+	tc.SetDrift(50 * time.Millisecond)  // starts correction at normal tier
+	tc.SetDrift(600 * time.Millisecond) // grows past soft mid-flight
+
+	if got := tc.Tier(); got != TierSoft {
+		t.Fatalf("tier: got %v, want TierSoft", got)
+	}
+	if len(tiers) != 1 || tiers[0] != TierSoft {
+		t.Fatalf("tier transitions: got %v, want [TierSoft]", tiers)
+	}
+}
+
+func TestTierNoFireWhenStable(t *testing.T) {
+	// Repeated SetDrift calls at the same tier must not re-fire OnTierChange.
+	tc := NewController(1200 * time.Millisecond)
+
+	var tiers []Tier
+	tc.OnTierChange(func(tier Tier) { tiers = append(tiers, tier) })
+
+	tc.SetDrift(600 * time.Millisecond)
+	tc.SetDrift(700 * time.Millisecond)
+	tc.SetDrift(800 * time.Millisecond)
+
+	if len(tiers) != 1 || tiers[0] != TierSoft {
+		t.Fatalf("tier transitions: got %v, want [TierSoft] (no re-fire within same tier)", tiers)
 	}
 }


### PR DESCRIPTION
The old pacer/tempo controller had a hard limit on how much it could adjust for drift, to prevent something from consistently drifting in one direction until the audio mixer dropped it. In that scenario, the track would be permenently out of sync - thIs will instead ramp up the adjustment rate if the track starts drifting too far away