### PR TITLE
Gracefully drain egress on high CPU before hard kill

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -190,6 +190,9 @@ func runHandler(_ context.Context, c *cli.Command) error {
 		return err
 	}
 
+	gracefulChan := make(chan os.Signal, 1)
+	signal.Notify(gracefulChan, syscall.SIGTERM)
+
 	killChan := make(chan os.Signal, 1)
 	signal.Notify(killChan, syscall.SIGINT)
 
@@ -202,9 +205,14 @@ func runHandler(_ context.Context, c *cli.Command) error {
 	}
 
 	go func() {
-		sig := <-killChan
-		logger.Infow("exit requested, stopping recording and shutting down", "signal", sig)
-		h.Kill()
+		select {
+		case <-gracefulChan:
+			logger.Infow("graceful stop requested (CPU limit), draining and uploading")
+			h.GracefulStop()
+		case sig := <-killChan:
+			logger.Infow("exit requested, stopping recording and shutting down", "signal", sig)
+			h.Kill()
+		}
 	}()
 
 	h.Run()

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/ipc"
 	"github.com/livekit/egress/pkg/pipeline"
+	"github.com/livekit/egress/pkg/types"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
@@ -172,6 +173,16 @@ func (h *Handler) Kill() {
 		return
 	}
 	h.controller.SendEOS(context.Background(), livekit.EndReasonKilled)
+}
+
+// GracefulStop sends EOS with EndReasonCPULimit without marking the egress as failed.
+// The pipeline drains, uploads complete, and the egress exits with status COMPLETE.
+func (h *Handler) GracefulStop() {
+	<-h.initialized.Watch()
+	if h.controller == nil {
+		return
+	}
+	h.controller.SendEOS(context.Background(), types.EndReasonCPULimit)
 }
 
 func (h *Handler) shouldInjectEgressFailure() bool {

--- a/pkg/service/process.go
+++ b/pkg/service/process.go
@@ -53,6 +53,7 @@ type ProcessManager interface {
 	GetGRPCClient(egressID string) (ipc.EgressHandlerClient, error)
 	KillAll()
 	AbortProcess(egressID string, err error)
+	GracefulStop(egressID string)
 	KillProcess(egressID string, reason string, err error)
 	GetKillReason(egressID string) string
 	ProcessFinished(egressID string)
@@ -222,6 +223,16 @@ func (pm *processManager) AbortProcess(egressID string, err error) {
 	logger.Infow("aborting egress completed", "egressID", egressID)
 }
 
+func (pm *processManager) GracefulStop(egressID string) {
+	logger.Infow("gracefully stopping egress due to high CPU", "egressID", egressID)
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	if h, ok := pm.activeHandlers[egressID]; ok {
+		h.gracefulStop()
+	}
+}
+
 func (pm *processManager) KillProcess(egressID string, reason string, err error) {
 	logger.Infow("killing egress", err, "egressID", egressID)
 	pm.mu.Lock()
@@ -301,4 +312,12 @@ func (p *Process) kill(e error) {
 			}
 		}
 	})
+}
+
+// gracefulStop sends SIGTERM to the handler process, triggering a graceful pipeline drain
+// and upload before exit. The egress completes with status COMPLETE rather than FAILED.
+func (p *Process) gracefulStop() {
+	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		logger.Errorw("failed to gracefully stop process", err, "egressID", p.req.EgressId)
+	}
 }

--- a/pkg/service/servicefakes/fake_process_manager.go
+++ b/pkg/service/servicefakes/fake_process_manager.go
@@ -91,6 +91,11 @@ type FakeProcessManager struct {
 	getStatusArgsForCall []struct {
 		arg1 map[string]interface{}
 	}
+	GracefulStopStub        func(string)
+	gracefulStopMutex       sync.RWMutex
+	gracefulStopArgsForCall []struct {
+		arg1 string
+	}
 	HandlerStartedStub        func(string) error
 	handlerStartedMutex       sync.RWMutex
 	handlerStartedArgsForCall []struct {
@@ -638,6 +643,38 @@ func (fake *FakeProcessManager) KillAllCalls(stub func()) {
 	fake.killAllMutex.Lock()
 	defer fake.killAllMutex.Unlock()
 	fake.KillAllStub = stub
+}
+
+func (fake *FakeProcessManager) GracefulStop(arg1 string) {
+	fake.gracefulStopMutex.Lock()
+	fake.gracefulStopArgsForCall = append(fake.gracefulStopArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.GracefulStopStub
+	fake.recordInvocation("GracefulStop", []interface{}{arg1})
+	fake.gracefulStopMutex.Unlock()
+	if stub != nil {
+		fake.GracefulStopStub(arg1)
+	}
+}
+
+func (fake *FakeProcessManager) GracefulStopCallCount() int {
+	fake.gracefulStopMutex.RLock()
+	defer fake.gracefulStopMutex.RUnlock()
+	return len(fake.gracefulStopArgsForCall)
+}
+
+func (fake *FakeProcessManager) GracefulStopCalls(stub func(string)) {
+	fake.gracefulStopMutex.Lock()
+	defer fake.gracefulStopMutex.Unlock()
+	fake.GracefulStopStub = stub
+}
+
+func (fake *FakeProcessManager) GracefulStopArgsForCall(i int) string {
+	fake.gracefulStopMutex.RLock()
+	defer fake.gracefulStopMutex.RUnlock()
+	argsForCall := fake.gracefulStopArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeProcessManager) KillProcess(arg1 string, arg2 string, arg3 error) {

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -39,6 +39,8 @@ const (
 	cpuHoldDuration         = time.Second * 15
 	defaultKillThreshold    = 0.95
 	minKillDuration         = 10
+	gracefulStopThreshold   = 0.85
+	minGracefulStopDuration = 5
 	gb                      = 1024.0 * 1024.0 * 1024.0
 	pulseClientHold         = 4
 	memoryHeadroomGB        = 1.0
@@ -49,6 +51,7 @@ type Service interface {
 	IsIdle() bool
 	IsDisabled() bool
 	IsTerminating() bool
+	GracefulStop(string)
 	KillProcess(egressID string, reason string, err error)
 }
 
@@ -74,17 +77,18 @@ type Monitor struct {
 	pendingPulseClients atomic.Int32
 	pendingMemoryUsage  atomic.Float64
 
-	mu                deadlock.Mutex
-	highCPUDuration   int
-	highMemoryStart   time.Time
-	lastMemoryDump    time.Time
-	pending           map[string]*processStats
-	procStats         map[int]*processStats
-	memoryUsage       float64
-	cgroupUsageBytes  uint64
-	cgroupOK          bool
-	cgroupErrorLogged atomic.Bool
-	pulseErrorLogged  atomic.Bool
+	mu                      deadlock.Mutex
+	highCPUDuration         int
+	highCPUGracefulDuration int
+	highMemoryStart         time.Time
+	lastMemoryDump          time.Time
+	pending                 map[string]*processStats
+	procStats               map[int]*processStats
+	memoryUsage             float64
+	cgroupUsageBytes        uint64
+	cgroupOK                bool
+	cgroupErrorLogged       atomic.Bool
+	pulseErrorLogged        atomic.Bool
 }
 
 type processStats struct {
@@ -654,10 +658,27 @@ func (m *Monitor) updateEgressStats(stats *hwstats.ProcStats) {
 		if m.requests.Load() > 1 {
 			m.highCPUDuration++
 			if m.highCPUDuration >= minKillDuration {
-				m.svc.KillProcess(maxCPUEgress, ResultKilledCPU, errors.ErrCPUExhausted(maxCPU))
+				m.svc.GracefulStop(maxCPUEgress)
 				m.highCPUDuration = 0
+				m.highCPUGracefulDuration = 0
 			}
 		}
+	} else if load > gracefulStopThreshold {
+		logger.Warnw("cpu usage approaching limit, gracefully stopping one egress", nil,
+			"cpu", load,
+			"requests", m.requests.Load(),
+		)
+
+		if m.requests.Load() > 1 {
+			m.highCPUGracefulDuration++
+			if m.highCPUGracefulDuration >= minGracefulStopDuration {
+				m.svc.GracefulStop(maxCPUEgress)
+				m.highCPUGracefulDuration = 0
+			}
+		}
+	} else {
+		m.highCPUDuration = 0
+		m.highCPUGracefulDuration = 0
 	}
 
 	totalMemory := 0

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -23,6 +23,10 @@ type OutputType string
 type FileExtension string
 
 const (
+	// EndReasonCPULimit is the end reason set when egress is gracefully stopped due to high CPU.
+	// Distinct from EndReasonAPI ("StopEgress API") so webhooks can identify CPU-triggered stops.
+	EndReasonCPULimit = "CPU limit reached"
+
 	// request types
 	RequestTypeTemplate = "template"
 	RequestTypeWeb      = "web"


### PR DESCRIPTION
## What

Today, when an instance crosses the CPU kill threshold (`0.95`), the monitor calls `KillProcess`, which terminates the offending egress and reports it as **FAILED** — losing whatever was recorded.

This PR adds a **graceful** path that drains and uploads the egress instead, so it finishes as **COMPLETE** with its output preserved, and only falls back to the existing hard kill when load is critical.

## How

- **Soft threshold (`0.85`)**: once load holds above it for a few update cycles, the monitor picks the highest-CPU egress and gracefully stops it.
- **Hard threshold (`0.95`)**: the action is switched from `KillProcess` to `GracefulStop` as well, so output is preserved wherever possible (the SIGINT/`Kill` path is still available for true emergencies).
- `cmd/server` now listens for **SIGTERM** → `Handler.GracefulStop`, leaving **SIGINT** for the existing immediate `Kill`.
- `ProcessManager.GracefulStop` signals SIGTERM to the handler process, triggering a normal pipeline drain + upload.
- A new end reason `"CPU limit reached"` (`types.EndReasonCPULimit`) is set on EOS so webhooks can distinguish CPU-triggered stops from a `StopEgress` API call. It only annotates the result; the ACTIVE → ENDING → COMPLETE flow is unchanged.

The generated `servicefakes` fake is updated for the new `ProcessManager` method.

## Notes

- Behavior below `0.85` is unchanged.
- `gofmt` clean. Verified the code compiles and interfaces are satisfied locally; I was not able to run the GStreamer-dependent integration tests in my environment, so a CI run / maintainer test is appreciated.
- Thresholds (`0.85` / `0.95`) are currently constants — happy to move them into `CPUCostConfig` if you'd prefer them configurable.