### PR TITLE
Preserve leftover recordings on container restart

### DIFF
--- a/build/egress/entrypoint.sh
+++ b/build/egress/entrypoint.sh
@@ -15,7 +15,11 @@
 
 set -euo pipefail
 
-# Clean out tmp
+# Preserve any recordings from the previous session before cleanup
+if [ -d /home/egress/tmp ] && [ "$(ls -A /home/egress/tmp 2>/dev/null)" ]; then
+    mkdir -p /home/egress/recovered
+    cp -r /home/egress/tmp/. /home/egress/recovered/
+fi
 rm -rf /home/egress/tmp/*
 
 # Start pulseaudio


### PR DESCRIPTION
## What

The entrypoint wipes `/home/egress/tmp` on every start. If a container restarts mid-egress (crash, OOM, redeploy), the in-progress recording in `tmp` is deleted before anyone can recover it.

## How

Before the cleanup, if `tmp` is non-empty, copy its contents to `/home/egress/recovered` so operators can retrieve partial output from the previous session:

```sh
if [ -d /home/egress/tmp ] && [ "$(ls -A /home/egress/tmp 2>/dev/null)" ]; then
    mkdir -p /home/egress/recovered
    cp -r /home/egress/tmp/. /home/egress/recovered/
fi
rm -rf /home/egress/tmp/*
```

## Notes

- When `tmp` is empty (the normal case), nothing is copied and startup is unchanged.
- `recovered/` is not auto-pruned — open to a retention/size cap if you'd prefer one (e.g. clearing it after N restarts or above a size threshold), happy to adjust.