### PR TITLE
Log redis sentinel messages as debug level 

### DIFF
--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -19,11 +19,14 @@ import (
 	"strings"
 	"time"
 
+	goredis "github.com/redis/go-redis/v9"
+
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/logger/medialogutils"
 	"github.com/livekit/protocol/redis"
 	lksdk "github.com/livekit/server-sdk-go/v2"
 
+	"github.com/livekit/egress/pkg/logging"
 	"github.com/livekit/egress/pkg/types"
 )
 
@@ -133,6 +136,7 @@ func (c *BaseConfig) InitLogger(serviceName string, values ...interface{}) error
 	l := zl.WithValues(values...)
 
 	logger.SetLogger(l, serviceName)
+	goredis.SetLogger(logging.NewRedisLogger(logger.GetLogger().WithComponent("redis")))
 	lksdk.SetLogger(medialogutils.NewOverrideLogger(logger.GetLogger().WithComponent("lksdk")))
 	return nil
 }

--- a/pkg/logging/redis.go
+++ b/pkg/logging/redis.go
@@ -1,0 +1,44 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	lklogger "github.com/livekit/protocol/logger"
+)
+
+type RedisLogger struct {
+	logger lklogger.Logger
+}
+
+func NewRedisLogger(l lklogger.Logger) RedisLogger {
+	return RedisLogger{logger: l}
+}
+
+func (l RedisLogger) Printf(_ context.Context, format string, v ...interface{}) {
+	msg := fmt.Sprintf(format, v...)
+	if IsRedisSentinelDiscoveryMessage(msg) {
+		l.logger.Debugw(msg)
+		return
+	}
+
+	l.logger.Warnw(msg, nil)
+}
+
+func IsRedisSentinelDiscoveryMessage(msg string) bool {
+	if !strings.Contains(msg, "sentinel: ") {
+		return false
+	}
+
+	switch {
+	case strings.Contains(msg, "sentinel: selected addr="):
+		return true
+	case strings.Contains(msg, "sentinel: new master="):
+		return true
+	case strings.Contains(msg, "sentinel: GetMasterAddrByName ") && strings.HasSuffix(msg, " failed: context canceled"):
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/logging/redis_test.go
+++ b/pkg/logging/redis_test.go
@@ -1,0 +1,50 @@
+package logging
+
+import "testing"
+
+func TestIsRedisSentinelDiscoveryMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{
+			name: "selected sentinel",
+			msg:  "sentinel: selected addr=10.0.1.62:26379 masterAddr=10.0.1.61:6379",
+			want: true,
+		},
+		{
+			name: "new master",
+			msg:  "sentinel: new master=\"voice-redis\" addr=\"10.0.1.61:6379\"",
+			want: true,
+		},
+		{
+			name: "canceled parallel sentinel lookup",
+			msg:  "sentinel: GetMasterAddrByName addr=10.0.1.63:26379, master=\"voice-redis\" failed: context canceled",
+			want: true,
+		},
+		{
+			name: "connection refused remains diagnostic",
+			msg:  "sentinel: GetMasterAddrByName addr=10.0.1.63:26379, master=\"voice-redis\" failed: dial tcp 10.0.1.63:26379: connect: connection refused",
+			want: false,
+		},
+		{
+			name: "deadline exceeded remains diagnostic",
+			msg:  "sentinel: GetMasterAddrByName addr=10.0.1.63:26379, master=\"voice-redis\" failed: context deadline exceeded",
+			want: false,
+		},
+		{
+			name: "non sentinel redis line remains diagnostic",
+			msg:  "redis: unable to connect to redis: all sentinels specified in configuration are unreachable",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRedisSentinelDiscoveryMessage(tt.msg); got != tt.want {
+				t.Fatalf("IsRedisSentinelDiscoveryMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
go-redis writes Sentinel discovery diagnostics to stderr by default. In Egress handler processes, stderr is consumed by HandlerLogger and any unparsed line is emitted as an error, which turns expected parallel Sentinel lookup cancellation into misleading error logs.

Install a go-redis logger backed by the Egress logger so Redis diagnostics keep their own severity. Expected Sentinel discovery chatter is logged at debug while real Redis diagnostics remain visible as warnings.