### PR TITLE
chromedp flag support mute-audio and ignore-certificate-errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,15 @@ storage:
     bucket: bucket to upload files to
 
 # dev/debugging fields
-insecure: can be used to connect to an insecure websocket (default false)
+insecure: can be used to connect to an insecure websocket (default false) , Deprecated use secure
+secure:
+  insecure: can be used to connect to an insecure websocket (default false)
+  ignore_certificate_errors: can be used to use self-signed certificates  (default false)
+  allow_running_insecure_content:  can be used to allow load http content from https  (default false)
+
+mute_audio: disables all audio output from the browser instance.   (default false)
+  
+
 debug:
   enable_profiling: create and upload pipeline dot file and pprof file on pipeline failure
   s3: upload config for dotfiles (see above)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ storage:
 # dev/debugging fields
 insecure: can be used to connect to an insecure websocket (default false) , Deprecated use secure
 secure:
-  insecure: can be used to connect to an insecure websocket (default false)
+  disable-web-security: can be used to connect to an insecure websocket (default false)
   ignore_certificate_errors: can be used to use self-signed certificates  (default false)
   allow_running_insecure_content:  can be used to allow load http content from https  (default false)
 

--- a/README.md
+++ b/README.md
@@ -181,14 +181,16 @@ Create a directory to mount. In this example, we will use `~/egress-test`.
 Create a config.yaml in the above directory.
 
 - `redis` and `ws_url` should use the above IP instead of `localhost`
-- `insecure` should be set to true
+- `secure.disable-web-security` and `secure.allow_running_insecure_content` should be set to true
 
 ```yaml
 log_level: debug
 api_key: your-api-key
 api_secret: your-api-secret
 ws_url: ws://192.168.65.2:7880
-insecure: true
+secure:
+  disable-web-security: true
+  allow_running_insecure_content: true
 redis:
   address: 192.168.65.2:6379
 ```

--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -51,13 +51,13 @@ type BaseConfig struct {
 	IOWorkers            int            `yaml:"io_workers"`             // number of IO update workers
 	MuteAudio            bool           `yaml:"mute_audio"`             // disables all audio output from the browser instance.
 
-	SessionLimits          `yaml:"session_limits"` // session duration limits
-	StorageConfig          *StorageConfig          `yaml:"storage,omitempty"`          // storage config
-	BackupConfig           *StorageConfig          `yaml:"backup,omitempty"`           // backup config, for storage failures
-	S3AssumeRoleKey        string                  `yaml:"s3_assume_role_key"`         // if set, this key is used for S3 uploads to assume the role defined in the assume_role_arn field of the S3 config
-	S3AssumeRoleSecret     string                  `yaml:"s3_assume_role_secret"`      // if set, this secret is used for S3 uploads to assume the role defined in the assume_role_arn field of the S3 config
-	S3AssumeRoleArn        string                  `yaml:"s3_assume_role_arn"`         // if set, this arn is used by default for S3 uploads
-	S3AssumeRoleExternalID string                  `yaml:"s3_assume_role_external_id"` // if set, this external ID is used by default for S3 uploads
+	SessionLimits          `yaml:"session_limits"`                            // session duration limits
+	StorageConfig          *StorageConfig `yaml:"storage,omitempty"`          // storage config
+	BackupConfig           *StorageConfig `yaml:"backup,omitempty"`           // backup config, for storage failures
+	S3AssumeRoleKey        string         `yaml:"s3_assume_role_key"`         // if set, this key is used for S3 uploads to assume the role defined in the assume_role_arn field of the S3 config
+	S3AssumeRoleSecret     string         `yaml:"s3_assume_role_secret"`      // if set, this secret is used for S3 uploads to assume the role defined in the assume_role_arn field of the S3 config
+	S3AssumeRoleArn        string         `yaml:"s3_assume_role_arn"`         // if set, this arn is used by default for S3 uploads
+	S3AssumeRoleExternalID string         `yaml:"s3_assume_role_external_id"` // if set, this external ID is used by default for S3 uploads
 
 	// advanced
 	Insecure                      bool                                `yaml:"insecure"`                           // allow chrome to connect to an insecure websocket, bypasses chrome LNA checks
@@ -81,15 +81,15 @@ type SessionLimits struct {
 }
 
 type DebugConfig struct {
-	EnableProfiling     bool             `yaml:"enable_profiling"`      // create dot file and pprof on internal error
-	EnableTrackLogging  bool             `yaml:"enable_track_logging"`  // log packets and keyframes for each track
-	EnableStreamLogging bool             `yaml:"enable_stream_logging"` // log bytes and keyframes for each stream
-	EnableChromeLogging bool             `yaml:"enable_chrome_logging"` // log all chrome console events
-	StorageConfig       `yaml:",inline"` // upload config (S3, Azure, GCP, or AliOSS)
+	EnableProfiling     bool `yaml:"enable_profiling"`      // create dot file and pprof on internal error
+	EnableTrackLogging  bool `yaml:"enable_track_logging"`  // log packets and keyframes for each track
+	EnableStreamLogging bool `yaml:"enable_stream_logging"` // log bytes and keyframes for each stream
+	EnableChromeLogging bool `yaml:"enable_chrome_logging"` // log all chrome console events
+	StorageConfig       `yaml:",inline"`                    // upload config (S3, Azure, GCP, or AliOSS)
 }
 
 type SecureConfig struct {
-	DisableWebSecurity          bool `yaml:"insecure"`                       //disable-web-security
+	DisableWebSecurity          bool `yaml:"disable_web_security"`           //disable-web-security
 	IgnoreCertificateErrors     bool `yaml:"ignore_certificate_errors"`      // allow self-signed certificates
 	AllowRunningInsecureContent bool `yaml:"allow_running_insecure_content"` // allow Mixed Content,https load http
 }

--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -49,6 +49,7 @@ type BaseConfig struct {
 	IOUpdateTimeout      time.Duration  `yaml:"io_update_timeout"`      // timeout for UpdateEgress calls
 	IOSelectionTimeout   time.Duration  `yaml:"io_selection_timeout"`   // timeout for affinity stage of IO RPC
 	IOWorkers            int            `yaml:"io_workers"`             // number of IO update workers
+	MuteAudio            bool           `yaml:"mute_audio"`             // disables all audio output from the browser instance.
 
 	SessionLimits          `yaml:"session_limits"` // session duration limits
 	StorageConfig          *StorageConfig          `yaml:"storage,omitempty"`          // storage config
@@ -60,6 +61,7 @@ type BaseConfig struct {
 
 	// advanced
 	Insecure                      bool                                `yaml:"insecure"`                           // allow chrome to connect to an insecure websocket, bypasses chrome LNA checks
+	Secure                        SecureConfig                        `yaml:"secure"`                             // secure config like --ignore-certificate-errors,--allow-running-insecure-content
 	Debug                         DebugConfig                         `yaml:"debug"`                              // create dot file on internal error
 	ChromeFlags                   map[string]interface{}              `yaml:"chrome_flags"`                       // additional flags to pass to Chrome
 	Latency                       LatencyConfig                       `yaml:"latency"`                            // gstreamer latencies, modifying these may break the service
@@ -84,6 +86,12 @@ type DebugConfig struct {
 	EnableStreamLogging bool             `yaml:"enable_stream_logging"` // log bytes and keyframes for each stream
 	EnableChromeLogging bool             `yaml:"enable_chrome_logging"` // log all chrome console events
 	StorageConfig       `yaml:",inline"` // upload config (S3, Azure, GCP, or AliOSS)
+}
+
+type SecureConfig struct {
+	DisableWebSecurity          bool `yaml:"insecure"`                       //disable-web-security
+	IgnoreCertificateErrors     bool `yaml:"ignore_certificate_errors"`      // allow self-signed certificates
+	AllowRunningInsecureContent bool `yaml:"allow_running_insecure_content"` // allow Mixed Content,https load http
 }
 
 type LatencyConfig struct {

--- a/pkg/pipeline/source/web.go
+++ b/pkg/pipeline/source/web.go
@@ -263,8 +263,10 @@ func (s *WebSource) launchChrome(ctx context.Context, p *config.PipelineConfig) 
 
 		// config
 		chromedp.Flag("window-size", fmt.Sprintf("%d,%d", p.Width, p.Height)),
-		chromedp.Flag("disable-web-security", p.Insecure),
-		chromedp.Flag("allow-running-insecure-content", p.Insecure),
+		chromedp.Flag("disable-web-security", p.Insecure || p.Secure.DisableWebSecurity),
+		chromedp.Flag("allow-running-insecure-content", p.Insecure || p.Secure.AllowRunningInsecureContent),
+		chromedp.Flag("ignore-certificate-errors", p.Secure.IgnoreCertificateErrors),
+		chromedp.Flag("mute-audio", p.MuteAudio),
 		chromedp.Flag("no-sandbox", !p.EnableChromeSandbox),
 
 		// output


### PR DESCRIPTION
support " ignore-certificate-errors " flag  allow WebEgress  open page  use self-signed certificates
support "mute-audio" flag allow WebEgress record audio

Compatible with previous configurations "Insecure"


[chromedp can support --ignore-certificate-errors setting ?#517](https://github.com/livekit/egress/issues/517)

[[FEATURE] Add Support for --ignore-certificate-errors in LiveKit Egress for Self-Signed Certificates
 #804](https://github.com/livekit/egress/issues/804)
