### PR TITLE
Adding warn log on pts patching

### DIFF
--- a/pkg/pipeline/builder/keyframe_probe.go
+++ b/pkg/pipeline/builder/keyframe_probe.go
@@ -118,6 +118,7 @@ func (p *keyframeProbe) processBuffer(buffer *gst.Buffer) gst.PadProbeReturn {
 		restored := gst.ClockTime(uint64(p.lastSrcPTS))
 		buffer.SetPresentationTimestamp(restored)
 		pts = p.lastSrcPTS
+		p.logger.Warnw("restored missing pts from previous buffer", nil, "pts", restored)
 	} else {
 		p.lastSrcPTS = pts
 		p.lastSrcValid = true


### PR DESCRIPTION
This hasn't happend frequently - but since we added parse element to all topologies - it would be good to have indication that's still the case, logging warnning when PTS patching takes place.