### PR TITLE
Don't unref pad retreived using GetStaticPad API

### DIFF
--- a/pkg/pipeline/builder/keyframe_probe.go
+++ b/pkg/pipeline/builder/keyframe_probe.go
@@ -93,7 +93,6 @@ func (p *keyframeProbe) Close() {
 
 	if p.srcPad != nil {
 		p.srcPad.RemoveProbe(p.srcProbeID)
-		p.srcPad.Unref()
 		p.srcPad = nil
 	}
 }


### PR DESCRIPTION
Pad returned by GetStaticPad is fully transferred ownership wise to the gst go wrapper - which register finalizer to unref the object. Doing it explicitly  here is double unreferencing. In most of the cases it's verbose logging but could create issues under some edge cases