### PR TITLE
Log disconnect reason

### DIFF
--- a/pkg/pipeline/source/sdk.go
+++ b/pkg/pipeline/source/sdk.go
@@ -808,7 +808,7 @@ func (s *SDKSource) onDisconnectedWithReason(reason lksdk.DisconnectionReason) {
 		s.duplicateIdentity.Store(true)
 	}
 	if reason != lksdk.RoomClosed && reason != lksdk.LeaveRequested {
-		logger.Warnw("disconnected from room", nil, "reason", reason)
+		logger.Warnw("disconnected from room", nil, "reason", reason, "protoReason", s.room.DisconnectReason().String())
 	}
 	s.finished()
 }


### PR DESCRIPTION
A lot of disconnects could come with "other reason" value for reason parm. Logging disconnect reason from proto to be able to differentiate real reasons