### PR TITLE
Make stopping egress due to a room disconnect transparent

### DIFF
--- a/pkg/config/test_overrides.go
+++ b/pkg/config/test_overrides.go
@@ -4,4 +4,7 @@ package config
 type TestOverrides struct {
 	// inject failure for rooms containing this substring, useful for testing failure conditions
 	FailureInjectionRoom string `yaml:"failure_injection_room"`
+	// simulate a retryable room disconnect for rooms containing this substring, once
+	// the egress is active, to test that the partial output is uploaded on failure
+	DisconnectInjectionRoom string `yaml:"disconnect_injection_room"`
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -109,6 +109,7 @@ var (
 	ErrShuttingDown               = psrpc.NewErrorf(psrpc.Unavailable, "server is shutting down")
 	ErrNonRetryableOutput         = psrpc.NewErrorf(psrpc.FailedPrecondition, "output configuration does not support retry")
 	ErrHandlerFailedToStart       = psrpc.NewErrorf(psrpc.Internal, "handler failed to start")
+	ErrRoomConnectionFailed       = psrpc.NewErrorf(psrpc.Unavailable, "recording ended early: connection to room failed")
 )
 
 func PageLoadError(err string) error {

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -665,7 +665,11 @@ func (c *Controller) Close() {
 
 	case livekit.EgressStatus_EGRESS_ACTIVE,
 		livekit.EgressStatus_EGRESS_ENDING:
-		c.Info.SetComplete()
+		if err := c.endError(); err != nil {
+			c.Info.SetFailed(err)
+		} else {
+			c.Info.SetComplete()
+		}
 		fallthrough
 
 	case livekit.EgressStatus_EGRESS_LIMIT_REACHED,
@@ -959,6 +963,16 @@ func (c *Controller) IsDuplicateIdentity() bool {
 		return false
 	}
 	return sdkSrc.IsDuplicateIdentity()
+}
+
+// endError returns a non-nil error if the SDK source ended on a retryable room
+// disconnect, so the finalized partial output is reported failed.
+func (c *Controller) endError() error {
+	sdkSrc, ok := c.src.(*source.SDKSource)
+	if !ok {
+		return nil
+	}
+	return sdkSrc.GetEndError()
 }
 
 func (c *Controller) updateEndTime() {

--- a/pkg/pipeline/source/sdk.go
+++ b/pkg/pipeline/source/sdk.go
@@ -64,6 +64,7 @@ type SDKSource struct {
 	active            atomic.Int32
 	closed            core.Fuse
 	duplicateIdentity atomic.Bool
+	connectionFailed  atomic.Bool
 
 	startRecording core.Fuse
 	endRecording   core.Fuse
@@ -150,6 +151,10 @@ func NewSDKSource(ctx context.Context, p *config.PipelineConfig, callbacks *gstr
 	if err := s.joinRoom(); err != nil {
 		s.disconnectRoom()
 		return nil, err
+	}
+
+	if room := s.TestOverrides.DisconnectInjectionRoom; room != "" && strings.Contains(s.Info.RoomName, room) {
+		go s.injectDisconnectForTest()
 	}
 
 	return s, nil
@@ -809,12 +814,26 @@ func (s *SDKSource) onDisconnectedWithReason(reason lksdk.DisconnectionReason) {
 	}
 	if reason != lksdk.RoomClosed && reason != lksdk.LeaveRequested {
 		logger.Warnw("disconnected from room", nil, "reason", reason, "protoReason", s.room.DisconnectReason().String())
+
+		if reason == lksdk.Failed {
+			s.connectionFailed.Store(true)
+		}
 	}
 	s.finished()
 }
 
 func (s *SDKSource) IsDuplicateIdentity() bool {
 	return s.duplicateIdentity.Load()
+}
+
+// GetEndError returns a non-nil error when recording ended because the room
+// connection failed after the SDK exhausted its reconnect attempts. The partial
+// output should still be finalized and uploaded; the egress is marked failed.
+func (s *SDKSource) GetEndError() error {
+	if !s.connectionFailed.Load() {
+		return nil
+	}
+	return errors.ErrRoomConnectionFailed
 }
 
 func (s *SDKSource) finished() {

--- a/pkg/pipeline/source/sdk_testing.go
+++ b/pkg/pipeline/source/sdk_testing.go
@@ -1,0 +1,30 @@
+package source
+
+import (
+	"time"
+
+	"github.com/livekit/protocol/logger"
+	lksdk "github.com/livekit/server-sdk-go/v2"
+)
+
+const (
+	// test-only: delay between the egress becoming active and the injected
+	// retryable disconnect, so a non-empty partial recording is produced
+	disconnectInjectionDelay = time.Second * 5
+)
+
+// injectDisconnectForTest simulates a "connection to room failed" disconnect
+func (s *SDKSource) injectDisconnectForTest() {
+	select {
+	case <-s.startRecording.Watch():
+	case <-s.closed.Watch():
+		return
+	}
+	select {
+	case <-time.After(disconnectInjectionDelay):
+	case <-s.closed.Watch():
+		return
+	}
+	logger.Warnw("injecting connection failure for test", nil, "room", s.Info.RoomName)
+	s.onDisconnectedWithReason(lksdk.Failed)
+}

--- a/test/edge.go
+++ b/test/edge.go
@@ -118,6 +118,25 @@ func (r *Runner) testEdgeCases(t *testing.T) {
 				custom: r.testRoomCompositeDisconnectDuration,
 			},
 
+			// Room composite where the egress participant loses its room
+			// connection with a retryable reason. The partial recording must
+			// still be finalized and uploaded, and the egress reported FAILED
+			// so cloud can retry it.
+
+			{
+				name:        "RoomCompositeRetryableDisconnect",
+				requestType: types.RequestTypeRoomComposite,
+				publishOptions: publishOptions{
+					audioCodec: types.MimeTypeOpus,
+					audioOnly:  true,
+				},
+				fileOptions: &fileOptions{
+					filename: "retryable_disconnect_{time}",
+					fileType: livekit.EncodedFileType_OGG,
+				},
+				custom: r.testRoomCompositeRetryableDisconnect,
+			},
+
 			// RTMP output with no valid urls
 
 			{
@@ -643,4 +662,44 @@ func (r *Runner) testDuplicateIdentitySilentExit(t *testing.T, test *testCase) {
 	// And the output file must not have landed in storage — another
 	// egress instance is presumed to own the destination.
 	requireNotUploaded(t, p.GetFileConfig().StorageConfig, storagePath)
+}
+
+func (r *Runner) testRoomCompositeRetryableDisconnect(t *testing.T, test *testCase) {
+	// Inject a retryable disconnect into this egress once it is active. Tests
+	// run serially, so scoping the override to the current room and clearing it
+	// on cleanup keeps it isolated to this test.
+	original := r.TestOverrides.DisconnectInjectionRoom
+	r.TestOverrides.DisconnectInjectionRoom = r.RoomName
+	t.Cleanup(func() { r.TestOverrides.DisconnectInjectionRoom = original })
+
+	req := r.build(test)
+	egressID := req.EgressId
+
+	p, err := config.GetValidatedPipelineConfig(r.ServiceConfig, req)
+	require.NoError(t, err)
+
+	r.startEgress(t, req)
+
+	// The injected disconnect should drive the egress to finalize and exit.
+	require.Eventually(t, r.svc.IsIdle, 45*time.Second, 200*time.Millisecond,
+		"egress should finalize and exit after retryable disconnect")
+
+	// Give a small grace period for the terminal UpdateEgress to land.
+	time.Sleep(2 * time.Second)
+
+	res := r.getUpdate(t, egressID)
+
+	require.Equal(t, livekit.EgressStatus_EGRESS_FAILED, res.Status)
+	require.Contains(t, res.Error, "connection to room failed")
+
+	// But the partial recording is still finalized and uploaded.
+	require.Len(t, res.FileResults, 1)
+	fileRes := res.FileResults[0]
+	require.NotEmpty(t, fileRes.Location, "partial file should be uploaded despite FAILED status")
+	require.Greater(t, fileRes.Size, int64(0))
+	require.Greater(t, fileRes.Duration, int64(0))
+
+	// And it is downloadable from storage.
+	local := fmt.Sprintf("%s/retryable_disconnect_partial.ogg", r.FilePrefix)
+	download(t, p.GetFileConfig().StorageConfig, local, fileRes.Filename, true)
 }

--- a/test/edge.go
+++ b/test/edge.go
@@ -121,7 +121,7 @@ func (r *Runner) testEdgeCases(t *testing.T) {
 			// Room composite where the egress participant loses its room
 			// connection with a retryable reason. The partial recording must
 			// still be finalized and uploaded, and the egress reported FAILED
-			// so cloud can retry it.
+			// so it could be retried.
 
 			{
 				name:        "RoomCompositeRetryableDisconnect",


### PR DESCRIPTION
If iit happens that egress gets disconnected from a room and the sdk retry logic doesn't manage to re-establish the connection - egress transparently succeeds and an API consumer has no clue that the recording got cut in the middle of the session. The goal of these chnages is to make egress fail under these circumstances but still upload what has been recorded by that time as there was nothing wrong with the media pipeline itself. To be able to integration test this I needed to add a hook for artifically triggering the disconnect flow.