### PR TITLE
Report custom endpoint in upload status metric

### DIFF
--- a/pkg/pipeline/sink/uploader/uploader.go
+++ b/pkg/pipeline/sink/uploader/uploader.go
@@ -51,8 +51,9 @@ func (u *Uploader) DisableUploads() {
 
 type store struct {
 	storage.Storage
-	conf *config.StorageConfig
-	name string
+	conf              *config.StorageConfig
+	name              string
+	hasCustomEndpoint bool
 }
 
 func New(primary, backup *config.StorageConfig, monitor *stats.HandlerMonitor, storageObserver config.StorageObserver, info *livekit.EgressInfo) (*Uploader, error) {
@@ -86,14 +87,16 @@ func getUploader(conf *config.StorageConfig) (*store, error) {
 	}
 
 	var (
-		s    storage.Storage
-		err  error
-		name string
+		s                 storage.Storage
+		err               error
+		name              string
+		hasCustomEndpoint bool
 	)
 	switch {
 	case conf.S3 != nil:
 		s, err = storage.NewS3(conf.S3)
 		name = "S3"
+		hasCustomEndpoint = conf.S3.Endpoint != ""
 	case conf.GCP != nil:
 		s, err = storage.NewGCP(conf.GCP)
 		name = "GCP"
@@ -103,6 +106,7 @@ func getUploader(conf *config.StorageConfig) (*store, error) {
 	case conf.AliOSS != nil:
 		s, err = storage.NewAliOSS(conf.AliOSS)
 		name = "AliOSS"
+		hasCustomEndpoint = conf.AliOSS.Endpoint != ""
 	default:
 		s, err = storage.NewLocal(&storage.LocalConfig{})
 		name = "Local"
@@ -112,9 +116,10 @@ func getUploader(conf *config.StorageConfig) (*store, error) {
 	}
 
 	return &store{
-		Storage: s,
-		conf:    conf,
-		name:    name,
+		Storage:           s,
+		conf:              conf,
+		name:              name,
+		hasCustomEndpoint: hasCustomEndpoint,
 	}, nil
 }
 
@@ -138,7 +143,7 @@ func (u *Uploader) Upload(
 		elapsed := time.Since(start)
 		if err == nil {
 			if u.monitor != nil {
-				u.monitor.IncUploadCountSuccess(string(outputType), float64(elapsed.Milliseconds()))
+				u.monitor.IncUploadCountSuccess(string(outputType), u.primary.hasCustomEndpoint, float64(elapsed.Milliseconds()))
 			}
 			if deleteAfterUpload {
 				_ = os.Remove(localFilepath)
@@ -146,7 +151,7 @@ func (u *Uploader) Upload(
 			return location, size, nil
 		}
 		if u.monitor != nil {
-			u.monitor.IncUploadCountFailure(string(outputType), uploadErrorStatus(err), float64(elapsed.Milliseconds()))
+			u.monitor.IncUploadCountFailure(string(outputType), uploadErrorStatus(err), u.primary.hasCustomEndpoint, float64(elapsed.Milliseconds()))
 		}
 		u.primaryFailed = true
 		primaryErr = err

--- a/pkg/pipeline/sink/uploader/uploader_test.go
+++ b/pkg/pipeline/sink/uploader/uploader_test.go
@@ -65,6 +65,53 @@ func TestUploader(t *testing.T) {
 	require.True(t, strings.HasPrefix(string(b), "package uploader"))
 }
 
+func TestHasCustomEndpoint(t *testing.T) {
+	cases := []struct {
+		name string
+		conf *config.StorageConfig
+		want bool
+	}{
+		{
+			name: "s3 without endpoint",
+			conf: &config.StorageConfig{S3: &storage.S3Config{Region: "us-east-1", Bucket: "b"}},
+			want: false,
+		},
+		{
+			name: "s3 with endpoint",
+			conf: &config.StorageConfig{S3: &storage.S3Config{Region: "us-east-1", Bucket: "b", Endpoint: "https://minio.example.com"}},
+			want: true,
+		},
+		{
+			name: "alioss without endpoint",
+			conf: &config.StorageConfig{AliOSS: &storage.AliOSSConfig{Bucket: "fake-bucket"}},
+			want: false,
+		},
+		{
+			name: "alioss with endpoint",
+			conf: &config.StorageConfig{AliOSS: &storage.AliOSSConfig{Bucket: "fake-bucket", Endpoint: "oss-cn-hangzhou.aliyuncs.com"}},
+			want: true,
+		},
+		{
+			name: "azure",
+			conf: &config.StorageConfig{Azure: &storage.AzureConfig{AccountName: "n", AccountKey: "a2V5", ContainerName: "c"}},
+			want: false,
+		},
+		{
+			name: "local",
+			conf: &config.StorageConfig{},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := getUploader(tc.conf)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, s.hasCustomEndpoint)
+		})
+	}
+}
+
 func TestUploadErrorHasStatusCode(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/pkg/stats/handler.go
+++ b/pkg/stats/handler.go
@@ -15,6 +15,8 @@
 package stats
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -35,7 +37,7 @@ func NewHandlerMonitor(nodeID, clusterID string) *HandlerMonitor {
 		Name:        "pipeline_uploads",
 		Help:        "Number of uploads per pipeline with type and status labels",
 		ConstLabels: constantLabels,
-	}, []string{"type", "status"}) // type: file, manifest, segment, liveplaylist, playlist; status: success, 4xx, 5xx, internal
+	}, []string{"type", "status", "custom_endpoint"}) // type: file, manifest, segment, liveplaylist, playlist; status: success, 4xx, 5xx, internal
 
 	m.uploadsResponseTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   "livekit",
@@ -44,7 +46,7 @@ func NewHandlerMonitor(nodeID, clusterID string) *HandlerMonitor {
 		Help:        "A histogram of latencies for upload requests in milliseconds.",
 		Buckets:     []float64{10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 15000, 20000, 30000},
 		ConstLabels: constantLabels,
-	}, []string{"type", "status"})
+	}, []string{"type", "status", "custom_endpoint"})
 
 	m.backupCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   "livekit",
@@ -59,14 +61,14 @@ func NewHandlerMonitor(nodeID, clusterID string) *HandlerMonitor {
 	return m
 }
 
-func (m *HandlerMonitor) IncUploadCountSuccess(uploadType string, elapsed float64) {
-	labels := prometheus.Labels{"type": uploadType, "status": "success"}
+func (m *HandlerMonitor) IncUploadCountSuccess(uploadType string, hasCustomEndpoint bool, elapsed float64) {
+	labels := prometheus.Labels{"type": uploadType, "status": "success", "custom_endpoint": strconv.FormatBool(hasCustomEndpoint)}
 	m.uploadsCounter.With(labels).Add(1)
 	m.uploadsResponseTime.With(labels).Observe(elapsed)
 }
 
-func (m *HandlerMonitor) IncUploadCountFailure(uploadType string, status string, elapsed float64) {
-	labels := prometheus.Labels{"type": uploadType, "status": status}
+func (m *HandlerMonitor) IncUploadCountFailure(uploadType string, status string, hasCustomEndpoint bool, elapsed float64) {
+	labels := prometheus.Labels{"type": uploadType, "status": status, "custom_endpoint": strconv.FormatBool(hasCustomEndpoint)}
 	m.uploadsCounter.With(labels).Add(1)
 	m.uploadsResponseTime.With(labels).Observe(elapsed)
 }


### PR DESCRIPTION
## Summary

Adds a `custom_endpoint` label to the upload status metrics (`pipeline_uploads` counter and `pipline_upload_response_time_ms` histogram), indicating whether the upload targeted a user-supplied endpoint.

The flag is set from a non-empty `Endpoint` field on the **S3** and **AliOSS** configs; other backends (GCP, Azure, Local) report `false`. It's computed once per store at construction (`getUploader`) and threaded through `IncUploadCountSuccess` / `IncUploadCountFailure` for the primary store.

## Motivation

This lets us alert on issues connecting to blobstores while ignoring failures caused by invalid endpoints provided in incoming requests — request-supplied custom endpoints are a frequent source of upload failures that shouldn't trigger infrastructure alerts.

## Notes

- Cardinality impact is a ×2 on two already-bounded metrics — constant per handler, no per-egress growth.
- `backup_storage_writes` is left untouched (separate metric).
- Adds `TestHasCustomEndpoint` covering S3/AliOSS with and without an endpoint, plus Azure and Local. Runs offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)