### PR TITLE
fix(egress): raise PulseAudio fd limit to prevent EMFILE under concurrent room-composite recordings

### DIFF
--- a/build/egress/entrypoint.sh
+++ b/build/egress/entrypoint.sh
@@ -20,6 +20,13 @@ rm -rf /home/egress/tmp/*
 
 # Start pulseaudio
 rm -rf /var/run/pulse /var/lib/pulse /home/egress/.config/pulse /home/egress/.cache/xdgr/pulse
+# PulseAudio defaults to rlimit-nofile=256, exhausted at ~18 concurrent Chrome
+# room-composite recordings (~13.5 fds each) — well below the max_pulse_clients
+# admission limit. Raise the process limit AND PulseAudio's own cap (it re-applies
+# its daemon.conf default via setrlimit, so ulimit alone is insufficient) so fd
+# exhaustion isn't the binding constraint (see #1272).
+ulimit -n 65536 || true
+echo "rlimit-nofile = 65536" >> /etc/pulse/daemon.conf
 pulseaudio -D --verbose --exit-idle-time=-1 --disallow-exit > /dev/null 2>&1
 
 # Run egress service


### PR DESCRIPTION
## Problem

The egress image starts PulseAudio with its default `rlimit-nofile = 256`. Each Chrome `room_composite` recording consumes ~13.5 fds on the pulse daemon (null-sink + client connection + internal pipes), so the daemon hits **EMFILE at ~18 concurrent recordings** — far below the `max_pulse_clients` admission limit (default 60, calibrated to the native-protocol `MAX_CONNECTIONS` of 64).

Because admission control counts pulse *connections*, not *fds*, recordings get admitted and then hard-fail rather than being gracefully rejected:

```
pulse/pactl.go:15  failed to list pulse info  error="Connection failure: Connection terminated"
source/web.go:79   failed to create pulse sink  error="failed to launch pulse: exit status 1"
```

Full analysis, measurements (`fds ≈ 9 + 13.5 × recordings`; captured `open=243 limit=256/256 sinks=17` at the failure instant), and relation to #999 / #1160 / #893 are in #1272.

## Fix

Raise both the process fd limit and PulseAudio's own `rlimit-nofile` in the entrypoint before launching the daemon. `ulimit -n` alone is insufficient — PulseAudio re-applies its `daemon.conf` default (256) via `setrlimit` regardless of the inherited limit — so both lines are required. This moves the fd ceiling out to thousands so it's no longer the binding constraint, leaving the existing connection-based admission control to gate near the real 64-connection limit.

## Testing

Verified the underlying fix — raising PulseAudio's `rlimit-nofile` from the 256 default to 65536 — on a self-hosted 4-replica deployment (`v1.13.0`). On that deployment it was applied as a `/etc/pulse/daemon.conf.d` drop-in plus a matching container `ulimit`; this PR folds the equivalent into the entrypoint so it works out of the box.

- **Before:** `/proc/$(pidof pulseaudio)/limits` showed `Max open files  256  256`; room_composite recordings failed in bursts at ~18 concurrent per replica (~3–4 bursts/day).
- **After:** `limit` reads `65536`; no room_composite pulse failures across 8 days, including peak windows.

For full transparency: I have **not** run this exact entrypoint diff through a from-scratch image build — the verification above is of the equivalent `rlimit-nofile` change in production. The script parses clean (`bash -n`).

Note: on hosts whose Docker default hard `nofile` is below 65536, operators may also need `--ulimit nofile=65536:65536` on the container; default Docker (hard = 1048576) needs no change.
