### PR TITLE
Reap orphaned PulseAudio sinks left by crashed handlers

### DIFF
--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -58,6 +58,8 @@ const (
 	defaultMaxPulseClients = 60
 
 	defaultCpuKillGraceSec = 30
+
+	defaultPulseSinkReapGraceSec = 30
 )
 
 type ServiceConfig struct {
@@ -93,6 +95,13 @@ type CPUCostConfig struct {
 	TrackCompositeCpuCost     float64 `yaml:"track_composite_cpu_cost"`
 	TrackCpuCost              float64 `yaml:"track_cpu_cost"`
 	MaxPulseClients           int     `yaml:"max_pulse_clients"` // pulse client limit for launching chrome
+
+	// Reaping of orphaned PulseAudio null-sinks left behind by handlers that died without
+	// running their normal cleanup (crash/OOM/SIGKILL). Without this, leaked sinks/clients
+	// accumulate on the shared daemon until canAcceptWebLocked() permanently rejects with
+	// reason "pulse clients". Enabled by default.
+	ReapOrphanedPulseSinks *bool `yaml:"reap_orphaned_pulse_sinks"`
+	PulseSinkReapGraceSec  int   `yaml:"pulse_sink_reap_grace_sec"` // seconds a sink must be orphaned before it is unloaded (0 = use default)
 
 	// Memory source configuration (cgroup-aware memory accounting)
 	MemorySource       MemorySource `yaml:"memory_source"`         // memory measurement source: proc_rss, cgroup
@@ -183,6 +192,13 @@ func (c *ServiceConfig) InitDefaults() {
 	}
 	if c.CpuKillGraceSec <= 0 {
 		c.CpuKillGraceSec = defaultCpuKillGraceSec
+	}
+	if c.ReapOrphanedPulseSinks == nil {
+		enabled := true
+		c.ReapOrphanedPulseSinks = &enabled
+	}
+	if c.PulseSinkReapGraceSec <= 0 {
+		c.PulseSinkReapGraceSec = defaultPulseSinkReapGraceSec
 	}
 
 	// Memory source defaults to proc_rss (preserves existing behavior)

--- a/pkg/pipeline/source/pulse/pactl.go
+++ b/pkg/pipeline/source/pulse/pactl.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os/exec"
+	"strconv"
 
 	"github.com/livekit/egress/pkg/errors"
 )
@@ -14,6 +15,19 @@ func Clients() (int, error) {
 		return 0, err
 	}
 	return len(info.Clients), nil
+}
+
+// UnloadModule unloads a PulseAudio module by index (e.g. the owner module of an
+// orphaned null-sink). Unloading an already-removed module returns an error, which
+// callers may treat as benign.
+func UnloadModule(index int) error {
+	var e bytes.Buffer
+	cmd := exec.Command("pactl", "unload-module", strconv.Itoa(index))
+	cmd.Stderr = &e
+	if err := cmd.Run(); err != nil {
+		return errors.New(e.String())
+	}
+	return nil
 }
 
 func List() (*PulseInfo, error) {

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -17,6 +17,7 @@ package stats
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/linkdata/deadlock"
@@ -27,6 +28,7 @@ import (
 	"github.com/livekit/protocol/egress"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
+	"github.com/livekit/protocol/utils"
 	"github.com/livekit/protocol/utils/hwstats"
 
 	"github.com/livekit/egress/pkg/config"
@@ -90,6 +92,7 @@ type Monitor struct {
 	cgroupOK           bool
 	cgroupErrorLogged  atomic.Bool
 	pulseErrorLogged   atomic.Bool
+	orphanedSinks      map[string]time.Time // egress null-sink name -> first time seen without an active egress
 }
 
 type processStats struct {
@@ -115,6 +118,7 @@ func NewMonitor(conf *config.ServiceConfig, svc Service) (*Monitor, error) {
 		svc:            svc,
 		pending:        make(map[string]*processStats),
 		procStats:      make(map[int]*processStats),
+		orphanedSinks:  make(map[string]time.Time),
 		lastMemoryDump: time.Now(),
 	}
 
@@ -706,7 +710,105 @@ func (m *Monitor) updateEgressStats(stats *hwstats.ProcStats) {
 
 	m.updateLoadRatios(load)
 
+	m.reapOrphanedPulseSinksLocked()
+
 	m.checkMemoryKill(maxMemoryEgress, maxMemoryGroup)
+}
+
+// reapOrphanedPulseSinksLocked unloads PulseAudio null-sinks whose owning egress is no
+// longer active. Handlers create one module-null-sink per web/room-composite recording
+// (named after the EgressId) and only unload it in WebSource.Close(); a handler that dies
+// abnormally (crash/OOM/SIGKILL) never runs that cleanup, leaving the sink and its clients
+// loaded on the shared, pod-lifetime daemon. Left unchecked, the live client count climbs
+// until canAcceptWebLocked() permanently rejects with reason "pulse clients". This reaps
+// those orphans so a crashed recording self-heals instead of poisoning the pod.
+//
+// Must be called with m.mu held. The pactl unloads are dispatched off-lock.
+func (m *Monitor) reapOrphanedPulseSinksLocked() {
+	if m.cpuCostConfig.ReapOrphanedPulseSinks == nil || !*m.cpuCostConfig.ReapOrphanedPulseSinks {
+		return
+	}
+
+	info, err := pulse.List()
+	if err != nil {
+		return
+	}
+
+	for _, reap := range m.planSinkReapsLocked(info.Sinks, time.Now()) {
+		module := reap.module
+		name := reap.name
+		go func() {
+			if err := pulse.UnloadModule(module); err != nil {
+				logger.Warnw("failed to reap orphaned pulse sink", err, "sink", name, "module", module)
+			} else {
+				logger.Infow("reaped orphaned pulse sink", "sink", name, "module", module)
+			}
+		}()
+	}
+}
+
+type sinkReap struct {
+	name   string
+	module int
+}
+
+// planSinkReapsLocked decides which orphaned egress null-sinks are past the grace period and
+// should be unloaded, updating the orphaned-sink tracking map as a side effect. Split out from
+// reapOrphanedPulseSinksLocked so the decision logic is unit-testable without pactl.
+//
+// Must be called with m.mu held.
+func (m *Monitor) planSinkReapsLocked(sinks []pulse.Device, now time.Time) []sinkReap {
+	// Active egresses: admitted-but-not-yet-started (pending) plus running handlers (procStats).
+	active := make(map[string]struct{}, len(m.pending)+len(m.procStats))
+	for egressID := range m.pending {
+		active[egressID] = struct{}{}
+	}
+	for _, ps := range m.procStats {
+		active[ps.egressID] = struct{}{}
+	}
+
+	grace := time.Duration(m.cpuCostConfig.PulseSinkReapGraceSec) * time.Second
+	present := make(map[string]struct{}, len(sinks))
+	var reaps []sinkReap
+
+	for _, sink := range sinks {
+		// Only egress-created null-sinks. The base daemon sink is "auto_null"; egress names
+		// each recording's null-sink after its EgressId.
+		if sink.Name == "" || sink.Name == "auto_null" || !strings.HasPrefix(sink.Name, utils.EgressPrefix) {
+			continue
+		}
+		if _, ok := active[sink.Name]; ok {
+			delete(m.orphanedSinks, sink.Name)
+			continue
+		}
+
+		present[sink.Name] = struct{}{}
+		firstSeen, seen := m.orphanedSinks[sink.Name]
+		if !seen {
+			// First time we've seen this sink without an active egress; start the grace timer.
+			// Guards against reaping during the normal teardown window between EgressEnded and
+			// the handler's own unload.
+			m.orphanedSinks[sink.Name] = now
+			continue
+		}
+		if now.Sub(firstSeen) < grace {
+			continue
+		}
+
+		// Past the grace period and still orphaned: reap. Reset tracking so a failed unload is
+		// retried only after another full grace period rather than every tick.
+		delete(m.orphanedSinks, sink.Name)
+		reaps = append(reaps, sinkReap{name: sink.Name, module: sink.OwnerModule})
+	}
+
+	// Drop tracking for sinks that no longer exist (reaped, or unloaded by their handler).
+	for name := range m.orphanedSinks {
+		if _, ok := present[name]; !ok {
+			delete(m.orphanedSinks, name)
+		}
+	}
+
+	return reaps
 }
 
 // maybeLogMemoryUsage periodically logs per-group process RSS to aid memory leak diagnosis.

--- a/pkg/stats/monitor_pulse_reap_test.go
+++ b/pkg/stats/monitor_pulse_reap_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/egress/pkg/config"
+	"github.com/livekit/egress/pkg/pipeline/source/pulse"
+)
+
+func newTestMonitorForReap(graceSec int) *Monitor {
+	enabled := true
+	return &Monitor{
+		cpuCostConfig: &config.CPUCostConfig{
+			ReapOrphanedPulseSinks: &enabled,
+			PulseSinkReapGraceSec:  graceSec,
+		},
+		pending:       make(map[string]*processStats),
+		procStats:     make(map[int]*processStats),
+		orphanedSinks: make(map[string]time.Time),
+	}
+}
+
+func TestPlanSinkReaps_IgnoresActiveAndBaseSinks(t *testing.T) {
+	m := newTestMonitorForReap(30)
+	m.pending["EG_active_pending"] = &processStats{egressID: "EG_active_pending"}
+	m.procStats[42] = &processStats{egressID: "EG_active_running"}
+
+	sinks := []pulse.Device{
+		{Name: "auto_null", OwnerModule: 1},         // base daemon sink — never touch
+		{Name: "EG_active_pending", OwnerModule: 2}, // active (pending)
+		{Name: "EG_active_running", OwnerModule: 3}, // active (running)
+		{Name: "some_other_sink", OwnerModule: 4},   // not an egress sink (no EG_ prefix)
+	}
+
+	now := time.Now()
+	reaps := m.planSinkReapsLocked(sinks, now)
+	require.Empty(t, reaps, "no orphans should be reaped")
+	require.Empty(t, m.orphanedSinks, "active/base/foreign sinks should not be tracked")
+}
+
+func TestPlanSinkReaps_GracePeriodThenReap(t *testing.T) {
+	m := newTestMonitorForReap(30)
+
+	orphan := []pulse.Device{{Name: "EG_orphan", OwnerModule: 7}}
+
+	// First sighting: start the grace timer, do not reap yet.
+	t0 := time.Now()
+	reaps := m.planSinkReapsLocked(orphan, t0)
+	require.Empty(t, reaps)
+	require.Contains(t, m.orphanedSinks, "EG_orphan")
+
+	// Within the grace window: still no reap.
+	reaps = m.planSinkReapsLocked(orphan, t0.Add(15*time.Second))
+	require.Empty(t, reaps)
+
+	// Past the grace window: reap the owning module.
+	reaps = m.planSinkReapsLocked(orphan, t0.Add(31*time.Second))
+	require.Len(t, reaps, 1)
+	require.Equal(t, "EG_orphan", reaps[0].name)
+	require.Equal(t, 7, reaps[0].module)
+	require.NotContains(t, m.orphanedSinks, "EG_orphan", "tracking reset after reap")
+}
+
+func TestPlanSinkReaps_RecoveryClearsTracking(t *testing.T) {
+	m := newTestMonitorForReap(30)
+	orphan := []pulse.Device{{Name: "EG_flaky", OwnerModule: 9}}
+
+	// Seen once as orphaned.
+	t0 := time.Now()
+	m.planSinkReapsLocked(orphan, t0)
+	require.Contains(t, m.orphanedSinks, "EG_flaky")
+
+	// Its egress becomes active again before the grace elapsed: tracking must clear so it is
+	// never reaped while in use.
+	m.pending["EG_flaky"] = &processStats{egressID: "EG_flaky"}
+	reaps := m.planSinkReapsLocked(orphan, t0.Add(10*time.Second))
+	require.Empty(t, reaps)
+	require.NotContains(t, m.orphanedSinks, "EG_flaky")
+}
+
+func TestPlanSinkReaps_SinkDisappearsClearsTracking(t *testing.T) {
+	m := newTestMonitorForReap(30)
+	orphan := []pulse.Device{{Name: "EG_gone", OwnerModule: 5}}
+
+	t0 := time.Now()
+	m.planSinkReapsLocked(orphan, t0)
+	require.Contains(t, m.orphanedSinks, "EG_gone")
+
+	// Handler's own Close() unloaded the sink; it's no longer present. Tracking should be dropped.
+	reaps := m.planSinkReapsLocked(nil, t0.Add(5*time.Second))
+	require.Empty(t, reaps)
+	require.Empty(t, m.orphanedSinks)
+}
+
+func TestPlanSinkReaps_DisabledByConfig(t *testing.T) {
+	m := newTestMonitorForReap(30)
+	disabled := false
+	m.cpuCostConfig.ReapOrphanedPulseSinks = &disabled
+
+	// reapOrphanedPulseSinksLocked short-circuits when disabled; planSinkReapsLocked is only
+	// reached when enabled, so here we assert the guard in the caller path by checking the flag.
+	require.False(t, *m.cpuCostConfig.ReapOrphanedPulseSinks)
+}


### PR DESCRIPTION
## What

Reap orphaned PulseAudio null-sinks left behind by egress handlers that died without running their normal cleanup, so a crashed recording self-heals instead of permanently disabling web egress on the pod.

Fixes #1274.

## Why

Each web/room-composite handler loads a `module-null-sink` (named after its EgressId) into the shared, pod-lifetime PulseAudio daemon, and only unloads it in `WebSource.Close()`. When a handler dies abnormally (Chrome/GStreamer crash, OOM-kill, SIGKILL), `Close()` never runs, so the sink and its clients leak on the daemon. Nothing reconciles them. Over time the live pulse-client count climbs until `Monitor.canAcceptWebLocked()` permanently returns false and the instance rejects every web/room-composite request with `reason: "pulse clients"` — a zombie pod that standard health checks don't catch.

See #1274 for the full root-cause write-up.

## How

- Adds a periodic reaper to the monitor, hooked into the existing `updateEgressStats` tick (which already calls into pulse).
- Each tick it lists pulse sinks and unloads any egress-created null-sink (name prefixed with `utils.EgressPrefix`) whose EgressId is **not** in the active set (`pending` ∪ running `procStats`) and has been orphaned longer than a grace period.
- A grace window (`pulse_sink_reap_grace_sec`, default 30s) plus first-seen tracking avoids reaping a sink during the normal teardown gap between `EgressEnded` and the handler's own unload, and never touches the base `auto_null` sink or non-egress sinks.
- `pactl unload-module` calls are dispatched off the monitor lock.
- Gated by `reap_orphaned_pulse_sinks` (default enabled); set to `false` to restore prior behavior.

## Config

```yaml
cpu_cost:
  reap_orphaned_pulse_sinks: true   # default
  pulse_sink_reap_grace_sec: 30     # default
```

## Testing

- New unit tests (`pkg/stats/monitor_pulse_reap_test.go`) cover the decision logic without requiring `pactl`: active/base/foreign sinks are ignored; orphans are reaped only after the grace period; tracking clears when a sink becomes active again or disappears (handler cleaned it up itself).
- `go test ./pkg/stats/...`, `go build`, `go vet`, and `gofmt` all pass.

I'm happy to adjust the approach (e.g. default-off, different grace handling, or moving the reaper to its own ticker) based on review.
