### PR TITLE
Fix silent upload failures orphaning HLS segments on disk

### DIFF
--- a/pkg/pipeline/sink/uploader/uploader.go
+++ b/pkg/pipeline/sink/uploader/uploader.go
@@ -180,9 +180,6 @@ func (u *Uploader) Upload(
 		return "", 0, psrpc.NewError(psrpc.InvalidArgument, backupErr)
 	}
 
-	if primaryErr == nil {
-		primaryErr = psrpc.NewErrorf(psrpc.Internal, "upload skipped: primary previously failed and no backup configured")
-	}
 	return "", 0, primaryErr
 }
 

--- a/pkg/pipeline/sink/uploader/uploader.go
+++ b/pkg/pipeline/sink/uploader/uploader.go
@@ -153,7 +153,7 @@ func (u *Uploader) Upload(
 		if u.monitor != nil {
 			u.monitor.IncUploadCountFailure(string(outputType), uploadErrorStatus(err), u.primary.hasCustomEndpoint, float64(elapsed.Milliseconds()))
 		}
-		u.primaryFailed = true
+		u.primaryFailed = u.backup != nil
 		primaryErr = err
 
 	}
@@ -180,6 +180,9 @@ func (u *Uploader) Upload(
 		return "", 0, psrpc.NewError(psrpc.InvalidArgument, backupErr)
 	}
 
+	if primaryErr == nil {
+		primaryErr = psrpc.NewErrorf(psrpc.Internal, "upload skipped: primary previously failed and no backup configured")
+	}
 	return "", 0, primaryErr
 }
 


### PR DESCRIPTION
When primary storage upload fails and no backup is configured, Uploader latches primaryFailed = true and then falls through to return "", 0, primaryErr with the local primaryErr variable still nil — so every subsequent call silently returns success without uploading or deleting the local file. Local segments accumulate on ephemeral storage, a single failing upload was enough to poison every subsequent segment upload for the rest of the session.

The fix only latches when there's a backup to fall over to.