### PR TITLE
Fix panic when track is closed during start-gate priming

### DIFF
--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -309,7 +309,8 @@ func (w *AppWriter) readNext() {
 			w.stats.packetsDropped.Add(uint64(dropped))
 			w.sendPLI()
 		}
-		if !done {
+		if !done || len(ready) == 0 {
+			// done with no packets means the track was closed during priming
 			return
 		}
 		w.initialized = true


### PR DESCRIPTION
The sync engine's PrimeForStart has a third outcome the AppWriter didn't account for: when a track is closed mid-priming (unsubscribe, SSRC/trackID collision on re-add, or AddTrack after End), it returns done=true with an empty slice instead of a packet batch. The AppWriter assumed done implied at least one packet and indexed ready[len(ready)-1], panicking with "index out of range [-1]". while the track was still inside the priming window.

readNext now returns early when priming completes with no packets, discarding the packet without initializing the writer or touching the jitter buffer. This is safe because a closed track's GetPTS only returns io.EOF, and the read loop still terminates through its usual paths: every event that closes a sync track also tears down the track reader, so the writer exits via EOF or the unsubscribed grace period.