### PR TITLE
Reap orphaned PulseAudio sinks in a dedicated monitor goroutine

### DIFF
--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -58,6 +58,8 @@ const (
 	defaultMaxPulseClients = 60
 
 	defaultCpuKillGraceSec = 30
+
+	defaultPulseSinkReapGraceSec = 30
 )
 
 type ServiceConfig struct {
@@ -67,6 +69,8 @@ type ServiceConfig struct {
 	TemplatePort     int `yaml:"template_port"`      // room composite template server port
 	PrometheusPort   int `yaml:"prometheus_port"`    // prometheus handler port
 	DebugHandlerPort int `yaml:"debug_handler_port"` // egress debug handler port
+
+	PulseSinkReapGraceSec int `yaml:"pulse_sink_reap_grace_sec"` // seconds a leaked pulse sink must stay orphaned before it is unloaded (0 = use default, negative = disable reaping)
 
 	*CPUCostConfig `yaml:"cpu_cost"` // CPU costs for the different egress types
 }
@@ -183,6 +187,9 @@ func (c *ServiceConfig) InitDefaults() {
 	}
 	if c.CpuKillGraceSec <= 0 {
 		c.CpuKillGraceSec = defaultCpuKillGraceSec
+	}
+	if c.PulseSinkReapGraceSec == 0 {
+		c.PulseSinkReapGraceSec = defaultPulseSinkReapGraceSec
 	}
 
 	// Memory source defaults to proc_rss (preserves existing behavior)

--- a/pkg/pipeline/source/pulse/pactl.go
+++ b/pkg/pipeline/source/pulse/pactl.go
@@ -2,8 +2,10 @@ package pulse
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os/exec"
+	"strconv"
 
 	"github.com/livekit/egress/pkg/errors"
 )
@@ -17,16 +19,37 @@ func Clients() (int, error) {
 }
 
 func List() (*PulseInfo, error) {
-	cmd := exec.Command("pactl", "--format", "json", "list")
+	return ListContext(context.Background())
+}
+
+func ListContext(ctx context.Context) (*PulseInfo, error) {
+	cmd := exec.CommandContext(ctx, "pactl", "--format", "json", "list")
 	var b, e bytes.Buffer
 	cmd.Stdout = &b
 	cmd.Stderr = &e
-	if cmd.Run() != nil {
-		return nil, errors.New(e.String())
+	if err := cmd.Run(); err != nil {
+		if e.Len() > 0 {
+			return nil, errors.New(e.String())
+		}
+		return nil, err
 	}
 
 	info := &PulseInfo{}
 	return info, json.Unmarshal(b.Bytes(), info)
+}
+
+// UnloadModule unloads a module from the pulse daemon, e.g. the null-sink owned by an egress.
+func UnloadModule(ctx context.Context, module int) error {
+	cmd := exec.CommandContext(ctx, "pactl", "unload-module", strconv.Itoa(module))
+	var e bytes.Buffer
+	cmd.Stderr = &e
+	if err := cmd.Run(); err != nil {
+		if e.Len() > 0 {
+			return errors.New(e.String())
+		}
+		return err
+	}
+	return nil
 }
 
 type PulseInfo struct {

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -55,15 +55,17 @@ type Service interface {
 }
 
 type Monitor struct {
-	nodeID        string
-	clusterID     string
-	cpuCostConfig *config.CPUCostConfig
+	nodeID             string
+	clusterID          string
+	cpuCostConfig      *config.CPUCostConfig
+	pulseSinkReapGrace time.Duration
 
 	promCPULoad           prometheus.Gauge
 	promCgroupMemory      prometheus.Gauge
 	promCgroupReadSuccess prometheus.Gauge
 	promProcRSS           prometheus.Gauge
 	promWouldRejectCgroup prometheus.Gauge
+	promPulseSinks        prometheus.Gauge
 	requestGauge          *prometheus.GaugeVec
 	handlerResults        *prometheus.CounterVec
 	promLoadRatio         *prometheus.GaugeVec
@@ -119,6 +121,11 @@ func NewMonitor(conf *config.ServiceConfig, svc Service) (*Monitor, error) {
 	}
 
 	m.initPrometheus()
+
+	if conf.PulseSinkReapGraceSec > 0 {
+		m.pulseSinkReapGrace = time.Duration(conf.PulseSinkReapGraceSec) * time.Second
+		go m.runPulseSinkReaper()
+	}
 
 	procStats, err := hwstats.NewProcMonitor(m.updateEgressStats)
 	if err != nil {

--- a/pkg/stats/monitor_prom.go
+++ b/pkg/stats/monitor_prom.go
@@ -100,6 +100,14 @@ func (m *Monitor) initPrometheus() {
 		ConstLabels: prometheus.Labels{"node_id": m.nodeID, "cluster_id": m.clusterID},
 	})
 
+	m.promPulseSinks = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   "livekit",
+		Subsystem:   "egress",
+		Name:        "pulse_sinks",
+		Help:        "Number of egress-owned null-sinks loaded on the pulse daemon",
+		ConstLabels: prometheus.Labels{"node_id": m.nodeID, "cluster_id": m.clusterID},
+	})
+
 	m.handlerResults = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   "livekit",
 		Subsystem:   "egress",
@@ -120,6 +128,7 @@ func (m *Monitor) initPrometheus() {
 		m.promCgroupMemory,
 		m.promCgroupReadSuccess, m.promProcRSS,
 		m.promWouldRejectCgroup,
+		m.promPulseSinks,
 		m.handlerResults,
 		m.promLoadRatio,
 	)

--- a/pkg/stats/pulse_reaper.go
+++ b/pkg/stats/pulse_reaper.go
@@ -1,0 +1,131 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/livekit/protocol/logger"
+	"github.com/livekit/protocol/utils"
+
+	"github.com/livekit/egress/pkg/pipeline/source/pulse"
+)
+
+const (
+	pulseReapInterval   = 30 * time.Second
+	pulseReapCmdTimeout = 10 * time.Second
+)
+
+// runPulseSinkReaper unloads null-sinks left on the shared pulse daemon by handlers that
+// exited without cleanup, before they accumulate and hit the pulse client limit.
+func (m *Monitor) runPulseSinkReaper() {
+	firstOrphaned := make(map[string]time.Time)
+	listFailing := false
+
+	// a grace shorter than the default interval would otherwise be quantized back up to it
+	ticker := time.NewTicker(min(pulseReapInterval, m.pulseSinkReapGrace))
+	defer ticker.Stop()
+
+	for range ticker.C {
+		info, err := listPulse()
+		if err != nil {
+			if !listFailing {
+				listFailing = true
+				logger.Warnw("pulse sink reaper: skipping check, list failed", err)
+			}
+			continue
+		}
+		listFailing = false
+
+		toReap, egressSinks := planPulseSinkReaps(info.Sinks, m.activeEgressIDs(), firstOrphaned, m.pulseSinkReapGrace, time.Now())
+		m.promPulseSinks.Set(float64(egressSinks))
+
+		for _, sink := range toReap {
+			if err = unloadPulseSink(sink); err != nil {
+				logger.Warnw("failed to unload orphaned pulse sink", err, "egressID", sink.Name, "module", sink.OwnerModule)
+			} else {
+				logger.Infow("unloaded orphaned pulse sink", "egressID", sink.Name, "module", sink.OwnerModule)
+			}
+		}
+	}
+}
+
+func listPulse() (*pulse.PulseInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), pulseReapCmdTimeout)
+	defer cancel()
+	return pulse.ListContext(ctx)
+}
+
+func unloadPulseSink(sink pulse.Device) error {
+	ctx, cancel := context.WithTimeout(context.Background(), pulseReapCmdTimeout)
+	defer cancel()
+	return pulse.UnloadModule(ctx, sink.OwnerModule)
+}
+
+// planPulseSinkReaps selects egress-owned sinks (named after their EgressId) whose egress
+// is no longer tracked by the monitor and which have stayed orphaned for the full grace
+// period, covering the window between EgressEnded and the handler unloading its own sink.
+func planPulseSinkReaps(
+	sinks []pulse.Device,
+	activeEgressIDs map[string]bool,
+	firstOrphaned map[string]time.Time,
+	grace time.Duration,
+	now time.Time,
+) (toReap []pulse.Device, egressSinks int) {
+	orphaned := make(map[string]bool, len(sinks))
+
+	for _, sink := range sinks {
+		if !strings.HasPrefix(sink.Name, utils.EgressPrefix) {
+			continue
+		}
+		egressSinks++
+		if activeEgressIDs[sink.Name] {
+			continue
+		}
+
+		orphaned[sink.Name] = true
+		since, seen := firstOrphaned[sink.Name]
+		if !seen {
+			firstOrphaned[sink.Name] = now
+		} else if now.Sub(since) >= grace {
+			toReap = append(toReap, sink)
+			delete(firstOrphaned, sink.Name)
+		}
+	}
+
+	for name := range firstOrphaned {
+		if !orphaned[name] {
+			delete(firstOrphaned, name)
+		}
+	}
+
+	return
+}
+
+func (m *Monitor) activeEgressIDs() map[string]bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ids := make(map[string]bool, len(m.pending)+len(m.procStats))
+	for egressID := range m.pending {
+		ids[egressID] = true
+	}
+	for _, ps := range m.procStats {
+		ids[ps.egressID] = true
+	}
+	return ids
+}

--- a/pkg/stats/pulse_reaper_test.go
+++ b/pkg/stats/pulse_reaper_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/egress/pkg/pipeline/source/pulse"
+)
+
+const testGrace = 30 * time.Second
+
+func TestPulseSinkReaper_SkipsActiveAndForeignSinks(t *testing.T) {
+	sinks := []pulse.Device{
+		{Name: "auto_null", OwnerModule: 1},
+		{Name: "EG_running", OwnerModule: 2},
+		{Name: "not_an_egress_sink", OwnerModule: 3},
+	}
+	active := map[string]bool{"EG_running": true}
+	firstOrphaned := map[string]time.Time{}
+
+	now := time.Now()
+	for _, tick := range []time.Duration{0, testGrace, 2 * testGrace} {
+		toReap, egressSinks := planPulseSinkReaps(sinks, active, firstOrphaned, testGrace, now.Add(tick))
+		require.Empty(t, toReap)
+		require.Equal(t, 1, egressSinks)
+	}
+	require.Empty(t, firstOrphaned)
+}
+
+func TestPulseSinkReaper_ReapsOrphanAfterGrace(t *testing.T) {
+	sinks := []pulse.Device{{Name: "EG_orphan", OwnerModule: 7}}
+	active := map[string]bool{}
+	firstOrphaned := map[string]time.Time{}
+	now := time.Now()
+
+	// first sighting only starts the clock
+	toReap, egressSinks := planPulseSinkReaps(sinks, active, firstOrphaned, testGrace, now)
+	require.Empty(t, toReap)
+	require.Equal(t, 1, egressSinks)
+	require.Contains(t, firstOrphaned, "EG_orphan")
+
+	// still within grace
+	toReap, _ = planPulseSinkReaps(sinks, active, firstOrphaned, testGrace, now.Add(testGrace/2))
+	require.Empty(t, toReap)
+
+	// grace elapsed
+	toReap, _ = planPulseSinkReaps(sinks, active, firstOrphaned, testGrace, now.Add(testGrace))
+	require.Len(t, toReap, 1)
+	require.Equal(t, "EG_orphan", toReap[0].Name)
+	require.Equal(t, 7, toReap[0].OwnerModule)
+	require.Empty(t, firstOrphaned)
+
+	// if the unload failed and the sink is still present, the clock restarts
+	toReap, _ = planPulseSinkReaps(sinks, active, firstOrphaned, testGrace, now.Add(testGrace+time.Second))
+	require.Empty(t, toReap)
+	require.Contains(t, firstOrphaned, "EG_orphan")
+}
+
+func TestPulseSinkReaper_EgressActiveAgainClearsTracking(t *testing.T) {
+	sinks := []pulse.Device{{Name: "EG_restarted", OwnerModule: 4}}
+	firstOrphaned := map[string]time.Time{}
+	now := time.Now()
+
+	planPulseSinkReaps(sinks, map[string]bool{}, firstOrphaned, testGrace, now)
+	require.Contains(t, firstOrphaned, "EG_restarted")
+
+	// the egress shows up as active before the grace elapses (e.g. retried request)
+	toReap, _ := planPulseSinkReaps(sinks, map[string]bool{"EG_restarted": true}, firstOrphaned, testGrace, now.Add(2*testGrace))
+	require.Empty(t, toReap)
+	require.Empty(t, firstOrphaned)
+}
+
+func TestPulseSinkReaper_SinkGoneClearsTracking(t *testing.T) {
+	firstOrphaned := map[string]time.Time{}
+	now := time.Now()
+
+	planPulseSinkReaps([]pulse.Device{{Name: "EG_cleaned", OwnerModule: 5}}, map[string]bool{}, firstOrphaned, testGrace, now)
+	require.Contains(t, firstOrphaned, "EG_cleaned")
+
+	// the handler unloaded its own sink during the grace window
+	toReap, egressSinks := planPulseSinkReaps(nil, map[string]bool{}, firstOrphaned, testGrace, now.Add(time.Second))
+	require.Empty(t, toReap)
+	require.Zero(t, egressSinks)
+	require.Empty(t, firstOrphaned)
+}

--- a/test/edge.go
+++ b/test/edge.go
@@ -20,12 +20,19 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/livekit/egress/pkg/config"
+	"github.com/livekit/egress/pkg/pipeline/source/pulse"
 	"github.com/livekit/egress/pkg/types"
 	"github.com/livekit/protocol/livekit"
 	lksdk "github.com/livekit/server-sdk-go/v2"
@@ -271,6 +278,23 @@ func (r *Runner) testEdgeCases(t *testing.T) {
 					fileType: livekit.EncodedFileType_OGG,
 				},
 				custom: r.testDuplicateIdentitySilentExit,
+			},
+
+			// Handler killed without cleanup (crash, OOM-kill) leaks its
+			// null-sink on the shared pulse daemon. The monitor's reaper
+			// must unload it once the egress is no longer active.
+
+			{
+				name:        "PulseSinkReaper",
+				requestType: types.RequestTypeRoomComposite,
+				publishOptions: publishOptions{
+					audioCodec: types.MimeTypeOpus,
+					videoCodec: types.MimeTypeVP8,
+				},
+				fileOptions: &fileOptions{
+					filename: "pulse_sink_reaper_{time}.mp4",
+				},
+				custom: r.testPulseSinkReaper,
 			},
 		} {
 			if !r.run(t, test) {
@@ -702,4 +726,107 @@ func (r *Runner) testRoomCompositeRetryableDisconnect(t *testing.T, test *testCa
 	// And it is downloadable from storage.
 	local := fmt.Sprintf("%s/retryable_disconnect_partial.ogg", r.FilePrefix)
 	download(t, p.GetFileConfig().StorageConfig, local, fileRes.Filename, true)
+}
+
+func (r *Runner) testPulseSinkReaper(t *testing.T, test *testCase) {
+	req := r.build(test)
+	egressID := r.startEgress(t, req)
+
+	// chrome records through a null-sink named after the egress
+	require.Eventually(t, func() bool {
+		loaded, err := egressSinkLoaded(egressID)
+		return err == nil && loaded
+	}, 30*time.Second, time.Second, "pulse sink should be loaded while the egress is running")
+
+	// the reaper's gauge picks up the loaded sink on its next tick
+	require.Eventually(t, func() bool {
+		return pulseSinksGauge(t) >= 1
+	}, 30*time.Second, time.Second, "pulse_sinks gauge should count the loaded sink")
+
+	// SIGKILL the handler so WebSource.Close never runs and the sink leaks
+	pid := findHandlerPID(t, egressID)
+	t.Cleanup(func() {
+		// sweep the orphaned chrome/xvfb the dead handler left behind
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	})
+	require.NoError(t, syscall.Kill(pid, syscall.SIGKILL))
+
+	// the service notices the death, reports the egress failed, and drops it
+	// from the monitor, leaving the sink orphaned
+	deadline := time.Now().Add(30 * time.Second)
+	for r.getUpdate(t, egressID).Status != livekit.EgressStatus_EGRESS_FAILED {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the killed egress to be reported failed")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// the reaper unloads the orphaned sink after the grace period
+	require.Eventually(t, func() bool {
+		loaded, err := egressSinkLoaded(egressID)
+		return err == nil && !loaded
+	}, time.Minute, time.Second, "orphaned pulse sink should be reaped")
+
+	// and the gauge drops back to zero on the tick after the unload
+	require.Eventually(t, func() bool {
+		return pulseSinksGauge(t) == 0
+	}, 30*time.Second, time.Second, "pulse_sinks gauge should drop after the reap")
+}
+
+// pulseSinksGauge reads livekit_egress_pulse_sinks from the default prometheus
+// registry, which the in-process monitor registers into. Returns -1 if the
+// gauge isn't registered or gathering fails.
+func pulseSinksGauge(t *testing.T) float64 {
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Logf("prometheus gather failed: %v", err)
+		return -1
+	}
+
+	for _, family := range families {
+		if family.GetName() == "livekit_egress_pulse_sinks" {
+			for _, m := range family.GetMetric() {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	return -1
+}
+
+func egressSinkLoaded(egressID string) (bool, error) {
+	info, err := pulse.List()
+	if err != nil {
+		return false, err
+	}
+	for _, sink := range info.Sinks {
+		if sink.Name == egressID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// findHandlerPID locates the `egress run-handler` process for the given egress
+// by scanning /proc, since the ProcessManager doesn't expose handler PIDs.
+func findHandlerPID(t *testing.T, egressID string) int {
+	entries, err := os.ReadDir("/proc")
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		cmdline, err := os.ReadFile(path.Join("/proc", e.Name(), "cmdline"))
+		if err != nil {
+			continue
+		}
+		args := string(cmdline)
+		if strings.Contains(args, "run-handler") && strings.Contains(args, egressID) {
+			return pid
+		}
+	}
+
+	t.Fatalf("no run-handler process found for %s", egressID)
+	return 0
 }

--- a/test/runner.go
+++ b/test/runner.go
@@ -170,6 +170,8 @@ func NewRunner(t *testing.T) *Runner {
 	conf.EnableSyncEngine = true
 	conf.AudioTempoController.Enabled = true
 	conf.AudioTempoController.AdjustmentRate = 0.05
+	// short grace so the pulse sink reaper edge case completes quickly
+	conf.PulseSinkReapGraceSec = 3
 
 	r.ServiceConfig = conf
 


### PR DESCRIPTION
Reap PulseAudio null-sinks left behind by egress handlers that died without running cleanup, so a crashed recording self-heals instead of permanently disabling web egress on the pod.

Fresh implementation of the idea from #1275 (credit to @biswajitpain), restructured to address the review feedback on #1279: the reaper must never run under the monitor lock or block the stats goroutine.

Each web/room-composite handler loads a `module-null-sink` (named after its EgressId) into the shared, pod-lifetime PulseAudio daemon, and only unloads it in `WebSource.Close()`. When a handler dies abnormally (Chrome/GStreamer crash, OOM-kill, SIGKILL), `Close()` never runs and the sink leaks. Nothing reconciles them, so the pulse client count climbs until `canAcceptWebLocked()` permanently rejects every web/room-composite request with `reason: "pulse clients"` - a zombie pod that health checks don't catch. See #1274 for the full write-up.

The reaper runs in its own goroutine on a 30s cadence, fully decoupled from the stats tick. It never holds the monitor mutex across pactl calls: active egress IDs (`pending` ∪ `procStats`) are snapshotted under the lock, which is released before any subprocess is spawned. `AcceptRequest` and `GetAvailableCPU` (liveness) are never blocked by a slow pulse daemon. All pactl invocations go through `exec.CommandContext` with a 10s timeout. If `pactl list` hangs or fails, the reaper logs once (throttled until recovery) and skips that check. Reap decisions live in a pure function: egress-owned sinks (`EG_` prefix)  whose egress is no longer tracked are unloaded only after remaining orphaned for a full grace period (default 30s), covering the normal teardown gap  between `EgressEnded` and the handler's own unload. Tracking resets when a sink becomes active again, disappears, or is reaped, so a failed unload waits out a fresh grace period instead of retrying every tick.

Replaces: https://github.com/livekit/egress/pull/1279