### PR TITLE
Restore livekitwebrtcsrc/sink in gstreamer images, support revision tags

### DIFF
--- a/.github/workflows/publish-gstreamer-base.yaml
+++ b/.github/workflows/publish-gstreamer-base.yaml
@@ -4,6 +4,12 @@ on:
       version:
         required: true
         type: string
+      image_tag:
+        # docker tag to publish under; may differ from version for revised
+        # builds of the same upstream release (e.g. 1.26.7 -> 1.26.7-1)
+        required: false
+        type: string
+        default: ""
       buildjet-runs-on:
         required: true
         type: string
@@ -17,6 +23,7 @@ on:
         required: true
 env:
   GST_VERSION: "${{ inputs.version }}"
+  IMAGE_TAG: "${{ inputs.image_tag != '' && inputs.image_tag || inputs.version }}"
   LIBNICE_VERSION: "0.1.21"
 
 jobs:
@@ -36,6 +43,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # the base stage downloads upstream sources, so its GSTREAMER_VERSION
+      # build-arg must be the real upstream version. The later stages only use
+      # the build-arg in FROM lines, so they get IMAGE_TAG to chain off the
+      # image built here.
       - name: Build and push base
         uses: docker/build-push-action@v7
         with:
@@ -45,7 +56,7 @@ jobs:
             GSTREAMER_VERSION=${{ env.GST_VERSION }}
             LIBNICE_VERSION=${{ env.LIBNICE_VERSION }}
           file: ./build/gstreamer/Dockerfile-base
-          tags: livekit/gstreamer:${{ env.GST_VERSION }}-base-${{ inputs.arch }}
+          tags: livekit/gstreamer:${{ env.IMAGE_TAG }}-base-${{ inputs.arch }}
 
       - name: Build and push dev
         uses: docker/build-push-action@v7
@@ -53,10 +64,10 @@ jobs:
           context: ./build/gstreamer
           push: true
           build-args: |
-            GSTREAMER_VERSION=${{ env.GST_VERSION }}
+            GSTREAMER_VERSION=${{ env.IMAGE_TAG }}
             LIBNICE_VERSION=${{ env.LIBNICE_VERSION }}
           file: ./build/gstreamer/Dockerfile-dev
-          tags: livekit/gstreamer:${{ env.GST_VERSION }}-dev-${{ inputs.arch }}
+          tags: livekit/gstreamer:${{ env.IMAGE_TAG }}-dev-${{ inputs.arch }}
 
       - name: Build and push prod
         uses: docker/build-push-action@v7
@@ -64,10 +75,10 @@ jobs:
           context: ./build/gstreamer
           push: true
           build-args: |
-            GSTREAMER_VERSION=${{ env.GST_VERSION }}
+            GSTREAMER_VERSION=${{ env.IMAGE_TAG }}
             LIBNICE_VERSION=${{ env.LIBNICE_VERSION }}
           file: ./build/gstreamer/Dockerfile-prod
-          tags: livekit/gstreamer:${{ env.GST_VERSION }}-prod-${{ inputs.arch }}
+          tags: livekit/gstreamer:${{ env.IMAGE_TAG }}-prod-${{ inputs.arch }}
 
       - name: Build and push prod RS
         uses: docker/build-push-action@v7
@@ -75,7 +86,7 @@ jobs:
           context: ./build/gstreamer
           push: true
           build-args: |
-            GSTREAMER_VERSION=${{ env.GST_VERSION }}
+            GSTREAMER_VERSION=${{ env.IMAGE_TAG }}
             LIBNICE_VERSION=${{ env.LIBNICE_VERSION }}
           file: ./build/gstreamer/Dockerfile-prod-rs
-          tags: livekit/gstreamer:${{ env.GST_VERSION }}-prod-rs-${{ inputs.arch }}
+          tags: livekit/gstreamer:${{ env.IMAGE_TAG }}-prod-rs-${{ inputs.arch }}

--- a/.github/workflows/publish-gstreamer-base.yaml
+++ b/.github/workflows/publish-gstreamer-base.yaml
@@ -23,7 +23,7 @@ on:
         required: true
 env:
   GST_VERSION: "${{ inputs.version }}"
-  IMAGE_TAG: "${{ inputs.image_tag != '' && inputs.image_tag || inputs.version }}"
+  IMAGE_TAG: "${{ inputs.image_tag || inputs.version }}"
   LIBNICE_VERSION: "0.1.21"
 
 jobs:

--- a/.github/workflows/publish-gstreamer.yaml
+++ b/.github/workflows/publish-gstreamer.yaml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/publish-gstreamer-base.yaml
     with:
       version: ${{ inputs.version }}
-      image_tag: ${{ inputs.image_tag != '' && inputs.image_tag || inputs.version }}
+      image_tag: ${{ inputs.image_tag || inputs.version }}
       buildjet-runs-on: ubuntu-latest-m
       arch: amd64
     secrets:
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/publish-gstreamer-base.yaml
     with:
       version: ${{ inputs.version }}
-      image_tag: ${{ inputs.image_tag != '' && inputs.image_tag || inputs.version }}
+      image_tag: ${{ inputs.image_tag || inputs.version }}
       buildjet-runs-on: namespace-profile-arm-16
       arch: arm64
     secrets:
@@ -53,4 +53,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run tag script
-        run: ./build/gstreamer/tag.sh ${{ inputs.image_tag != '' && inputs.image_tag || inputs.version }}
+        run: ./build/gstreamer/tag.sh ${{ inputs.image_tag || inputs.version }}

--- a/.github/workflows/publish-gstreamer.yaml
+++ b/.github/workflows/publish-gstreamer.yaml
@@ -4,15 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "GStreamer version to publish (e.g. 1.24.4)"
+        description: "Upstream GStreamer version to build (e.g. 1.26.7)"
         required: true
         type: string
+      image_tag:
+        description: "Docker tag to publish under (e.g. 1.26.7-1). Defaults to version."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   gstreamer-build-amd64:
     uses: ./.github/workflows/publish-gstreamer-base.yaml
     with:
       version: ${{ inputs.version }}
+      image_tag: ${{ inputs.image_tag != '' && inputs.image_tag || inputs.version }}
       buildjet-runs-on: ubuntu-latest-m
       arch: amd64
     secrets:
@@ -23,6 +29,7 @@ jobs:
     uses: ./.github/workflows/publish-gstreamer-base.yaml
     with:
       version: ${{ inputs.version }}
+      image_tag: ${{ inputs.image_tag != '' && inputs.image_tag || inputs.version }}
       buildjet-runs-on: namespace-profile-arm-16
       arch: arm64
     secrets:
@@ -46,4 +53,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run tag script
-        run: ./build/gstreamer/tag.sh ${{ inputs.version }}
+        run: ./build/gstreamer/tag.sh ${{ inputs.image_tag != '' && inputs.image_tag || inputs.version }}

--- a/build/gstreamer/compile-rs
+++ b/build/gstreamer/compile-rs
@@ -12,7 +12,9 @@ for repo in gst-plugins-rs; do
   sed s,'\[profile.release\]','[profile.release]\nstrip="debuginfo"', Cargo.toml.old > Cargo.toml
   cargo update -p time
 
-  opts="-D prefix=/usr -D tests=disabled -D doc=disabled"
+  # webrtc-livekit is disabled by default upstream; without it the rswebrtc
+  # plugin builds without the livekitwebrtcsrc/livekitwebrtcsink elements
+  opts="-D prefix=/usr -D tests=disabled -D doc=disabled -D webrtc-livekit=enabled"
 
   if [[ $DEBUG == 'true' ]]; then
     if [[ $OPTIMIZATIONS == 'true' ]]; then
@@ -40,3 +42,7 @@ for repo in gst-plugins-rs; do
 done
 
 gst-inspect-1.0
+
+# fail the build if the livekit signaller silently fell out of the webrtc plugin
+gst-inspect-1.0 livekitwebrtcsrc > /dev/null
+gst-inspect-1.0 livekitwebrtcsink > /dev/null


### PR DESCRIPTION
Enable the LiveKit signaller when building gst-plugins-rs: newer upstream releases moved it behind an opt-in meson option (`webrtc-livekit`, disabled by default), so the 1.26.7 images silently lost `livekitwebrtcsrc` /  `livekitwebrtcsink` (present in 1.24.12). `compile-rs` now passes `-D webrtc-livekit=enabled` and fails the build either element is missing, so this can't regress silently again.

Decouple the docker tag from the upstream source version in the publish workflows via a new optional `image_tag` input (defaults to `version`). This allows republishing a fixed build of an already-released version under a  revision tag (e.g. `1.26.7-1`) instead of mutating the existing `1.26.7` tags. Only the base stage uses the version for source downloads; the dev/prod/prod-rs stages use the build-arg solely in `FROM` lines, so they chain off the revision-tagged base.