### PR TITLE
Fix appsrc state regression when adding source bins during pipeline startup

### DIFF
--- a/pkg/gstreamer/bin.go
+++ b/pkg/gstreamer/bin.go
@@ -647,7 +647,10 @@ func linkPeersLocked(src, sink *Bin) error {
 				}
 				return gst.PadProbeRemove
 			})
-			return src.SetState(gst.StatePlaying)
+			if !src.bin.SyncStateWithParent() {
+				return errors.New(fmt.Sprintf("failed to sync %s state with parent", src.bin.GetName()))
+			}
+			return nil
 		}
 
 		if sinkState == gst.StateNull {

--- a/pkg/gstreamer/bin.go
+++ b/pkg/gstreamer/bin.go
@@ -648,7 +648,7 @@ func linkPeersLocked(src, sink *Bin) error {
 				return gst.PadProbeRemove
 			})
 			if !src.bin.SyncStateWithParent() {
-				return errors.New(fmt.Sprintf("failed to sync %s state with parent", src.bin.GetName()))
+				return fmt.Errorf("failed to sync %s state with parent", src.bin.GetName())
 			}
 			return nil
 		}


### PR DESCRIPTION
When a source bin (appsrc) is added dynamically, `linkPeersLocked` forced it to PLAYING with `SetState(gst.StatePlaying)`. This races with the pipeline's own NULL → PLAYING transition: dynamic linking is enabled at `StateStarted`, which is set before `pipeline.SetState(PLAYING)` is called, so a track can be added while the pipeline is still NULL or mid-transition. GStreamer's state propagation (`gst_bin_element_set_state`) always recurses into child bins - the "already at target state" skip does not apply to them. A source bin manually set to PLAYING therefore gets forced back down to READY by the pipeline's NULL → READY step. That downward transition deactivates the appsrc's pads and stops its streaming task, and depending on interleaving (e.g. a stale cached ASYNC_START causing subsequent upward steps to skip the child) the bin can be stranded below PLAYING while the rest of the pipeline reaches PLAYING. nothing is pushed downstream anymore.

Using `gst_element_sync_state_with_parent()` instead of forcing PLAYING. It targets the parent's pending state (the final target of an in-flight transition), falling back to its current state:
- Pipeline not yet transitioning (NULL): no-op; the pipeline's upcoming transition brings the bin up along with all other children
- Pipeline mid NULL → PLAYING: commands PLAYING, but never above the pipeline's target, so it converges with the transition instead of being dragged down from a state ahead of it.
- Pipeline already PLAYING: commands PLAYING directly, same as before.

This should fix one of the biggest remaining pipeline frozen errors and eliminate the need to forcefully re-add flushing source.