### PR TITLE
Log egress hw stats at the end with the info level

### DIFF
--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -542,6 +542,33 @@ func ShouldUseSDKSource(req interface {
 	return req.GetAudioOnly() && req.GetLayout() == "" && req.GetCustomBaseUrl() == ""
 }
 
+func IsSDKSourceRequest(req *rpc.StartEgressRequest) bool {
+	switch r := req.Request.(type) {
+	case *rpc.StartEgressRequest_RoomComposite:
+		return ShouldUseSDKSource(r.RoomComposite)
+	case *rpc.StartEgressRequest_Web:
+		return false
+	case *rpc.StartEgressRequest_Egress:
+		return isV2SDKSource(r.Egress)
+	case *rpc.StartEgressRequest_Replay:
+		return isV2SDKSource(r.Replay)
+	}
+	return true
+}
+
+func isV2SDKSource(req egress.EgressRequest) bool {
+	if req == nil {
+		return true
+	}
+	if req.GetWeb() != nil {
+		return false
+	}
+	if t := req.GetTemplate(); t != nil {
+		return ShouldUseSDKSource(t)
+	}
+	return true
+}
+
 // applyV2Source handles the shared Template/Web/Media source switch for the v2
 // request shape. Satisfied by both *livekit.StartEgressRequest and *livekit.ExportReplayRequest.
 func (p *PipelineConfig) applyV2Source(req egress.EgressRequest) (connectionInfoRequired bool, err error) {

--- a/pkg/server/server_rpc.go
+++ b/pkg/server/server_rpc.go
@@ -188,8 +188,12 @@ func (s *Server) processEnded(req *rpc.StartEgressRequest, info *livekit.EgressI
 
 	avgCPU, maxCPU, maxMemory := s.monitor.EgressEnded(req)
 	if maxCPU > 0 {
+		requestType, outputType := egress.GetTypes(info.Request)
 		logger.Infow("egress metrics",
 			"egressID", info.EgressId,
+			"requestType", requestType,
+			"outputType", outputType,
+			"sdkSource", config.IsSDKSourceRequest(req),
 			"avgCPU", avgCPU,
 			"maxCPU", maxCPU,
 			"maxMemory", maxMemory,

--- a/pkg/server/server_rpc.go
+++ b/pkg/server/server_rpc.go
@@ -188,7 +188,7 @@ func (s *Server) processEnded(req *rpc.StartEgressRequest, info *livekit.EgressI
 
 	avgCPU, maxCPU, maxMemory := s.monitor.EgressEnded(req)
 	if maxCPU > 0 {
-		logger.Debugw("egress metrics",
+		logger.Infow("egress metrics",
 			"egressID", info.EgressId,
 			"avgCPU", avgCPU,
 			"maxCPU", maxCPU,


### PR DESCRIPTION
These metrics are quite important and interesting, making sure info level logs also include it.