### PR TITLE
Pass handler config/request via env vars, not cmdline

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -57,10 +57,12 @@ func main() {
 				Description: "runs a request in a new process",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name: "request",
+						Name:    "request",
+						Sources: cli.EnvVars("EGRESS_HANDLER_REQUEST"),
 					},
 					&cli.StringFlag{
-						Name: "config",
+						Name:    "config",
+						Sources: cli.EnvVars("EGRESS_HANDLER_CONFIG_BODY"),
 					},
 				},
 				Action: runHandler,

--- a/pkg/server/server_rpc.go
+++ b/pkg/server/server_rpc.go
@@ -135,12 +135,12 @@ func (s *Server) launchProcess(req *rpc.StartEgressRequest, info *livekit.Egress
 		return err
 	}
 
-	cmd := exec.Command("egress",
-		"run-handler",
-		"--config", string(confString),
-		"--request", string(reqString),
-	)
+	cmd := exec.Command("egress", "run-handler")
 	cmd.Dir = "/"
+	cmd.Env = append(os.Environ(),
+		"EGRESS_HANDLER_CONFIG_BODY="+string(confString),
+		"EGRESS_HANDLER_REQUEST="+string(reqString),
+	)
 
 	l := logging.NewHandlerLogger(handlerID, req.EgressId)
 	cmd.Stdout = l

--- a/test/edge.go
+++ b/test/edge.go
@@ -807,7 +807,9 @@ func egressSinkLoaded(egressID string) (bool, error) {
 }
 
 // findHandlerPID locates the `egress run-handler` process for the given egress
-// by scanning /proc, since the ProcessManager doesn't expose handler PIDs.
+// by scanning /proc, since the ProcessManager doesn't expose handler PIDs. The
+// egress ID is passed to the handler via its environment (EGRESS_HANDLER_*),
+// not its command line, so match on /proc/<pid>/environ.
 func findHandlerPID(t *testing.T, egressID string) int {
 	entries, err := os.ReadDir("/proc")
 	require.NoError(t, err)
@@ -818,11 +820,14 @@ func findHandlerPID(t *testing.T, egressID string) int {
 			continue
 		}
 		cmdline, err := os.ReadFile(path.Join("/proc", e.Name(), "cmdline"))
+		if err != nil || !strings.Contains(string(cmdline), "run-handler") {
+			continue
+		}
+		environ, err := os.ReadFile(path.Join("/proc", e.Name(), "environ"))
 		if err != nil {
 			continue
 		}
-		args := string(cmdline)
-		if strings.Contains(args, "run-handler") && strings.Contains(args, egressID) {
+		if strings.Contains(string(environ), egressID) {
 			return pid
 		}
 	}


### PR DESCRIPTION
## Summary

The per-egress config and request are passed to the hidden `run-handler` child process as `--config` / `--request` command-line args. The marshaled `PipelineConfig` carries secrets — Redis password, S3/Azure/GCP credentials, API keys — so they leak to any local user via `ps` / `/proc/<pid>/cmdline`.

This moves both payloads onto the child process **environment** instead:

- `pkg/server/server_rpc.go` — `launchProcess` sets `EGRESS_HANDLER_CONFIG_BODY` and `EGRESS_HANDLER_REQUEST` on `cmd.Env` (inheriting `os.Environ()`) instead of appending CLI args.
- `cmd/server/main.go` — the `run-handler` `--config` / `--request` flags gain those env vars as `Sources`, so they're populated from the environment. `runHandler` is unchanged (`c.String(...)` resolves the env source transparently), and the flags still work for manual invocation.

Env vars also sidestep `ARG_MAX` limits on the (potentially large) config+request payloads.

Closes [CS-1878](https://linear.app/livekit/issue/CS-1878/bug-api-secret-leaks-in-egress-cmdline)

## Test plan

- [ ] `pkg/server` builds cleanly
- [ ] Existing integration suite (`mage integration`) exercises the real parent→child launch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)