### PR TITLE
Add least-privilege permissions to GitHub workflows

### DIFF
--- a/.github/workflows/publish-chrome.yaml
+++ b/.github/workflows/publish-chrome.yaml
@@ -12,6 +12,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-egress.yaml
+++ b/.github/workflows/publish-egress.yaml
@@ -21,6 +21,10 @@ on:
     # only publish on version tags
     tags:
       - 'v*.*.*'
+
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest-m

--- a/.github/workflows/publish-gstreamer-base.yaml
+++ b/.github/workflows/publish-gstreamer-base.yaml
@@ -21,6 +21,9 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
+permissions:
+  contents: read
+
 env:
   GST_VERSION: "${{ inputs.version }}"
   IMAGE_TAG: "${{ inputs.image_tag || inputs.version }}"

--- a/.github/workflows/publish-gstreamer.yaml
+++ b/.github/workflows/publish-gstreamer.yaml
@@ -13,6 +13,9 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   gstreamer-build-amd64:
     uses: ./.github/workflows/publish-gstreamer-base.yaml

--- a/.github/workflows/publish-template-sdk.yaml
+++ b/.github/workflows/publish-template-sdk.yaml
@@ -18,6 +18,9 @@ on:
     tags:
       - "template*"
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-template.yaml
+++ b/.github/workflows/publish-template.yaml
@@ -22,6 +22,10 @@ on:
       - template-default/**
       - template-sdk/**
 
+# EndBug/add-and-commit pushes the updated template version back to the branch
+permissions:
+  contents: write
+
 jobs:
   docker:
     runs-on: ubuntu-latest-m

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -29,7 +29,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -22,6 +22,9 @@ on:
       - template-default/**
       - template-sdk/**
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: template-default


### PR DESCRIPTION
## Summary

Sets explicit `GITHUB_TOKEN` permissions on all GitHub workflows following the principle of least privilege. Previously most workflows had no `permissions` block and inherited the repo-wide default token scope.

## Changes

Added top-level `permissions` to the 7 workflows that had none:

| Workflow | Permission | Rationale |
|---|---|---|
| `publish-chrome.yaml` | `contents: read` | Checkout + DockerHub push via secrets |
| `publish-egress.yaml` | `contents: read` | Checkout + DockerHub push |
| `publish-gstreamer-base.yaml` | `contents: read` | Reusable workflow; checkout + DockerHub push |
| `publish-gstreamer.yaml` | `contents: read` | Checkout + DockerHub push |
| `publish-template-sdk.yaml` | `contents: read` | Checkout + npm publish via `NPM_TOKEN` |
| `publish-template.yaml` | `contents: write` | `EndBug/add-and-commit` pushes the version bump back to the branch |
| `test-template.yaml` | `contents: read` | Checkout + pnpm build |

Also removed the unused `packages: write` from `test-integration.yaml` — it pushes to DockerHub via secrets, not GHCR.

Workflows already carrying explicit blocks (`slack-notifier.yaml`, `test-cleanup.yaml`, `test-integration.yaml`) were left as-is aside from the change above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)