### PR TITLE
Don't log room deleted reason as warning

### DIFF
--- a/pkg/pipeline/source/sdk.go
+++ b/pkg/pipeline/source/sdk.go
@@ -813,17 +813,20 @@ func (s *SDKSource) onDisconnectedWithReason(reason lksdk.DisconnectionReason) {
 	if reason == lksdk.DuplicateIdentity {
 		s.duplicateIdentity.Store(true)
 	}
-	if reason != lksdk.RoomClosed && reason != lksdk.LeaveRequested {
-		protoReason := "unknown"
-		if room := s.room.Load(); room != nil {
-			protoReason = room.DisconnectReason().String()
-		}
-		logger.Warnw("disconnected from room", nil, "reason", reason, "protoReason", protoReason)
 
-		if reason == lksdk.Failed {
-			s.connectionFailed.Store(true)
-		}
+	protoReason := livekit.DisconnectReason_UNKNOWN_REASON
+	if room := s.room.Load(); room != nil {
+		protoReason = room.DisconnectReason()
 	}
+
+	if shouldWarnOnRoomDisconnect(reason, protoReason) {
+		logger.Warnw("disconnected from room", nil, "reason", reason, "protoReason", protoReason)
+	}
+
+	if reason == lksdk.Failed {
+		s.connectionFailed.Store(true)
+	}
+
 	s.finished()
 }
 
@@ -872,4 +875,10 @@ func (s *SDKSource) shouldDisableAudioPTSAdjustment() bool {
 		s.RequestType == types.RequestTypeTemplate || // SDK templates are audio only - same as room composite
 		s.RequestType == types.RequestTypeTrack || // no A/V sync needed for single track requests
 		s.AudioTempoController.Enabled
+}
+
+func shouldWarnOnRoomDisconnect(reason lksdk.DisconnectionReason, protoReason livekit.DisconnectReason) bool {
+	return reason != lksdk.RoomClosed &&
+		reason != lksdk.LeaveRequested &&
+		protoReason != livekit.DisconnectReason_ROOM_DELETED
 }


### PR DESCRIPTION
Room deleted reason could happen as part of expected flow and shouldn't be logged as warning