### PR TITLE
Remove appsrc recovery on flushing

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -110,6 +110,7 @@ var (
 	ErrNonRetryableOutput         = psrpc.NewErrorf(psrpc.FailedPrecondition, "output configuration does not support retry")
 	ErrHandlerFailedToStart       = psrpc.NewErrorf(psrpc.Internal, "handler failed to start")
 	ErrRoomConnectionFailed       = psrpc.NewErrorf(psrpc.Unavailable, "recording ended early: connection to room failed")
+	ErrPersistentFlushing         = psrpc.NewErrorf(psrpc.Internal, "recording ended early: track stuck in persistent FlowFlushing")
 )
 
 func PageLoadError(err string) error {

--- a/pkg/gstreamer/bin.go
+++ b/pkg/gstreamer/bin.go
@@ -16,7 +16,6 @@ package gstreamer
 
 import (
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
@@ -46,9 +45,6 @@ const (
 //     - Bin fields (`srcs`, `sinks`, `elements`, `pads`, etc.) under `b.mu`.
 //     Then unlock before scheduling the callback. Avoid holding these locks
 //     while waiting for the callback to run on the GLib loop.
-//     Exception: ForceRemoveSourceBin intentionally holds a shared state lock
-//     across the wait to prevent state-mutation races from concurrent Stop/
-//     state-transition calls while forced detach is in progress.
 //
 
 // Bin is designed to hold a single stream, with any number of sources and sinks
@@ -179,61 +175,6 @@ func (b *Bin) AddElements(elements ...*gst.Element) error {
 		return errors.ErrGstPipelineError(err)
 	}
 	return nil
-}
-
-// ForceRemoveSourceBin synchronously removes a source bin without waiting for EOS.
-// This is used for FlowFlushing recovery where EOS will never propagate from a stuck appsrc.
-// The removal runs on the GLib main loop thread via glib.IdleAdd and blocks until complete.
-func (b *Bin) ForceRemoveSourceBin(name string) error {
-	logger.Infow("force removing source bin", "src", name, "from", b.bin.GetName())
-
-	b.LockStateShared()
-	defer b.UnlockStateShared()
-
-	state := b.GetStateLocked()
-	if state > StateRunning {
-		return nil
-	}
-
-	b.mu.Lock()
-
-	idx := slices.IndexFunc(b.srcs, func(s *Bin) bool { return s.bin.GetName() == name })
-	if idx == -1 {
-		b.mu.Unlock()
-		return nil
-	}
-	src := b.srcs[idx]
-
-	src.mu.Lock()
-	srcGhostPad, sinkGhostPad, ok := deleteGhostPadsLocked(src, b)
-	src.mu.Unlock()
-	if !ok {
-		b.mu.Unlock()
-		return errors.New("ghost pads not found for force removal")
-	}
-
-	// Now safe to remove from the tracking slice
-	b.srcs = slices.Delete(b.srcs, idx, idx+1)
-
-	// Capture references before releasing the lock.
-	// These fields are set during construction and never modified, so safe to use after unlock.
-	peerElement := b.elements[0]
-	parentBin := b.bin
-	pipeline := b.pipeline
-
-	b.mu.Unlock()
-
-	// Execute removal synchronously on the GLib main loop thread
-	done := make(chan error, 1)
-	if _, err := glib.IdleAdd(func() bool {
-		logger.Debugw("force removing source bin on GLib thread", "bin", src.bin.GetName())
-		done <- detachSourceBin(src, srcGhostPad, sinkGhostPad, peerElement, parentBin, pipeline)
-		return false
-	}); err != nil {
-		return errors.ErrGstPipelineError(err)
-	}
-
-	return <-done
 }
 
 func (b *Bin) RemoveSourceBin(name string) error {

--- a/pkg/gstreamer/callbacks.go
+++ b/pkg/gstreamer/callbacks.go
@@ -36,7 +36,6 @@ type Callbacks struct {
 	onTrackMuted     []func(string)
 	onTrackUnmuted   []func(string)
 	onTrackRemoved   []func(string)
-	onSourceBinReset []func(*config.TrackSource) error
 	onEOSSent        func()
 
 	pipelinePaused core.Fuse
@@ -162,29 +161,6 @@ func (c *Callbacks) OnTrackRemoved(trackID string) {
 	for _, f := range onTrackRemoved {
 		f(trackID)
 	}
-}
-
-func (c *Callbacks) AddOnSourceBinReset(f func(*config.TrackSource) error) {
-	c.mu.Lock()
-	c.onSourceBinReset = append(c.onSourceBinReset, f)
-	c.mu.Unlock()
-}
-
-// OnSourceBinReset calls registered handlers to force-remove a stuck source bin and
-// replace it with a new one. Each handler checks the track kind and returns nil if
-// not applicable. The first handler that returns a non-nil error aborts the operation.
-// On success, ts.AppSrc is updated to the new appsrc by the handler.
-func (c *Callbacks) OnSourceBinReset(ts *config.TrackSource) error {
-	c.mu.RLock()
-	handlers := c.onSourceBinReset
-	c.mu.RUnlock()
-
-	for _, f := range handlers {
-		if err := f(ts); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (c *Callbacks) SetOnEOSSent(f func()) {

--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/go-gst/go-gst/gst"
-	"github.com/go-gst/go-gst/gst/app"
 	"github.com/linkdata/deadlock"
 
 	"github.com/livekit/egress/pkg/config"
@@ -70,7 +69,6 @@ func BuildAudioBin(pipeline *gstreamer.Pipeline, p *config.PipelineConfig) error
 
 		pipeline.AddOnTrackAdded(b.onTrackAdded)
 		pipeline.AddOnTrackRemoved(b.onTrackRemoved)
-		pipeline.AddOnSourceBinReset(b.onSourceBinReset)
 	}
 
 	if len(p.GetEncodedOutputs()) > 1 {
@@ -323,61 +321,6 @@ func (b *AudioBin) addAudioAppSrcBinLocked(ts *config.TrackSource) error {
 	return nil
 }
 
-func (b *AudioBin) onSourceBinReset(ts *config.TrackSource) error {
-	if ts.TrackKind != lksdk.TrackKindAudio {
-		return nil
-	}
-	return b.resetAudioAppSrcBin(ts)
-}
-
-func (b *AudioBin) resetAudioAppSrcBin(ts *config.TrackSource) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	oldName, ok := b.names[ts.TrackID]
-	if !ok {
-		return errors.New("track already removed, cannot reset audio source bin")
-	}
-
-	if b.bin.GetState() > gstreamer.StateRunning {
-		return errors.New("pipeline stopping, cannot reset audio source bin")
-	}
-
-	// Detach the tempo controller callback so a concurrent SetDrift can't invoke
-	// the old pacer's closure on the soon-to-be-freed pitch element. The new
-	// callback is re-registered inside addAudioAppSrcBinLocked below.
-	//
-	// CancelInFlight clears the in-flight target so the immediate-callback fire
-	// inside the new OnDriftDetectedCallback registration does not arm the new
-	// pacer with the old pacer's target. The old pacer's partial compensation
-	// is downstream of the bin being discarded — re-applying it on the new
-	// pacer would double-correct. The next SR will surface any residual drift
-	// and the controller arms fresh against the current state.
-	if ts.TempoController != nil {
-		ts.TempoController.OnDriftDetectedCallback(nil)
-		ts.TempoController.OnTierChange(nil)
-		ts.TempoController.CancelInFlight()
-	}
-
-	// Force-remove old bin (blocks on GLib main loop, safe to hold b.mu since
-	// ForceRemoveSourceBin only acquires gstreamer.Bin's internal mutex)
-	if err := b.bin.ForceRemoveSourceBin(oldName); err != nil {
-		return fmt.Errorf("failed to force remove audio source bin: %w", err)
-	}
-
-	newElement, err := gst.NewElementWithName("appsrc", fmt.Sprintf("app_%s", ts.TrackID))
-	if err != nil {
-		return errors.ErrGstPipelineError(err)
-	}
-	ts.AppSrc = app.SrcFromElement(newElement)
-
-	if err := b.addAudioAppSrcBinLocked(ts); err != nil {
-		return fmt.Errorf("failed to add new audio source bin: %w", err)
-	}
-
-	logger.Infow("audio source bin reset complete", "trackID", ts.TrackID, "newBin", b.names[ts.TrackID])
-	return nil
-}
 
 func (b *AudioBin) getChannelLocked(ts *config.TrackSource) livekit.AudioChannel {
 	if ts.AudioChannel != nil {

--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/go-gst/go-gst/gst"
-	"github.com/go-gst/go-gst/gst/app"
 	"github.com/linkdata/deadlock"
 
 	"github.com/livekit/egress/pkg/config"
@@ -85,7 +84,6 @@ func BuildVideoBin(pipeline *gstreamer.Pipeline, p *config.PipelineConfig) error
 		pipeline.AddOnTrackRemoved(b.onTrackRemoved)
 		pipeline.AddOnTrackMuted(b.onTrackMuted)
 		pipeline.AddOnTrackUnmuted(b.onTrackUnmuted)
-		pipeline.AddOnSourceBinReset(b.onSourceBinReset)
 	}
 
 	var getPad func() *gst.Pad
@@ -202,76 +200,6 @@ func (b *VideoBin) onTrackUnmuted(trackID string) {
 		}
 	}
 	b.mu.Unlock()
-}
-
-func (b *VideoBin) onSourceBinReset(ts *config.TrackSource) error {
-	if ts.TrackKind != lksdk.TrackKindVideo {
-		return nil
-	}
-	return b.resetVideoAppSrcBin(ts)
-}
-
-func (b *VideoBin) resetVideoAppSrcBin(ts *config.TrackSource) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	oldName, ok := b.names[ts.TrackID]
-	if !ok {
-		return errors.New("track already removed, cannot reset video source bin")
-	}
-
-	if b.bin.GetState() > gstreamer.StateRunning {
-		return errors.New("pipeline stopping, cannot reset video source bin")
-	}
-
-	// If the stuck bin is the currently selected pad, switch to test src first
-	if b.conf.VideoDecoding && b.selectedPad == oldName {
-		if err := b.setSelectorPadLocked(videoTestSrcName); err != nil {
-			return err
-		}
-	}
-
-	// Clean up old pad reference before force-remove
-	delete(b.pads, oldName)
-	b.closeProbe(oldName)
-
-	// Force-remove old bin (blocks on GLib main loop, safe to hold b.mu since
-	// ForceRemoveSourceBin only acquires gstreamer.Bin's internal mutex)
-	if err := b.bin.ForceRemoveSourceBin(oldName); err != nil {
-		return fmt.Errorf("failed to force remove video source bin: %w", err)
-	}
-
-	// Create new appsrc element (reuse the same element name so watch.go works)
-	newElement, err := gst.NewElementWithName("appsrc", fmt.Sprintf("app_%s", ts.TrackID))
-	if err != nil {
-		return errors.ErrGstPipelineError(err)
-	}
-	ts.AppSrc = app.SrcFromElement(newElement)
-
-	name := fmt.Sprintf("%s_%d", ts.TrackID, b.nextID)
-	b.nextID++
-
-	appSrcBin, err := b.buildAppSrcBin(ts, name)
-	if err != nil {
-		return fmt.Errorf("failed to build new video source bin: %w", err)
-	}
-
-	if b.conf.VideoDecoding {
-		b.createSrcPadLocked(ts.TrackID, name)
-	}
-
-	if err = b.bin.AddSourceBin(appSrcBin); err != nil {
-		return fmt.Errorf("failed to add new video source bin: %w", err)
-	}
-
-	if b.conf.VideoDecoding {
-		if err := b.setSelectorPadLocked(name); err != nil {
-			return err
-		}
-	}
-
-	logger.Infow("video source bin reset complete", "trackID", ts.TrackID, "newBin", name)
-	return nil
 }
 
 func (b *VideoBin) buildWebInput() error {

--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -49,11 +49,9 @@ const (
 	drainingTimeout         = time.Second * 3
 	unsubscribedGracePeriod = time.Second * 2
 
-	// FlowFlushing recovery: threshold of consecutive FlowFlushing returns before
-	// triggering source bin reset. ~2 seconds of 20ms audio packets.
+	// Threshold of consecutive FlowFlushing returns before the writer gives up
+	// and drains. ~2 seconds of 20ms audio packets.
 	flushingThreshold = 100
-	// Maximum number of source bin resets per writer lifetime.
-	maxSrcResets = 2
 )
 
 var errFlowFlushingThreshold = errors.New("persistent FlowFlushing detected")
@@ -114,9 +112,8 @@ type AppWriter struct {
 	finished                 core.Fuse
 	stats                    appWriterStats
 
-	// FlowFlushing recovery
-	flushingCount int // consecutive FlowFlushing returns from PushBuffer
-	srcResetCount int // number of source bin resets performed
+	// consecutive FlowFlushing returns from PushBuffer
+	flushingCount int
 
 	// diagnostics, set on unexpected flushing when pushing packets to the pipeline
 	flushDotRequested atomic.Bool
@@ -527,9 +524,7 @@ func (w *AppWriter) pushSamples() {
 		for _, pkt := range item.sample {
 			if err := w.pushPacket(pkt); err != nil {
 				if errors.Is(err, errFlowFlushingThreshold) {
-					if w.tryRecoverFromFlushing() {
-						continue
-					}
+					w.callbacks.OnError(errors.ErrPersistentFlushing)
 					w.draining.Break()
 					w.notifyPushSamples()
 					return
@@ -618,55 +613,6 @@ func (w *AppWriter) pushPacket(pkt jitter.ExtPacket) error {
 	w.lastPTS = pts
 	w.maybeCheckPipelineLag(pts)
 	return nil
-}
-
-// tryRecoverFromFlushing attempts to recover from persistent FlowFlushing by
-// removing the stuck source bin and replacing it with a new one.
-// Returns true if recovery succeeded and pushing can continue.
-func (w *AppWriter) tryRecoverFromFlushing() bool {
-	if w.draining.IsBroken() {
-		w.logger.Debugw("skipping FlowFlushing recovery: draining")
-		return false
-	}
-	if w.unsubscribed.IsBroken() {
-		w.logger.Debugw("skipping FlowFlushing recovery: unsubscribed")
-		return false
-	}
-	if w.endStreamSignaled.IsBroken() {
-		w.logger.Debugw("skipping FlowFlushing recovery: end stream signaled")
-		return false
-	}
-
-	if w.srcResetCount >= maxSrcResets {
-		w.logger.Warnw("max FlowFlushing recovery attempts reached, giving up", nil,
-			"attempts", w.srcResetCount)
-		return false
-	}
-
-	w.logger.Infow("attempting FlowFlushing recovery via source bin reset",
-		"flushingCount", w.flushingCount, "attempt", w.srcResetCount+1)
-
-	oldAppSrc := w.trackSource.AppSrc
-
-	// Call the builder layer to force-remove the old bin and add a new one.
-	// The callback updates ts.AppSrc to the new appsrc on success.
-	if err := w.callbacks.OnSourceBinReset(w.trackSource); err != nil {
-		w.logger.Errorw("FlowFlushing recovery failed", err)
-		return false
-	}
-
-	if w.trackSource.AppSrc == oldAppSrc {
-		w.logger.Errorw("FlowFlushing recovery: no handler replaced the appsrc", nil)
-		return false
-	}
-
-	w.src = w.trackSource.AppSrc
-	w.flushingCount = 0
-	w.srcResetCount++
-
-	w.logger.Infow("FlowFlushing recovery succeeded, continuing with new appsrc",
-		"totalResets", w.srcResetCount)
-	return true
 }
 
 func (w *AppWriter) maybeCheckPipelineLag(pts time.Duration) {

--- a/pkg/pipeline/tempo/controller_test.go
+++ b/pkg/pipeline/tempo/controller_test.go
@@ -217,9 +217,9 @@ func TestZeroDriftNoop(t *testing.T) {
 func TestCancelInFlightClearsCurrent(t *testing.T) {
 	// CancelInFlight must clear `current` so a subsequent
 	// OnDriftDetectedCallback registration does not re-fire the abandoned
-	// target. This is the load-bearing property for the source-bin-reset
-	// path: when the audio downstream of the pacer is discarded, the partial
-	// compensation cannot be re-applied by a fresh pacer with the same target.
+	// target. This is the load-bearing property for pacer teardown: when the
+	// audio downstream of the pacer is discarded, the partial compensation
+	// cannot be re-applied by a fresh pacer with the same target.
 	tc := NewController(1200 * time.Millisecond)
 
 	cb1Calls := []time.Duration{}
@@ -230,8 +230,7 @@ func TestCancelInFlightClearsCurrent(t *testing.T) {
 		t.Fatalf("expected initial arm: got %v", cb1Calls)
 	}
 
-	// Detach and cancel — simulates resetAudioAppSrcBin tearing down the old
-	// pacer mid-correction.
+	// Detach and cancel — simulates a pacer teardown mid-correction.
 	tc.OnDriftDetectedCallback(nil)
 	tc.CancelInFlight()
 
@@ -258,7 +257,7 @@ func TestCancelInFlightClearsCurrent(t *testing.T) {
 
 func TestCancelInFlightWhenIdleIsNoop(t *testing.T) {
 	// Calling CancelInFlight when no correction is in flight must not corrupt
-	// state. resetAudioAppSrcBin calls it unconditionally.
+	// state. Callers may invoke it unconditionally.
 	tc := NewController(1200 * time.Millisecond)
 
 	tc.CancelInFlight()


### PR DESCRIPTION
The reason we introduced recovery on persistent flow flushing errors while pushing packets for a track was appsrc src pad task deactivation due to race condition which is fixed in https://github.com/livekit/egress/pull/1293

There is another reason we might get flow flushing - and that's not fully correct and forceful rmtp sink removal / re-adding on e.g rtmp connectivity issue. That issue will be fixed independently - but is now causing appsource recovery path when it happens, which doesn't really help (as it's not the original problem the recovery is added for) and might even cause deadlocks.

When persistent flow flushing is happening due to the rtmp issue - it's the most honest to fail the egress as soon as we exceeded tolerable threshold instead of silently continuing without a stream. As mentioned the rmtp source of flushing error will also be addressed independently.