### PR TITLE
test: serve web egress fixture from localhost instead of blender.org

### DIFF
--- a/test/builder.go
+++ b/test/builder.go
@@ -17,7 +17,11 @@
 package test
 
 import (
+	"fmt"
+	"net"
+	"net/http"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,11 +33,27 @@ import (
 )
 
 const (
-	webUrl        = "https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4"
 	setAtRuntime  = "set-at-runtime"
 	setP1Identity = "set-p1-identity"
 	setP2Identity = "set-p2-identity"
+
+	mediaSamplesDir = "/media-samples"
+	webFixture      = "BigBuckBunny_320x180.mp4"
 )
+
+// webURL serves the vendored Big Buck Bunny clip from a localhost file server
+// (rooted at the media-samples dir) and returns its URL, starting the server
+// once on first use. The web egress tests previously navigated Chrome to this
+// clip on download.blender.org, which now 404s (upstream removed the loose
+// .mp4); serving it locally removes that external dependency.
+var webURL = sync.OnceValue(func() string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(fmt.Sprintf("failed to start web fixture server: %v", err))
+	}
+	go func() { _ = http.Serve(ln, http.FileServer(http.Dir(mediaSamplesDir))) }()
+	return fmt.Sprintf("http://%s/%s", ln.Addr(), webFixture)
+})
 
 type testCase struct {
 	name        string
@@ -163,7 +183,7 @@ func (r *Runner) build(test *testCase) *rpc.StartEgressRequest {
 
 	case types.RequestTypeWeb:
 		web := &livekit.WebEgressRequest{
-			Url:       webUrl,
+			Url:       webURL(),
 			AudioOnly: test.audioOnly,
 			VideoOnly: test.videoOnly,
 		}
@@ -521,7 +541,7 @@ func (r *Runner) buildV2(test *testCase) *rpc.StartEgressRequest {
 	case types.RequestTypeWeb:
 		egressReq.Source = &livekit.StartEgressRequest_Web{
 			Web: &livekit.WebSource{
-				Url:       webUrl,
+				Url:       webURL(),
 				AudioOnly: test.audioOnly,
 				VideoOnly: test.videoOnly,
 			},


### PR DESCRIPTION
## Why

The web integration tests (`TestEgress/*/Web`) navigate headless Chrome to
`https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4`.
Blender removed the loose `.mp4` files (only the `.zip` remains), so that URL now
**404s** — first intermittently as CDN edges expire, then permanently. The
navigation gets an HTTP ≥400, which the web source treats as a non-retryable
page-load error, so the Web subtests fail on essentially every egress CI run.

## What

Stop depending on the external URL. The clip is now vendored in
`media-samples` (see livekit/media-samples#14, git-lfs, CC BY 3.0). This change
serves it from a localhost file server rooted at the existing `/media-samples`
dir and points the web tests at that URL instead:

```go
var webURL = sync.OnceValue(func() string {
    ln, _ := net.Listen("tcp", "127.0.0.1:0")
    go http.Serve(ln, http.FileServer(http.Dir("/media-samples")))
    return fmt.Sprintf("http://%s/BigBuckBunny_320x180.mp4", ln.Addr())
})
```

Same clip, same behavior — just served locally, so the tests no longer make an
external request (and all matrix jobs stop hammering blender.org concurrently).

## Ordering / dependency

Requires the clip to be present at `/media-samples/BigBuckBunny_320x180.mp4` in
the test image — i.e. **merge livekit/media-samples#14 first**, then this. Until
then the Web tests would 404 locally instead of remotely.

## Note

Integration tests need gstreamer + the `integration` build tag, so this wasn't
compiled locally; the change is confined to `test/builder.go` (stdlib-only
additions) and CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
