### PR TITLE
Serve handler RPC topics from the service process over IPC

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -187,16 +187,10 @@ func runHandler(_ context.Context, c *cli.Command) error {
 	defer os.RemoveAll(conf.TmpDir)
 	_ = os.Setenv("TMPDIR", conf.TmpDir)
 
-	rc, err := lkredis.GetRedisClient(conf.Redis)
-	if err != nil {
-		return err
-	}
-
 	killChan := make(chan os.Signal, 1)
 	signal.Notify(killChan, syscall.SIGINT)
 
-	bus := psrpc.NewRedisMessageBus(rc)
-	h, err := handler.NewHandler(conf, bus)
+	h, err := handler.NewHandler(conf)
 	if err != nil {
 		// service will send info update and shut down
 		logger.Errorw("failed to create handler", err)

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -31,7 +31,6 @@ import (
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
-	"github.com/livekit/psrpc"
 
 	"github.com/livekit/egress/pkg/config"
 	"github.com/livekit/egress/pkg/ipc"
@@ -43,7 +42,6 @@ type Handler struct {
 
 	conf             *config.PipelineConfig
 	controller       *pipeline.Controller
-	rpcServer        rpc.EgressHandlerServer
 	ipcHandlerServer *grpc.Server
 	ipcServiceClient ipc.EgressServiceClient
 	initialized      core.Fuse
@@ -54,7 +52,7 @@ var (
 	tracer = otel.Tracer("github.com/livekit/egress/pkg/handler")
 )
 
-func NewHandler(conf *config.PipelineConfig, bus psrpc.MessageBus) (*Handler, error) {
+func NewHandler(conf *config.PipelineConfig) (*Handler, error) {
 	// The service already exposes go_* / process_* — leaving these registered
 	// causes prometheus.Gatherers.Gather to reject the scrape as duplicate.
 	prometheus.Unregister(collectors.NewGoCollector())
@@ -78,21 +76,6 @@ func NewHandler(conf *config.PipelineConfig, bus psrpc.MessageBus) (*Handler, er
 		return nil, err
 	}
 
-	rpcServer, err := rpc.NewEgressHandlerServer(h, bus)
-	if err != nil {
-		return nil, err
-	}
-	if err = rpcServer.RegisterUpdateStreamTopic(conf.Info.EgressId); err != nil {
-		return nil, err
-	}
-	if err = rpcServer.RegisterStopEgressTopic(conf.Info.EgressId); err != nil {
-		return nil, err
-	}
-	if err = rpcServer.RegisterUpdateEgressTopic(conf.Info.EgressId); err != nil {
-		return nil, err
-	}
-	h.rpcServer = rpcServer
-
 	_, err = h.ipcServiceClient.HandlerReady(context.Background(), &ipc.HandlerReadyRequest{EgressId: conf.Info.EgressId})
 	if err != nil {
 		logger.Errorw("failed to notify service", err)
@@ -106,10 +89,7 @@ func (h *Handler) Run() {
 	ctx, span := tracer.Start(context.Background(), "Handler.Run")
 	defer span.End()
 
-	defer func() {
-		h.rpcServer.Shutdown()
-		h.ipcHandlerServer.Stop()
-	}()
+	defer h.ipcHandlerServer.Stop()
 
 	var err error
 	egressID := h.conf.Info.EgressId

--- a/pkg/ipc/ipc.pb.go
+++ b/pkg/ipc/ipc.pb.go
@@ -622,7 +622,7 @@ const file_ipc_proto_rawDesc = "" +
 	"\rHandlerUpdate\x12\x13.livekit.EgressInfo\x1a\x16.google.protobuf.Empty\"\x00\x12H\n" +
 	"\x0fHandlerFinished\x12\x1b.ipc.HandlerFinishedRequest\x1a\x16.google.protobuf.Empty\"\x00\x12B\n" +
 	"\vReplayReady\x12\x17.rpc.EgressReadyRequest\x1a\x18.rpc.EgressReadyResponse\"\x00\x12B\n" +
-	"\fStorageEvent\x12\x18.ipc.StorageEventRequest\x1a\x16.google.protobuf.Empty\"\x002\xd8\x02\n" +
+	"\fStorageEvent\x12\x18.ipc.StorageEventRequest\x1a\x16.google.protobuf.Empty\"\x002\xa3\x04\n" +
 	"\rEgressHandler\x12U\n" +
 	"\x0eGetPipelineDot\x12\x1f.ipc.GstPipelineDebugDotRequest\x1a .ipc.GstPipelineDebugDotResponse\"\x00\x123\n" +
 	"\bGetPProf\x12\x11.ipc.PProfRequest\x1a\x12.ipc.PProfResponse\"\x00\x129\n" +
@@ -630,7 +630,11 @@ const file_ipc_proto_rawDesc = "" +
 	"GetMetrics\x12\x13.ipc.MetricsRequest\x1a\x14.ipc.MetricsResponse\"\x00\x12@\n" +
 	"\vStopHandler\x12\x17.ipc.StopHandlerRequest\x1a\x16.google.protobuf.Empty\"\x00\x12>\n" +
 	"\n" +
-	"KillEgress\x12\x16.ipc.KillEgressRequest\x1a\x16.google.protobuf.Empty\"\x00B#Z!github.com/livekit/egress/pkg/ipcb\x06proto3"
+	"KillEgress\x12\x16.ipc.KillEgressRequest\x1a\x16.google.protobuf.Empty\"\x00\x12C\n" +
+	"\fUpdateStream\x12\x1c.livekit.UpdateStreamRequest\x1a\x13.livekit.EgressInfo\"\x00\x12C\n" +
+	"\fUpdateEgress\x12\x1c.livekit.UpdateEgressRequest\x1a\x13.livekit.EgressInfo\"\x00\x12?\n" +
+	"\n" +
+	"StopEgress\x12\x1a.livekit.StopEgressRequest\x1a\x13.livekit.EgressInfo\"\x00B#Z!github.com/livekit/egress/pkg/ipcb\x06proto3"
 
 var (
 	file_ipc_proto_rawDescOnce sync.Once
@@ -659,8 +663,11 @@ var file_ipc_proto_goTypes = []any{
 	(*KillEgressRequest)(nil),           // 10: ipc.KillEgressRequest
 	(*livekit.EgressInfo)(nil),          // 11: livekit.EgressInfo
 	(*rpc.EgressReadyRequest)(nil),      // 12: rpc.EgressReadyRequest
-	(*emptypb.Empty)(nil),               // 13: google.protobuf.Empty
-	(*rpc.EgressReadyResponse)(nil),     // 14: rpc.EgressReadyResponse
+	(*livekit.UpdateStreamRequest)(nil), // 13: livekit.UpdateStreamRequest
+	(*livekit.UpdateEgressRequest)(nil), // 14: livekit.UpdateEgressRequest
+	(*livekit.StopEgressRequest)(nil),   // 15: livekit.StopEgressRequest
+	(*emptypb.Empty)(nil),               // 16: google.protobuf.Empty
+	(*rpc.EgressReadyResponse)(nil),     // 17: rpc.EgressReadyResponse
 }
 var file_ipc_proto_depIdxs = []int32{
 	11, // 0: ipc.HandlerFinishedRequest.info:type_name -> livekit.EgressInfo
@@ -674,18 +681,24 @@ var file_ipc_proto_depIdxs = []int32{
 	7,  // 8: ipc.EgressHandler.GetMetrics:input_type -> ipc.MetricsRequest
 	9,  // 9: ipc.EgressHandler.StopHandler:input_type -> ipc.StopHandlerRequest
 	10, // 10: ipc.EgressHandler.KillEgress:input_type -> ipc.KillEgressRequest
-	13, // 11: ipc.EgressService.HandlerReady:output_type -> google.protobuf.Empty
-	13, // 12: ipc.EgressService.HandlerUpdate:output_type -> google.protobuf.Empty
-	13, // 13: ipc.EgressService.HandlerFinished:output_type -> google.protobuf.Empty
-	14, // 14: ipc.EgressService.ReplayReady:output_type -> rpc.EgressReadyResponse
-	13, // 15: ipc.EgressService.StorageEvent:output_type -> google.protobuf.Empty
-	4,  // 16: ipc.EgressHandler.GetPipelineDot:output_type -> ipc.GstPipelineDebugDotResponse
-	6,  // 17: ipc.EgressHandler.GetPProf:output_type -> ipc.PProfResponse
-	8,  // 18: ipc.EgressHandler.GetMetrics:output_type -> ipc.MetricsResponse
-	13, // 19: ipc.EgressHandler.StopHandler:output_type -> google.protobuf.Empty
-	13, // 20: ipc.EgressHandler.KillEgress:output_type -> google.protobuf.Empty
-	11, // [11:21] is the sub-list for method output_type
-	1,  // [1:11] is the sub-list for method input_type
+	13, // 11: ipc.EgressHandler.UpdateStream:input_type -> livekit.UpdateStreamRequest
+	14, // 12: ipc.EgressHandler.UpdateEgress:input_type -> livekit.UpdateEgressRequest
+	15, // 13: ipc.EgressHandler.StopEgress:input_type -> livekit.StopEgressRequest
+	16, // 14: ipc.EgressService.HandlerReady:output_type -> google.protobuf.Empty
+	16, // 15: ipc.EgressService.HandlerUpdate:output_type -> google.protobuf.Empty
+	16, // 16: ipc.EgressService.HandlerFinished:output_type -> google.protobuf.Empty
+	17, // 17: ipc.EgressService.ReplayReady:output_type -> rpc.EgressReadyResponse
+	16, // 18: ipc.EgressService.StorageEvent:output_type -> google.protobuf.Empty
+	4,  // 19: ipc.EgressHandler.GetPipelineDot:output_type -> ipc.GstPipelineDebugDotResponse
+	6,  // 20: ipc.EgressHandler.GetPProf:output_type -> ipc.PProfResponse
+	8,  // 21: ipc.EgressHandler.GetMetrics:output_type -> ipc.MetricsResponse
+	16, // 22: ipc.EgressHandler.StopHandler:output_type -> google.protobuf.Empty
+	16, // 23: ipc.EgressHandler.KillEgress:output_type -> google.protobuf.Empty
+	11, // 24: ipc.EgressHandler.UpdateStream:output_type -> livekit.EgressInfo
+	11, // 25: ipc.EgressHandler.UpdateEgress:output_type -> livekit.EgressInfo
+	11, // 26: ipc.EgressHandler.StopEgress:output_type -> livekit.EgressInfo
+	14, // [14:27] is the sub-list for method output_type
+	1,  // [1:14] is the sub-list for method input_type
 	1,  // [1:1] is the sub-list for extension type_name
 	1,  // [1:1] is the sub-list for extension extendee
 	0,  // [0:1] is the sub-list for field type_name

--- a/pkg/ipc/ipc.proto
+++ b/pkg/ipc/ipc.proto
@@ -57,6 +57,12 @@ service EgressHandler {
   rpc GetMetrics(MetricsRequest) returns (MetricsResponse) {};
   rpc StopHandler(StopHandlerRequest) returns (google.protobuf.Empty) {};
   rpc KillEgress(KillEgressRequest) returns (google.protobuf.Empty) {};
+
+  // proxied EgressHandler RPCs: the service owns the message bus subscription
+  // and forwards these to the handler over IPC
+  rpc UpdateStream(livekit.UpdateStreamRequest) returns (livekit.EgressInfo) {};
+  rpc UpdateEgress(livekit.UpdateEgressRequest) returns (livekit.EgressInfo) {};
+  rpc StopEgress(livekit.StopEgressRequest) returns (livekit.EgressInfo) {};
 }
 
 message GstPipelineDebugDotRequest {}

--- a/pkg/ipc/ipc_grpc.pb.go
+++ b/pkg/ipc/ipc_grpc.pb.go
@@ -295,6 +295,9 @@ const (
 	EgressHandler_GetMetrics_FullMethodName     = "/ipc.EgressHandler/GetMetrics"
 	EgressHandler_StopHandler_FullMethodName    = "/ipc.EgressHandler/StopHandler"
 	EgressHandler_KillEgress_FullMethodName     = "/ipc.EgressHandler/KillEgress"
+	EgressHandler_UpdateStream_FullMethodName   = "/ipc.EgressHandler/UpdateStream"
+	EgressHandler_UpdateEgress_FullMethodName   = "/ipc.EgressHandler/UpdateEgress"
+	EgressHandler_StopEgress_FullMethodName     = "/ipc.EgressHandler/StopEgress"
 )
 
 // EgressHandlerClient is the client API for EgressHandler service.
@@ -306,6 +309,11 @@ type EgressHandlerClient interface {
 	GetMetrics(ctx context.Context, in *MetricsRequest, opts ...grpc.CallOption) (*MetricsResponse, error)
 	StopHandler(ctx context.Context, in *StopHandlerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	KillEgress(ctx context.Context, in *KillEgressRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// proxied EgressHandler RPCs: the service owns the message bus subscription
+	// and forwards these to the handler over IPC
+	UpdateStream(ctx context.Context, in *livekit.UpdateStreamRequest, opts ...grpc.CallOption) (*livekit.EgressInfo, error)
+	UpdateEgress(ctx context.Context, in *livekit.UpdateEgressRequest, opts ...grpc.CallOption) (*livekit.EgressInfo, error)
+	StopEgress(ctx context.Context, in *livekit.StopEgressRequest, opts ...grpc.CallOption) (*livekit.EgressInfo, error)
 }
 
 type egressHandlerClient struct {
@@ -366,6 +374,36 @@ func (c *egressHandlerClient) KillEgress(ctx context.Context, in *KillEgressRequ
 	return out, nil
 }
 
+func (c *egressHandlerClient) UpdateStream(ctx context.Context, in *livekit.UpdateStreamRequest, opts ...grpc.CallOption) (*livekit.EgressInfo, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(livekit.EgressInfo)
+	err := c.cc.Invoke(ctx, EgressHandler_UpdateStream_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *egressHandlerClient) UpdateEgress(ctx context.Context, in *livekit.UpdateEgressRequest, opts ...grpc.CallOption) (*livekit.EgressInfo, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(livekit.EgressInfo)
+	err := c.cc.Invoke(ctx, EgressHandler_UpdateEgress_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *egressHandlerClient) StopEgress(ctx context.Context, in *livekit.StopEgressRequest, opts ...grpc.CallOption) (*livekit.EgressInfo, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(livekit.EgressInfo)
+	err := c.cc.Invoke(ctx, EgressHandler_StopEgress_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // EgressHandlerServer is the server API for EgressHandler service.
 // All implementations must embed UnimplementedEgressHandlerServer
 // for forward compatibility.
@@ -375,6 +413,11 @@ type EgressHandlerServer interface {
 	GetMetrics(context.Context, *MetricsRequest) (*MetricsResponse, error)
 	StopHandler(context.Context, *StopHandlerRequest) (*emptypb.Empty, error)
 	KillEgress(context.Context, *KillEgressRequest) (*emptypb.Empty, error)
+	// proxied EgressHandler RPCs: the service owns the message bus subscription
+	// and forwards these to the handler over IPC
+	UpdateStream(context.Context, *livekit.UpdateStreamRequest) (*livekit.EgressInfo, error)
+	UpdateEgress(context.Context, *livekit.UpdateEgressRequest) (*livekit.EgressInfo, error)
+	StopEgress(context.Context, *livekit.StopEgressRequest) (*livekit.EgressInfo, error)
 	mustEmbedUnimplementedEgressHandlerServer()
 }
 
@@ -399,6 +442,15 @@ func (UnimplementedEgressHandlerServer) StopHandler(context.Context, *StopHandle
 }
 func (UnimplementedEgressHandlerServer) KillEgress(context.Context, *KillEgressRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method KillEgress not implemented")
+}
+func (UnimplementedEgressHandlerServer) UpdateStream(context.Context, *livekit.UpdateStreamRequest) (*livekit.EgressInfo, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateStream not implemented")
+}
+func (UnimplementedEgressHandlerServer) UpdateEgress(context.Context, *livekit.UpdateEgressRequest) (*livekit.EgressInfo, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateEgress not implemented")
+}
+func (UnimplementedEgressHandlerServer) StopEgress(context.Context, *livekit.StopEgressRequest) (*livekit.EgressInfo, error) {
+	return nil, status.Error(codes.Unimplemented, "method StopEgress not implemented")
 }
 func (UnimplementedEgressHandlerServer) mustEmbedUnimplementedEgressHandlerServer() {}
 func (UnimplementedEgressHandlerServer) testEmbeddedByValue()                       {}
@@ -511,6 +563,60 @@ func _EgressHandler_KillEgress_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _EgressHandler_UpdateStream_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(livekit.UpdateStreamRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EgressHandlerServer).UpdateStream(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: EgressHandler_UpdateStream_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EgressHandlerServer).UpdateStream(ctx, req.(*livekit.UpdateStreamRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _EgressHandler_UpdateEgress_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(livekit.UpdateEgressRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EgressHandlerServer).UpdateEgress(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: EgressHandler_UpdateEgress_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EgressHandlerServer).UpdateEgress(ctx, req.(*livekit.UpdateEgressRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _EgressHandler_StopEgress_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(livekit.StopEgressRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EgressHandlerServer).StopEgress(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: EgressHandler_StopEgress_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EgressHandlerServer).StopEgress(ctx, req.(*livekit.StopEgressRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // EgressHandler_ServiceDesc is the grpc.ServiceDesc for EgressHandler service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -537,6 +643,18 @@ var EgressHandler_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "KillEgress",
 			Handler:    _EgressHandler_KillEgress_Handler,
+		},
+		{
+			MethodName: "UpdateStream",
+			Handler:    _EgressHandler_UpdateStream_Handler,
+		},
+		{
+			MethodName: "UpdateEgress",
+			Handler:    _EgressHandler_UpdateEgress_Handler,
+		},
+		{
+			MethodName: "StopEgress",
+			Handler:    _EgressHandler_StopEgress_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	monitor *stats.Monitor
 
 	psrpcServer      rpc.EgressInternalServer
+	handlerProxy     *service.HandlerRPCProxy
 	ipcServiceServer *grpc.Server
 	promServer       *http.Server
 	ioClient         info.SessionReporter
@@ -121,6 +122,13 @@ func NewServer(conf *config.ServiceConfig, bus psrpc.MessageBus, ioClient info.S
 		return nil, err
 	}
 	s.psrpcServer = psrpcServer
+
+	handlerProxy, err := service.NewHandlerRPCProxy(pm, bus)
+	if err != nil {
+		return nil, err
+	}
+	s.handlerProxy = handlerProxy
+	pm.SetHandlerTopicHooks(handlerProxy.RegisterEgress, handlerProxy.DeregisterEgress)
 
 	return s, nil
 }
@@ -198,6 +206,7 @@ func (s *Server) Drain() {
 	}
 
 	s.psrpcServer.Shutdown()
+	s.handlerProxy.Shutdown()
 	logger.Infow("draining io client")
 	s.ioClient.Drain()
 }

--- a/pkg/service/handler_proxy.go
+++ b/pkg/service/handler_proxy.go
@@ -1,0 +1,100 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/rpc"
+	"github.com/livekit/psrpc"
+)
+
+// HandlerRPCProxy hosts the per-egress EgressHandler psrpc topics in the
+// service process and forwards requests to the handler subprocess over IPC,
+// so handlers never connect to the message bus.
+type HandlerRPCProxy struct {
+	pm     ProcessManager
+	server rpc.EgressHandlerServer
+}
+
+func NewHandlerRPCProxy(pm ProcessManager, bus psrpc.MessageBus) (*HandlerRPCProxy, error) {
+	p := &HandlerRPCProxy{pm: pm}
+	server, err := rpc.NewEgressHandlerServer(p, bus)
+	if err != nil {
+		return nil, err
+	}
+	p.server = server
+	return p, nil
+}
+
+// RegisterEgress is invoked by the process manager during Launch, once the
+// handler's IPC client exists, so incoming requests can always resolve a
+// client. Calls made before the handler's IPC listener is up wait on the
+// connection (bounded by the request deadline) instead of failing fast.
+func (p *HandlerRPCProxy) RegisterEgress(egressID string) error {
+	if err := p.server.RegisterUpdateStreamTopic(egressID); err != nil {
+		return err
+	}
+	if err := p.server.RegisterStopEgressTopic(egressID); err != nil {
+		p.DeregisterEgress(egressID)
+		return err
+	}
+	if err := p.server.RegisterUpdateEgressTopic(egressID); err != nil {
+		p.DeregisterEgress(egressID)
+		return err
+	}
+	return nil
+}
+
+func (p *HandlerRPCProxy) DeregisterEgress(egressID string) {
+	p.server.DeregisterUpdateStreamTopic(egressID)
+	p.server.DeregisterStopEgressTopic(egressID)
+	p.server.DeregisterUpdateEgressTopic(egressID)
+}
+
+func (p *HandlerRPCProxy) UpdateStream(ctx context.Context, req *livekit.UpdateStreamRequest) (*livekit.EgressInfo, error) {
+	client, err := p.pm.GetGRPCClient(req.EgressId)
+	if err != nil {
+		return nil, err
+	}
+	return client.UpdateStream(ctx, req, grpc.WaitForReady(true))
+}
+
+func (p *HandlerRPCProxy) UpdateEgress(ctx context.Context, req *livekit.UpdateEgressRequest) (*livekit.EgressInfo, error) {
+	client, err := p.pm.GetGRPCClient(req.EgressId)
+	if err != nil {
+		return nil, err
+	}
+	return client.UpdateEgress(ctx, req, grpc.WaitForReady(true))
+}
+
+func (p *HandlerRPCProxy) StopEgress(ctx context.Context, req *livekit.StopEgressRequest) (*livekit.EgressInfo, error) {
+	client, err := p.pm.GetGRPCClient(req.EgressId)
+	if err != nil {
+		return nil, err
+	}
+	return client.StopEgress(ctx, req, grpc.WaitForReady(true))
+}
+
+func (p *HandlerRPCProxy) Shutdown() {
+	p.server.Shutdown()
+}
+
+func (p *HandlerRPCProxy) Kill() {
+	p.server.Kill()
+}

--- a/pkg/service/process.go
+++ b/pkg/service/process.go
@@ -53,9 +53,8 @@ type ProcessManager interface {
 	// SetHandlerTopicHooks installs callbacks used to advertise and remove the
 	// per-egress handler RPC topics. Registration happens inside Launch, after
 	// the handler's IPC client exists; deregistration happens in ProcessFinished.
-	// The hooks are stored without synchronization and read by Launch and
-	// ProcessFinished, so this must be called once during server construction,
-	// before any handler can be launched.
+	// The hooks are read without synchronization, so this must be called once
+	// during server construction, before any handler is launched.
 	SetHandlerTopicHooks(register func(egressID string) error, deregister func(egressID string))
 	GetContext(egressID string) context.Context
 	AlreadyExists(egressID string) bool

--- a/pkg/service/process.go
+++ b/pkg/service/process.go
@@ -50,6 +50,10 @@ const (
 
 type ProcessManager interface {
 	Launch(ctx context.Context, handlerID string, req *rpc.StartEgressRequest, info *livekit.EgressInfo, cmd *exec.Cmd) error
+	// SetHandlerTopicHooks installs callbacks used to advertise and remove the
+	// per-egress handler RPC topics. Registration happens inside Launch, after
+	// the handler's IPC client exists; deregistration happens in ProcessFinished.
+	SetHandlerTopicHooks(register func(egressID string) error, deregister func(egressID string))
 	GetContext(egressID string) context.Context
 	AlreadyExists(egressID string) bool
 	HandlerStarted(egressID string) error
@@ -74,12 +78,20 @@ type ProcessManager interface {
 type processManager struct {
 	mu             deadlock.RWMutex
 	activeHandlers map[string]*Process
+
+	registerTopics   func(egressID string) error
+	deregisterTopics func(egressID string)
 }
 
 func NewProcessManager() ProcessManager {
 	return &processManager{
 		activeHandlers: make(map[string]*Process),
 	}
+}
+
+func (pm *processManager) SetHandlerTopicHooks(register func(egressID string) error, deregister func(egressID string)) {
+	pm.registerTopics = register
+	pm.deregisterTopics = deregister
 }
 
 func (pm *processManager) StoreAccumulatableMetrics(egressID string, metrics []*dto.MetricFamily) {
@@ -133,8 +145,19 @@ func (pm *processManager) Launch(
 	pm.activeHandlers[info.EgressId] = p
 	pm.mu.Unlock()
 
+	// advertise the handler RPC topics only once the IPC client can serve
+	// them; requests arriving during handler startup wait on the connection.
+	// The map entry is cleaned up by ProcessFinished on failure, same as the
+	// cmd.Start error path.
+	if pm.registerTopics != nil {
+		if err = pm.registerTopics(info.EgressId); err != nil {
+			logger.Errorw("could not register handler rpc topics", err, "egressID", info.EgressId)
+			return err
+		}
+	}
+
 	if err = cmd.Start(); err != nil {
-		logger.Errorw("could not launch process", err)
+		logger.Errorw("could not launch process", err, "egressID", info.EgressId)
 		return err
 	}
 
@@ -326,6 +349,11 @@ func (pm *processManager) GetKillReason(egressID string) string {
 
 func (pm *processManager) ProcessFinished(egressID string) {
 	logger.Debugw("process finished", "egressID", egressID)
+
+	if pm.deregisterTopics != nil {
+		pm.deregisterTopics(egressID)
+	}
+
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 

--- a/pkg/service/process.go
+++ b/pkg/service/process.go
@@ -53,6 +53,9 @@ type ProcessManager interface {
 	// SetHandlerTopicHooks installs callbacks used to advertise and remove the
 	// per-egress handler RPC topics. Registration happens inside Launch, after
 	// the handler's IPC client exists; deregistration happens in ProcessFinished.
+	// The hooks are stored without synchronization and read by Launch and
+	// ProcessFinished, so this must be called once during server construction,
+	// before any handler can be launched.
 	SetHandlerTopicHooks(register func(egressID string) error, deregister func(egressID string))
 	GetContext(egressID string) context.Context
 	AlreadyExists(egressID string) bool

--- a/pkg/service/servicefakes/fake_process_manager.go
+++ b/pkg/service/servicefakes/fake_process_manager.go
@@ -153,6 +153,12 @@ type FakeProcessManager struct {
 		arg1 string
 		arg2 string
 	}
+	SetHandlerTopicHooksStub        func(func(egressID string) error, func(egressID string))
+	setHandlerTopicHooksMutex       sync.RWMutex
+	setHandlerTopicHooksArgsForCall []struct {
+		arg1 func(egressID string) error
+		arg2 func(egressID string)
+	}
 	StopProcessStub        func(string, string)
 	stopProcessMutex       sync.RWMutex
 	stopProcessArgsForCall []struct {
@@ -897,6 +903,39 @@ func (fake *FakeProcessManager) SetExitReasonArgsForCall(i int) (string, string)
 	fake.setExitReasonMutex.RLock()
 	defer fake.setExitReasonMutex.RUnlock()
 	argsForCall := fake.setExitReasonArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeProcessManager) SetHandlerTopicHooks(arg1 func(egressID string) error, arg2 func(egressID string)) {
+	fake.setHandlerTopicHooksMutex.Lock()
+	fake.setHandlerTopicHooksArgsForCall = append(fake.setHandlerTopicHooksArgsForCall, struct {
+		arg1 func(egressID string) error
+		arg2 func(egressID string)
+	}{arg1, arg2})
+	stub := fake.SetHandlerTopicHooksStub
+	fake.recordInvocation("SetHandlerTopicHooks", []interface{}{arg1, arg2})
+	fake.setHandlerTopicHooksMutex.Unlock()
+	if stub != nil {
+		fake.SetHandlerTopicHooksStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeProcessManager) SetHandlerTopicHooksCallCount() int {
+	fake.setHandlerTopicHooksMutex.RLock()
+	defer fake.setHandlerTopicHooksMutex.RUnlock()
+	return len(fake.setHandlerTopicHooksArgsForCall)
+}
+
+func (fake *FakeProcessManager) SetHandlerTopicHooksCalls(stub func(func(egressID string) error, func(egressID string))) {
+	fake.setHandlerTopicHooksMutex.Lock()
+	defer fake.setHandlerTopicHooksMutex.Unlock()
+	fake.SetHandlerTopicHooksStub = stub
+}
+
+func (fake *FakeProcessManager) SetHandlerTopicHooksArgsForCall(i int) (func(egressID string) error, func(egressID string)) {
+	fake.setHandlerTopicHooksMutex.RLock()
+	defer fake.setHandlerTopicHooksMutex.RUnlock()
+	argsForCall := fake.setHandlerTopicHooksArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 


### PR DESCRIPTION
## Why

Each egress handler subprocess currently opens its own message-bus connection during startup, solely to serve three per-egress RPC topics (`UpdateStream`, `UpdateEgress`, `StopEgress`). This sits in the pre-ready window, so bus connect/registration failures or slowness surface as `handler failed to start` after the 10s launch timeout — historically the dominant transient cause of launch failures — and every concurrent handler multiplies bus connections and reconnect storms. Ingress already avoids all of this by keeping its handlers bus-free and forwarding RPCs from the main process over IPC.

## What

- **`ipc.proto`**: adds `UpdateStream` / `UpdateEgress` / `StopEgress` to the `EgressHandler` IPC service, using the same `livekit.*` request/response types as the psrpc definitions. The existing handler methods already match the generated gRPC signatures, so they become the IPC implementations unchanged. psrpc error codes survive the hop (`psrpc.Error` implements `GRPCStatus()`, and psrpc's response encoding maps status errors back symmetrically).
- **New `service.HandlerRPCProxy`**: implements `rpc.EgressHandlerServerImpl` on a single node-wide psrpc server, resolving the target handler via the process manager's IPC client per request.
- **Topic lifecycle owned by the ProcessManager**: registration happens inside `Launch` — after the IPC client exists and the process is in the active map, before `cmd.Start` — so there is no window where an advertised topic can't resolve a client. Deregistration happens in `ProcessFinished`, which runs on every exit path; `DeregisterHandler` is a safe no-op for unknown topics, making cleanup idempotent.
- **`grpc.WaitForReady(true)`** on the proxied calls: a request arriving while the handler's IPC listener is still coming up waits, bounded by the caller's psrpc request deadline, instead of failing fast. The handler-side implementations already gate on the `initialized` fuse, so a stop landing mid-boot resolves into a graceful early stop.
- **Handler slimming**: `NewHandler` drops the bus parameter and its psrpc server; `run-handler` drops the redis connection.

## Behavior notes

- Registration failure inside `Launch` is handled like a `cmd.Start` failure: error returned after `EgressStarted`, cleanup via `ProcessFinished`, accounting paired.
- Register/deregister are local buffered writes on the shared connection (no dial, no server round-trip), verified down through psrpc and the nats client; no lock is held across I/O, so a slow call affects only its own StartEgress.
- Boot-window requests change from "no subscriber → full-timeout `ErrNoResponse`" to either waiting for the handler or failing at the same deadline with the same `DeadlineExceeded` class — never a false `NotFound`.

## Testing

Full file-integration suite run on this branch: 27/31 passing, with every passing test exercising the new path end to end (bus-free handler launch, `HandlerReady` over IPC, `StopEgress` via bus → proxy → IPC). The 4 failures were `TestEgress/*/Web*`, caused by the since-removed blender.org fixture URL — fixed independently by #1308, which is now merged into this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)