### PR TITLE
Recover appsrc from stranded flushing state instead of failing the egress

### DIFF
--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -596,6 +596,9 @@ func (w *AppWriter) pushPacket(pkt jitter.ExtPacket) error {
 					w.callbacks.OnDebugDotRequest("appsrc_flush_" + w.track.ID())
 				}
 			}
+			if w.flushingCount == flushingThreshold/2 {
+				w.recoverFromFlushing()
+			}
 			if w.flushingCount >= flushingThreshold {
 				return errFlowFlushingThreshold
 			}
@@ -613,6 +616,21 @@ func (w *AppWriter) pushPacket(pkt jitter.ExtPacket) error {
 	w.lastPTS = pts
 	w.maybeCheckPipelineLag(pts)
 	return nil
+}
+
+// recoverFromFlushing restarts an appsrc stranded with its internal flushing
+func (w *AppWriter) recoverFromFlushing() {
+	w.logger.Infow("attempting FlowFlushing recovery",
+		"flushingCount", w.flushingCount,
+		"appsrcState", w.src.Element.GetCurrentState().String())
+	if !w.src.SendEvent(gst.NewFlushStartEvent()) {
+		w.logger.Warnw("failed to send recovery flush start event", nil)
+		return
+	}
+	if !w.src.SendEvent(gst.NewFlushStopEvent(false)) {
+		w.logger.Warnw("failed to send recovery flush stop event", nil)
+	}
+	w.logger.Infow("FlowFlushing recovery successful")
 }
 
 func (w *AppWriter) maybeCheckPipelineLag(pts time.Duration) {

--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -629,6 +629,7 @@ func (w *AppWriter) recoverFromFlushing() {
 	}
 	if !w.src.SendEvent(gst.NewFlushStopEvent(false)) {
 		w.logger.Warnw("failed to send recovery flush stop event", nil)
+		return
 	}
 	w.logger.Infow("FlowFlushing recovery successful")
 }


### PR DESCRIPTION
We still see persistent FlowFlushing failures after #1293/#1305, including on file-only egress, which rules out the RTMP sink path as the only trigger. The pipeline dump from that failure shows the exact stranded state: the appsrc reports PLAYING with clean pad flags, but its streaming task is paused and its internal flushing flag is stuck, so every PushBuffer returns FlowFlushing from the very first packet until the writer gives up.

Trying to fix the persistent flow flushing with significantly lighter logic than before - basically by sending flush start / stop events which should clear the flushing state and restart task allowing data to flow