### PR TITLE
Recover from stranded flushnig on end of stream too

### DIFF
--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -270,8 +270,15 @@ func (w *AppWriter) start() {
 	// clean up
 	if w.playing.IsBroken() {
 		w.callbacks.OnEOSSent()
-		if flow := w.src.EndStream(); flow != gst.FlowOK && flow != gst.FlowFlushing {
-			w.logger.Warnw("unexpected flow return", nil, "flowReturn", flow.String())
+		flow := w.src.EndStream()
+		if flow == gst.FlowFlushing {
+			// a stuck appsrc refuses EOS, blocking EOS aggregation in the
+			// mixer and freezing the shutdown - recover it and retry
+			w.recoverFromFlushing()
+			flow = w.src.EndStream()
+		}
+		if flow != gst.FlowOK {
+			w.logger.Warnw("appsrc rejected EOS, pipeline may not reach EOS", nil, "flowReturn", flow.String())
 		}
 		if w.driftHandler != nil {
 			w.logger.Debugw("processed drift", "drift", w.driftHandler.Processed())


### PR DESCRIPTION
The previous change added recovery from stranded flushing on packet push - so that track can start ingesting packets into pipeline correctly. There is one more case that will benefit from the recovery - sending the end of stream signal - if packets started flushing but the recovery wasn't yet performed (didn't reach the threshold) and the track/recording ends - a writer will try to send EOS and that call will get the same flow flushing error, so EOS never propagates and we get the same pipeline frozen error. The change here introduces the recovery path for that use case as well. This is the only appsrc related cause of pipeline frozen errors remaining that I can see in logs.