### PR TITLE
Add videotestsrc delay headroom to audio_queue to stop HLS audio drops

### DIFF
--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -80,7 +80,11 @@ func BuildAudioBin(pipeline *gstreamer.Pipeline, p *config.PipelineConfig) error
 			return err
 		}
 	} else {
-		queue, err := gstreamer.BuildQueue(fmt.Sprintf("%s_queue", audioBinName), p.Latency.PipelineLatency, p.Live)
+		latency := p.Latency.PipelineLatency
+		if p.SourceType == types.SourceTypeSDK && p.VideoEnabled {
+			latency += videoTestSrcDelay
+		}
+		queue, err := gstreamer.BuildQueue(fmt.Sprintf("%s_queue", audioBinName), latency, p.Live)
 		if err != nil {
 			return errors.ErrGstPipelineError(err)
 		}
@@ -320,7 +324,6 @@ func (b *AudioBin) addAudioAppSrcBinLocked(ts *config.TrackSource) error {
 
 	return nil
 }
-
 
 func (b *AudioBin) getChannelLocked(ts *config.TrackSource) livekit.AudioChannel {
 	if ts.AudioChannel != nil {

--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -523,7 +523,7 @@ func (b *VideoBin) addVideoTestSrcBin() error {
 	if err != nil {
 		return err
 	}
-	if err = queue.SetProperty("min-threshold-time", uint64(videoTestSrcDelay)); err != nil {
+	if err = queue.SetProperty("min-threshold-time", uint64(videoTestSrcDelay.Nanoseconds())); err != nil {
 		return errors.ErrGstPipelineError(err)
 	}
 

--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	videoTestSrcName = "video_test_src"
+	videoTestSrcName  = "video_test_src"
+	videoTestSrcDelay = 2 * time.Second
 )
 
 type VideoBin struct {
@@ -522,7 +523,7 @@ func (b *VideoBin) addVideoTestSrcBin() error {
 	if err != nil {
 		return err
 	}
-	if err = queue.SetProperty("min-threshold-time", uint64(2e9)); err != nil {
+	if err = queue.SetProperty("min-threshold-time", uint64(videoTestSrcDelay)); err != nil {
 		return errors.ErrGstPipelineError(err)
 	}
 

--- a/test/builder.go
+++ b/test/builder.go
@@ -129,10 +129,11 @@ type streamOptions struct {
 }
 
 type segmentOptions struct {
-	prefix       string
-	playlist     string
-	livePlaylist string
-	suffix       livekit.SegmentedFileSuffix
+	prefix          string
+	playlist        string
+	livePlaylist    string
+	suffix          livekit.SegmentedFileSuffix
+	segmentDuration uint32
 }
 
 type imageOptions struct {
@@ -354,6 +355,7 @@ func (r *Runner) buildSegmentOutputs(o *segmentOptions) []*livekit.SegmentedFile
 			PlaylistName:     o.playlist,
 			LivePlaylistName: o.livePlaylist,
 			FilenameSuffix:   o.suffix,
+			SegmentDuration:  o.segmentDuration,
 		}
 
 		switch conf := u.(type) {
@@ -373,6 +375,7 @@ func (r *Runner) buildSegmentOutputs(o *segmentOptions) []*livekit.SegmentedFile
 		PlaylistName:     o.playlist,
 		LivePlaylistName: o.livePlaylist,
 		FilenameSuffix:   o.suffix,
+		SegmentDuration:  o.segmentDuration,
 	}}
 }
 
@@ -494,6 +497,7 @@ func (r *Runner) buildV2Outputs(test *testCase) []*livekit.Output {
 					PlaylistName:     test.playlist,
 					LivePlaylistName: test.livePlaylist,
 					FilenameSuffix:   test.segmentOptions.suffix,
+					SegmentDuration:  test.segmentDuration,
 				},
 			},
 			Storage: storage,

--- a/test/segments.go
+++ b/test/segments.go
@@ -110,6 +110,18 @@ func (r *Runner) testSegments(t *testing.T) {
 				},
 			},
 			{
+				name:        "ParticipantComposite/AudioOnlyPublisher",
+				requestType: types.RequestTypeParticipant,
+				publishOptions: publishOptions{
+					audioCodec: types.MimeTypeOpus,
+				},
+				segmentOptions: &segmentOptions{
+					prefix:          "participant_{publisher_identity}_audio_only_{time}",
+					playlist:        "participant_{publisher_identity}_audio_only_{time}.m3u8",
+					segmentDuration: 6,
+				},
+			},
+			{
 				name:        "ParticipantComposite/H264",
 				requestType: types.RequestTypeParticipant,
 				publishOptions: publishOptions{


### PR DESCRIPTION
## Problem

Participant egress with segments (HLS) output steadily discards audio in the leaky `audio_queue` whenever the participant publishes audio but no video. Reported case: 1,731 buffers ≈ 33% of all audio missing from a 112s recording, gaps throughout. participant+file and room_composite are unaffected.

## Root cause

With no video track, the splitmuxsink reference stream is the black `videotestsrc` branch, which is delayed 2s by `min-threshold-time` on `video_test_src_queue` (added in 84d9654 / #725 to keep the test-src PTS watermark behind a late-arriving real track, so the selector monotonicity probes don't drop the camera's first frames — the 2s matches the jitter buffer latency).

splitmuxsink admits an audio buffer with PTS `t` only after a reference (video) buffer with PTS > `t` has arrived (`gstsplitmuxsink.c` non-reference gate). With the reference 2s + encoder-lookahead late, every audio buffer waits ~2.2s of the leaky `audio_queue`'s 3s (`PipelineLatency`) budget at steady state. Fragment closes stall the reference further; the queue tops out and `leaky=downstream` silently discards the oldest buffers — each one a hole in the muxed audio.

## Fix

Size `audio_queue` at `PipelineLatency + videoTestSrcDelay` for SDK pipelines with video enabled — i.e. exactly when the test-src branch can be the mux reference — restoring the headroom the delay consumes. The 2s literal is promoted to a shared `videoTestSrcDelay` constant so the delay and the audio headroom can't drift apart. The queue stays leaky so a genuinely wedged downstream still degrades gracefully instead of stalling the audio path.

No latency or memory impact: the cap is not a target (occupancy is set by the muxer gate either way), and the queue holds encoded audio (~32KB per extra second).

## Testing

New segments integration test `ParticipantComposite/AudioOnlyPublisher` (audio-only publisher, 6s segments, mirrors the reported production request). Before this change it fails via the beep-presence content check:

- repro: `droppedByQueue: {audio_queue: 289}` (~6.2s of audio), beeps 26/30 (87%) → FAIL
- control (`ParticipantComposite/VP8`, same config + camera): 0 dropped, beeps 30/30 → PASS

With the change the repro passes alongside the existing segments suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)