### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish-chrome.yaml
+++ b/.github/workflows/publish-chrome.yaml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install the Linode CLI
-        uses: linode/action-linode-cli@v1
+        uses: linode/action-linode-cli@39bf520df2250ffb8e94e139bcdd86e4b35c5b8d # v1
         with:
           token: ${{ secrets.LINODE_PAT }}
 
@@ -299,16 +299,16 @@ jobs:
           unzip -o "${{ github.workspace }}/build/chrome/output.zip" -d "${{ github.workspace }}/build/chrome"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./build/chrome
           file: ./build/chrome/Dockerfile

--- a/.github/workflows/publish-egress.yaml
+++ b/.github/workflows/publish-egress.yaml
@@ -29,9 +29,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest-m
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/go/pkg/mod
@@ -42,7 +42,7 @@ jobs:
 
       - name: Docker metadata
         id: docker-md
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: livekit/egress
           tags: |
@@ -50,7 +50,7 @@ jobs:
             type=semver,pattern=v{{major}}.{{minor}}
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: 1.26.5
 
@@ -64,19 +64,19 @@ jobs:
           echo "template_tag=$TEMPLATE_TAG" > "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./build/egress/Dockerfile

--- a/.github/workflows/publish-gstreamer-base.yaml
+++ b/.github/workflows/publish-gstreamer-base.yaml
@@ -35,13 +35,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       # the build-arg in FROM lines, so they get IMAGE_TAG to chain off the
       # image built here.
       - name: Build and push base
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./build/gstreamer
           push: true
@@ -62,7 +62,7 @@ jobs:
           tags: livekit/gstreamer:${{ env.IMAGE_TAG }}-base-${{ inputs.arch }}
 
       - name: Build and push dev
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./build/gstreamer
           push: true
@@ -73,7 +73,7 @@ jobs:
           tags: livekit/gstreamer:${{ env.IMAGE_TAG }}-dev-${{ inputs.arch }}
 
       - name: Build and push prod
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./build/gstreamer
           push: true
@@ -84,7 +84,7 @@ jobs:
           tags: livekit/gstreamer:${{ env.IMAGE_TAG }}-prod-${{ inputs.arch }}
 
       - name: Build and push prod RS
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./build/gstreamer
           push: true

--- a/.github/workflows/publish-gstreamer.yaml
+++ b/.github/workflows/publish-gstreamer.yaml
@@ -44,13 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/publish-template-sdk.yaml
+++ b/.github/workflows/publish-template-sdk.yaml
@@ -28,12 +28,12 @@ jobs:
       run:
         working-directory: ./template-sdk
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 11
       - name: Use Node.js 18
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/publish-template.yaml
+++ b/.github/workflows/publish-template.yaml
@@ -30,19 +30,19 @@ jobs:
   docker:
     runs-on: ubuntu-latest-m
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         # for pull requests, need to checkout head for EndBug/add-and-commit to work
         if: github.event_name == 'pull_request'
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: github.event_name != 'pull_request'
 
       - name: Docker metadata
         id: docker-md
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: livekit/egress-templates
           tags: |
@@ -50,16 +50,16 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./build/template/Dockerfile
@@ -75,7 +75,7 @@ jobs:
           mv -f version.go version/version.go
 
       - name: Commit version changes
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
         with:
           default_author: github_actions
           message: |

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -37,7 +37,7 @@ jobs:
     outputs:
       image: ${{ steps.docker-md.outputs.tags }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           lfs: true
       - name: Fetch media-samples (with LFS)
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: build/test/fetch-media-samples.sh
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/go/pkg/mod
@@ -56,14 +56,14 @@ jobs:
 
       - name: Docker metadata
         id: docker-md
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: livekit/egress-integration
           tags: |
             type=sha
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: 1.26.5
 
@@ -77,20 +77,20 @@ jobs:
           echo "template_tag=$TEMPLATE_TAG" > "$GITHUB_OUTPUT"
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         with:
           driver: docker-container
           install: true
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -114,7 +114,7 @@ jobs:
         integration_type: [file-room, file-track, file-media, stream, segments, images, multi, edge]
     runs-on: ubuntu-latest-m
     steps:
-      - uses: shogo82148/actions-setup-redis@v1
+      - uses: shogo82148/actions-setup-redis@3e38d435ea02619c76909c929ecc501806c7145e # v1
         with:
           redis-version: '6.x'
           auto-start: true
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload avsync stats artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: avsync-stats-${{ matrix.integration_type }}
           path: /tmp/avsync-stats.json
@@ -160,10 +160,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download avsync stats artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: avsync-stats-*
           path: stats/

--- a/.github/workflows/test-template.yaml
+++ b/.github/workflows/test-template.yaml
@@ -33,12 +33,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 11
       - name: Use Node.js 22
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: "pnpm"


### PR DESCRIPTION
## Summary

Pins all third-party GitHub Actions across the workflows to full 40-char commit SHAs, hardening the CI supply chain against mutable/hijacked version tags. Each pin keeps the original version as a trailing comment (e.g. `# v7`) so it stays human-readable and Dependabot/Renovate-updatable.

## Actions pinned

`actions/checkout`, `actions/cache`, `actions/setup-go`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact`, `docker/setup-buildx-action`, `docker/setup-qemu-action`, `docker/login-action`, `docker/build-push-action`, `docker/metadata-action`, `pnpm/action-setup`, `EndBug/add-and-commit`, `linode/action-linode-cli`, `shogo82148/actions-setup-redis`.

## Left unpinned (intentional)

- **`livekit/slack-notifier-action@main`** — first-party org action, kept floating on `main`.
- **Local reusable workflows** (`./.github/workflows/publish-gstreamer-base.yaml`) — same-repo path refs, resolved from the checked-out ref.

## Note

Pinning freezes each action at its current SHA, so automatic patch/security updates stop unless a bot bumps them — the `@sha # vX` format is understood by Dependabot and Renovate for exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)