### PR TITLE
Separate admission costs for SDK-source audio room composites

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ backup_storage: files will be moved here when uploads fail. location must have w
 enable_chrome_sandbox: if true, egress will run Chrome with sandboxing enabled. This requires a specific Docker setup, see below.
 cpu_cost: # optionally override cpu cost estimation, used when accepting or denying requests
   room_composite_cpu_cost: 3.0
+  audio_room_composite_cpu_cost: 1.0
+  sdk_audio_room_composite_cpu_cost: 0.5 # audio-only room composites without layout or custom_base_url (no chrome). Defaults to audio_room_composite_cpu_cost
+  sdk_audio_room_composite_memory_cost: 1.0 # memory in GB. Defaults to memory_cost
   web_cpu_cost: 3.0
   track_composite_cpu_cost: 2.0
   track_cpu_cost: 1.0

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -86,17 +86,19 @@ const (
 )
 
 type CPUCostConfig struct {
-	MaxCpuUtilization         float64 `yaml:"max_cpu_utilization"` // maximum allowed CPU utilization when deciding to accept a request. Default to 80%
-	MaxMemory                 float64 `yaml:"max_memory"`          // maximum allowed memory usage in GB. 0 to disable
-	MemoryCost                float64 `yaml:"memory_cost"`         // minimum memory in GB
-	RoomCompositeCpuCost      float64 `yaml:"room_composite_cpu_cost"`
-	AudioRoomCompositeCpuCost float64 `yaml:"audio_room_composite_cpu_cost"`
-	WebCpuCost                float64 `yaml:"web_cpu_cost"`
-	AudioWebCpuCost           float64 `yaml:"audio_web_cpu_cost"`
-	ParticipantCpuCost        float64 `yaml:"participant_cpu_cost"`
-	TrackCompositeCpuCost     float64 `yaml:"track_composite_cpu_cost"`
-	TrackCpuCost              float64 `yaml:"track_cpu_cost"`
-	MaxPulseClients           int     `yaml:"max_pulse_clients"` // pulse client limit for launching chrome
+	MaxCpuUtilization               float64 `yaml:"max_cpu_utilization"` // maximum allowed CPU utilization when deciding to accept a request. Default to 80%
+	MaxMemory                       float64 `yaml:"max_memory"`          // maximum allowed memory usage in GB. 0 to disable
+	MemoryCost                      float64 `yaml:"memory_cost"`         // minimum memory in GB
+	RoomCompositeCpuCost            float64 `yaml:"room_composite_cpu_cost"`
+	AudioRoomCompositeCpuCost       float64 `yaml:"audio_room_composite_cpu_cost"`
+	SDKAudioRoomCompositeCpuCost    float64 `yaml:"sdk_audio_room_composite_cpu_cost"`
+	SDKAudioRoomCompositeMemoryCost float64 `yaml:"sdk_audio_room_composite_memory_cost"`
+	WebCpuCost                      float64 `yaml:"web_cpu_cost"`
+	AudioWebCpuCost                 float64 `yaml:"audio_web_cpu_cost"`
+	ParticipantCpuCost              float64 `yaml:"participant_cpu_cost"`
+	TrackCompositeCpuCost           float64 `yaml:"track_composite_cpu_cost"`
+	TrackCpuCost                    float64 `yaml:"track_cpu_cost"`
+	MaxPulseClients                 int     `yaml:"max_pulse_clients"` // pulse client limit for launching chrome
 
 	// Memory source configuration (cgroup-aware memory accounting)
 	MemorySource       MemorySource `yaml:"memory_source"`         // memory measurement source: proc_rss, cgroup
@@ -166,6 +168,12 @@ func (c *ServiceConfig) InitDefaults() {
 	}
 	if c.AudioRoomCompositeCpuCost <= 0 {
 		c.AudioRoomCompositeCpuCost = audioRoomCompositeCpuCost
+	}
+	if c.SDKAudioRoomCompositeCpuCost <= 0 {
+		c.SDKAudioRoomCompositeCpuCost = c.AudioRoomCompositeCpuCost
+	}
+	if c.SDKAudioRoomCompositeMemoryCost <= 0 {
+		c.SDKAudioRoomCompositeMemoryCost = c.MemoryCost
 	}
 	if c.WebCpuCost <= 0 {
 		c.WebCpuCost = webCpuCost

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -149,6 +149,7 @@ func (m *Monitor) validateCPUConfig() error {
 	requirements := []float64{
 		m.cpuCostConfig.RoomCompositeCpuCost,
 		m.cpuCostConfig.AudioRoomCompositeCpuCost,
+		m.cpuCostConfig.SDKAudioRoomCompositeCpuCost,
 		m.cpuCostConfig.WebCpuCost,
 		m.cpuCostConfig.AudioWebCpuCost,
 		m.cpuCostConfig.ParticipantCpuCost,
@@ -259,7 +260,12 @@ func (m *Monitor) costsForRequest(req *rpc.StartEgressRequest) requestCosts {
 		if template := request.GetTemplate(); template != nil {
 			costs.isWeb = !config.ShouldUseSDKSource(template)
 			if template.AudioOnly {
-				costs.cpu = m.cpuCostConfig.AudioRoomCompositeCpuCost
+				if costs.isWeb {
+					costs.cpu = m.cpuCostConfig.AudioRoomCompositeCpuCost
+				} else {
+					costs.cpu = m.cpuCostConfig.SDKAudioRoomCompositeCpuCost
+					costs.memory = m.cpuCostConfig.SDKAudioRoomCompositeMemoryCost
+				}
 			} else {
 				costs.cpu = m.cpuCostConfig.RoomCompositeCpuCost
 			}
@@ -279,7 +285,12 @@ func (m *Monitor) costsForRequest(req *rpc.StartEgressRequest) requestCosts {
 	case *rpc.StartEgressRequest_RoomComposite:
 		costs.isWeb = !config.ShouldUseSDKSource(r.RoomComposite)
 		if r.RoomComposite.AudioOnly {
-			costs.cpu = m.cpuCostConfig.AudioRoomCompositeCpuCost
+			if costs.isWeb {
+				costs.cpu = m.cpuCostConfig.AudioRoomCompositeCpuCost
+			} else {
+				costs.cpu = m.cpuCostConfig.SDKAudioRoomCompositeCpuCost
+				costs.memory = m.cpuCostConfig.SDKAudioRoomCompositeMemoryCost
+			}
 		} else {
 			costs.cpu = m.cpuCostConfig.RoomCompositeCpuCost
 		}

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -213,91 +213,22 @@ func (m *Monitor) canAcceptRequestLocked(req *rpc.StartEgressRequest) ([]interfa
 		"memorySource", m.cpuCostConfig.MemorySource,
 	}
 
+	costs := m.costsForRequest(req)
+
 	// Memory admission check based on configured source
-	if reject, reason := m.checkMemoryAdmissionLocked(); reject {
+	if reject, reason := m.checkMemoryAdmissionLocked(costs.memory); reject {
 		fields = append(fields, "canAccept", false, "reason", reason)
 		return fields, false
 	}
 
-	required := req.EstimatedCpu
-
-	setRequired := func(request egress.EgressRequest) bool {
-		if template := request.GetTemplate(); template != nil {
-			useSDK := config.ShouldUseSDKSource(template)
-			if !useSDK && !m.canAcceptWebLocked() {
-				fields = append(fields, "canAccept", false, "reason", "pulse clients")
-				return false
-			}
-			if required == 0 {
-				if template.AudioOnly {
-					required = m.cpuCostConfig.AudioRoomCompositeCpuCost
-				} else {
-					required = m.cpuCostConfig.RoomCompositeCpuCost
-				}
-			}
-		} else if web := request.GetWeb(); web != nil {
-			if !m.canAcceptWebLocked() {
-				fields = append(fields, "canAccept", false, "reason", "pulse clients")
-				return false
-			}
-			if required == 0 {
-				if web.AudioOnly {
-					required = m.cpuCostConfig.AudioWebCpuCost
-				} else {
-					required = m.cpuCostConfig.WebCpuCost
-				}
-			}
-		} else if media := request.GetMedia(); media != nil {
-			if required == 0 {
-				required = m.cpuCostConfig.ParticipantCpuCost
-				return true
-			}
-		}
-		return false
+	if costs.isWeb && !m.canAcceptWebLocked() {
+		fields = append(fields, "canAccept", false, "reason", "pulse clients")
+		return fields, false
 	}
 
-	switch r := req.Request.(type) {
-	case *rpc.StartEgressRequest_RoomComposite:
-		useSDK := config.ShouldUseSDKSource(r.RoomComposite)
-		if !useSDK && !m.canAcceptWebLocked() {
-			fields = append(fields, "canAccept", false, "reason", "pulse clients")
-			return fields, false
-		}
-		if required == 0 {
-			if r.RoomComposite.AudioOnly {
-				required = m.cpuCostConfig.AudioRoomCompositeCpuCost
-			} else {
-				required = m.cpuCostConfig.RoomCompositeCpuCost
-			}
-		}
-	case *rpc.StartEgressRequest_Web:
-		if !m.canAcceptWebLocked() {
-			fields = append(fields, "canAccept", false, "reason", "pulse clients")
-			return fields, false
-		}
-		if required == 0 {
-			if r.Web.AudioOnly {
-				required = m.cpuCostConfig.AudioWebCpuCost
-			} else {
-				required = m.cpuCostConfig.WebCpuCost
-			}
-		}
-	case *rpc.StartEgressRequest_Participant:
-		if required == 0 {
-			required = m.cpuCostConfig.ParticipantCpuCost
-		}
-	case *rpc.StartEgressRequest_TrackComposite:
-		if required == 0 {
-			required = m.cpuCostConfig.TrackCompositeCpuCost
-		}
-	case *rpc.StartEgressRequest_Track:
-		if required == 0 {
-			required = m.cpuCostConfig.TrackCpuCost
-		}
-	case *rpc.StartEgressRequest_Replay:
-		setRequired(r.Replay)
-	case *rpc.StartEgressRequest_Egress:
-		setRequired(r.Egress)
+	required := req.EstimatedCpu
+	if required == 0 {
+		required = costs.cpu
 	}
 
 	accept := available >= required
@@ -312,6 +243,68 @@ func (m *Monitor) canAcceptRequestLocked(req *rpc.StartEgressRequest) ([]interfa
 	return fields, accept
 }
 
+// requestCosts holds the static admission costs and source classification for a request.
+type requestCosts struct {
+	cpu    float64
+	memory float64
+	isWeb  bool
+}
+
+// costsForRequest is the single source of truth for per-request admission costs,
+// used by both the admission check and the reservation.
+func (m *Monitor) costsForRequest(req *rpc.StartEgressRequest) requestCosts {
+	costs := requestCosts{memory: m.cpuCostConfig.MemoryCost}
+
+	setV2Costs := func(request egress.EgressRequest) {
+		if template := request.GetTemplate(); template != nil {
+			costs.isWeb = !config.ShouldUseSDKSource(template)
+			if template.AudioOnly {
+				costs.cpu = m.cpuCostConfig.AudioRoomCompositeCpuCost
+			} else {
+				costs.cpu = m.cpuCostConfig.RoomCompositeCpuCost
+			}
+		} else if web := request.GetWeb(); web != nil {
+			costs.isWeb = true
+			if web.AudioOnly {
+				costs.cpu = m.cpuCostConfig.AudioWebCpuCost
+			} else {
+				costs.cpu = m.cpuCostConfig.WebCpuCost
+			}
+		} else if request.GetMedia() != nil {
+			costs.cpu = m.cpuCostConfig.ParticipantCpuCost
+		}
+	}
+
+	switch r := req.Request.(type) {
+	case *rpc.StartEgressRequest_RoomComposite:
+		costs.isWeb = !config.ShouldUseSDKSource(r.RoomComposite)
+		if r.RoomComposite.AudioOnly {
+			costs.cpu = m.cpuCostConfig.AudioRoomCompositeCpuCost
+		} else {
+			costs.cpu = m.cpuCostConfig.RoomCompositeCpuCost
+		}
+	case *rpc.StartEgressRequest_Web:
+		costs.isWeb = true
+		if r.Web.AudioOnly {
+			costs.cpu = m.cpuCostConfig.AudioWebCpuCost
+		} else {
+			costs.cpu = m.cpuCostConfig.WebCpuCost
+		}
+	case *rpc.StartEgressRequest_Participant:
+		costs.cpu = m.cpuCostConfig.ParticipantCpuCost
+	case *rpc.StartEgressRequest_TrackComposite:
+		costs.cpu = m.cpuCostConfig.TrackCompositeCpuCost
+	case *rpc.StartEgressRequest_Track:
+		costs.cpu = m.cpuCostConfig.TrackCpuCost
+	case *rpc.StartEgressRequest_Replay:
+		setV2Costs(r.Replay)
+	case *rpc.StartEgressRequest_Egress:
+		setV2Costs(r.Egress)
+	}
+
+	return costs
+}
+
 func (m *Monitor) canAcceptWebLocked() bool {
 	clients, err := pulse.Clients()
 	if err != nil {
@@ -322,13 +315,12 @@ func (m *Monitor) canAcceptWebLocked() bool {
 
 // checkMemoryAdmissionLocked checks if a request should be rejected due to memory constraints.
 // Returns (reject, reason) where reject=true means the request should be rejected.
-func (m *Monitor) checkMemoryAdmissionLocked() (bool, string) {
+func (m *Monitor) checkMemoryAdmissionLocked(memoryCost float64) (bool, string) {
 	if m.cpuCostConfig.MaxMemory == 0 {
 		return false, ""
 	}
 
 	pendingMem := m.pendingMemoryUsage.Load()
-	memoryCost := m.cpuCostConfig.MemoryCost
 	headroom := memoryHeadroomGB
 	maxMem := m.cpuCostConfig.MaxMemory
 
@@ -372,81 +364,23 @@ func (m *Monitor) AcceptRequest(req *rpc.StartEgressRequest) error {
 	}
 
 	m.requests.Inc()
-	var cpuHold float64
+
+	costs := m.costsForRequest(req)
 	var pulseClients int32
-	var countedAsWeb bool
-
-	setCPUHold := func(request egress.EgressRequest) {
-		if template := request.GetTemplate(); template != nil {
-			useSDK := config.ShouldUseSDKSource(template)
-			if !useSDK {
-				m.webRequests.Inc()
-				countedAsWeb = true
-				pulseClients = pulseClientHold
-			}
-			if template.AudioOnly {
-				cpuHold = m.cpuCostConfig.AudioRoomCompositeCpuCost
-			} else {
-				cpuHold = m.cpuCostConfig.RoomCompositeCpuCost
-			}
-		} else if web := request.GetWeb(); web != nil {
-			pulseClients = pulseClientHold
-			m.webRequests.Inc()
-			countedAsWeb = true
-			if web.AudioOnly {
-				cpuHold = m.cpuCostConfig.AudioWebCpuCost
-			} else {
-				cpuHold = m.cpuCostConfig.WebCpuCost
-			}
-		} else if request.GetMedia() != nil {
-			cpuHold = m.cpuCostConfig.ParticipantCpuCost
-		}
-	}
-
-	switch r := req.Request.(type) {
-	case *rpc.StartEgressRequest_RoomComposite:
-		useSDK := config.ShouldUseSDKSource(r.RoomComposite)
-		if !useSDK {
-			m.webRequests.Inc()
-			countedAsWeb = true
-			pulseClients = pulseClientHold
-		}
-		if r.RoomComposite.AudioOnly {
-			cpuHold = m.cpuCostConfig.AudioRoomCompositeCpuCost
-		} else {
-			cpuHold = m.cpuCostConfig.RoomCompositeCpuCost
-		}
-	case *rpc.StartEgressRequest_Web:
-		pulseClients = pulseClientHold
+	if costs.isWeb {
 		m.webRequests.Inc()
-		countedAsWeb = true
-		if r.Web.AudioOnly {
-			cpuHold = m.cpuCostConfig.AudioWebCpuCost
-		} else {
-			cpuHold = m.cpuCostConfig.WebCpuCost
-		}
-	case *rpc.StartEgressRequest_Participant:
-		cpuHold = m.cpuCostConfig.ParticipantCpuCost
-	case *rpc.StartEgressRequest_TrackComposite:
-		cpuHold = m.cpuCostConfig.TrackCompositeCpuCost
-	case *rpc.StartEgressRequest_Track:
-		cpuHold = m.cpuCostConfig.TrackCpuCost
-	case *rpc.StartEgressRequest_Replay:
-		setCPUHold(r.Replay)
-	case *rpc.StartEgressRequest_Egress:
-		setCPUHold(r.Egress)
+		pulseClients = pulseClientHold
 	}
 
-	reqType := requestTypeFromReq(req)
 	ps := &processStats{
 		egressID:     req.EgressId,
-		requestType:  reqType,
-		pendingCPU:   cpuHold,
-		allowedCPU:   cpuHold,
-		countedAsWeb: countedAsWeb,
+		requestType:  requestTypeFromReq(req),
+		pendingCPU:   costs.cpu,
+		allowedCPU:   costs.cpu,
+		countedAsWeb: costs.isWeb,
 	}
 
-	m.pendingMemoryUsage.Add(m.cpuCostConfig.MemoryCost)
+	m.pendingMemoryUsage.Add(costs.memory)
 	m.pendingPulseClients.Add(pulseClients)
 
 	time.AfterFunc(cpuHoldDuration, func() {
@@ -454,7 +388,7 @@ func (m *Monitor) AcceptRequest(req *rpc.StartEgressRequest) error {
 		defer m.mu.Unlock()
 
 		ps.pendingCPU = 0
-		m.pendingMemoryUsage.Add(-m.cpuCostConfig.MemoryCost)
+		m.pendingMemoryUsage.Add(-costs.memory)
 		m.pendingPulseClients.Add(-pulseClients)
 	})
 	m.pending[req.EgressId] = ps

--- a/pkg/stats/monitor_costs_test.go
+++ b/pkg/stats/monitor_costs_test.go
@@ -28,14 +28,16 @@ import (
 func TestCostsForRequest(t *testing.T) {
 	m := &Monitor{
 		cpuCostConfig: &config.CPUCostConfig{
-			RoomCompositeCpuCost:      4,
-			AudioRoomCompositeCpuCost: 1,
-			WebCpuCost:                4.5,
-			AudioWebCpuCost:           1.5,
-			ParticipantCpuCost:        2,
-			TrackCompositeCpuCost:     2.5,
-			TrackCpuCost:              0.2,
-			MemoryCost:                3,
+			RoomCompositeCpuCost:            4,
+			AudioRoomCompositeCpuCost:       1,
+			SDKAudioRoomCompositeCpuCost:    0.5,
+			SDKAudioRoomCompositeMemoryCost: 1,
+			WebCpuCost:                      4.5,
+			AudioWebCpuCost:                 1.5,
+			ParticipantCpuCost:              2,
+			TrackCompositeCpuCost:           2.5,
+			TrackCpuCost:                    0.2,
+			MemoryCost:                      3,
 		},
 	}
 
@@ -63,7 +65,7 @@ func TestCostsForRequest(t *testing.T) {
 		{
 			name: "room composite audio sdk",
 			req:  roomComposite(&livekit.RoomCompositeEgressRequest{AudioOnly: true}),
-			cpu:  1, memory: 3, isWeb: false,
+			cpu:  0.5, memory: 1, isWeb: false,
 		},
 		{
 			name: "room composite audio with layout",
@@ -113,7 +115,7 @@ func TestCostsForRequest(t *testing.T) {
 		{
 			name: "v2 template audio sdk",
 			req:  v2Template(&livekit.TemplateSource{AudioOnly: true}),
-			cpu:  1, memory: 3, isWeb: false,
+			cpu:  0.5, memory: 1, isWeb: false,
 		},
 		{
 			name: "v2 template audio with layout",
@@ -151,7 +153,7 @@ func TestCostsForRequest(t *testing.T) {
 					Source: &livekit.ExportReplayRequest_Template{Template: &livekit.TemplateSource{AudioOnly: true}},
 				},
 			}},
-			cpu: 1, memory: 3, isWeb: false,
+			cpu: 0.5, memory: 1, isWeb: false,
 		},
 		{
 			name: "v2 no source",

--- a/pkg/stats/monitor_costs_test.go
+++ b/pkg/stats/monitor_costs_test.go
@@ -1,0 +1,171 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/rpc"
+
+	"github.com/livekit/egress/pkg/config"
+)
+
+func TestCostsForRequest(t *testing.T) {
+	m := &Monitor{
+		cpuCostConfig: &config.CPUCostConfig{
+			RoomCompositeCpuCost:      4,
+			AudioRoomCompositeCpuCost: 1,
+			WebCpuCost:                4.5,
+			AudioWebCpuCost:           1.5,
+			ParticipantCpuCost:        2,
+			TrackCompositeCpuCost:     2.5,
+			TrackCpuCost:              0.2,
+			MemoryCost:                3,
+		},
+	}
+
+	roomComposite := func(r *livekit.RoomCompositeEgressRequest) *rpc.StartEgressRequest {
+		return &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_RoomComposite{RoomComposite: r}}
+	}
+	v2Template := func(tmpl *livekit.TemplateSource) *rpc.StartEgressRequest {
+		return &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_Egress{
+			Egress: &livekit.StartEgressRequest{Source: &livekit.StartEgressRequest_Template{Template: tmpl}},
+		}}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		req    *rpc.StartEgressRequest
+		cpu    float64
+		memory float64
+		isWeb  bool
+	}{
+		{
+			name: "room composite video",
+			req:  roomComposite(&livekit.RoomCompositeEgressRequest{}),
+			cpu:  4, memory: 3, isWeb: true,
+		},
+		{
+			name: "room composite audio sdk",
+			req:  roomComposite(&livekit.RoomCompositeEgressRequest{AudioOnly: true}),
+			cpu:  1, memory: 3, isWeb: false,
+		},
+		{
+			name: "room composite audio with layout",
+			req:  roomComposite(&livekit.RoomCompositeEgressRequest{AudioOnly: true, Layout: "speaker"}),
+			cpu:  1, memory: 3, isWeb: true,
+		},
+		{
+			name: "room composite audio with custom base url",
+			req:  roomComposite(&livekit.RoomCompositeEgressRequest{AudioOnly: true, CustomBaseUrl: "https://example.com"}),
+			cpu:  1, memory: 3, isWeb: true,
+		},
+		{
+			name: "web",
+			req: &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_Web{
+				Web: &livekit.WebEgressRequest{},
+			}},
+			cpu: 4.5, memory: 3, isWeb: true,
+		},
+		{
+			name: "web audio only",
+			req: &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_Web{
+				Web: &livekit.WebEgressRequest{AudioOnly: true},
+			}},
+			cpu: 1.5, memory: 3, isWeb: true,
+		},
+		{
+			name: "participant",
+			req: &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_Participant{
+				Participant: &livekit.ParticipantEgressRequest{},
+			}},
+			cpu: 2, memory: 3, isWeb: false,
+		},
+		{
+			name: "track composite",
+			req: &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_TrackComposite{
+				TrackComposite: &livekit.TrackCompositeEgressRequest{},
+			}},
+			cpu: 2.5, memory: 3, isWeb: false,
+		},
+		{
+			name: "track",
+			req: &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_Track{
+				Track: &livekit.TrackEgressRequest{},
+			}},
+			cpu: 0.2, memory: 3, isWeb: false,
+		},
+		{
+			name: "v2 template audio sdk",
+			req:  v2Template(&livekit.TemplateSource{AudioOnly: true}),
+			cpu:  1, memory: 3, isWeb: false,
+		},
+		{
+			name: "v2 template audio with layout",
+			req:  v2Template(&livekit.TemplateSource{AudioOnly: true, Layout: "speaker"}),
+			cpu:  1, memory: 3, isWeb: true,
+		},
+		{
+			name: "v2 template audio with custom base url",
+			req:  v2Template(&livekit.TemplateSource{AudioOnly: true, CustomBaseUrl: "https://example.com"}),
+			cpu:  1, memory: 3, isWeb: true,
+		},
+		{
+			name: "v2 template video",
+			req:  v2Template(&livekit.TemplateSource{}),
+			cpu:  4, memory: 3, isWeb: true,
+		},
+		{
+			name: "v2 web",
+			req: &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_Egress{
+				Egress: &livekit.StartEgressRequest{Source: &livekit.StartEgressRequest_Web{Web: &livekit.WebSource{}}},
+			}},
+			cpu: 4.5, memory: 3, isWeb: true,
+		},
+		{
+			name: "v2 media",
+			req: &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_Egress{
+				Egress: &livekit.StartEgressRequest{Source: &livekit.StartEgressRequest_Media{Media: &livekit.MediaSource{}}},
+			}},
+			cpu: 2, memory: 3, isWeb: false,
+		},
+		{
+			name: "v2 replay template audio sdk",
+			req: &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_Replay{
+				Replay: &livekit.ExportReplayRequest{
+					Source: &livekit.ExportReplayRequest_Template{Template: &livekit.TemplateSource{AudioOnly: true}},
+				},
+			}},
+			cpu: 1, memory: 3, isWeb: false,
+		},
+		{
+			name: "v2 no source",
+			req: &rpc.StartEgressRequest{Request: &rpc.StartEgressRequest_Egress{
+				Egress: &livekit.StartEgressRequest{},
+			}},
+			cpu: 0, memory: 3, isWeb: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			costs := m.costsForRequest(tc.req)
+			require.Equal(t, tc.cpu, costs.cpu, "cpu")
+			require.Equal(t, tc.memory, costs.memory, "memory")
+			require.Equal(t, tc.isWeb, costs.isWeb, "isWeb")
+		})
+	}
+}

--- a/pkg/stats/monitor_memory_test.go
+++ b/pkg/stats/monitor_memory_test.go
@@ -33,12 +33,12 @@ func TestCheckMemoryAdmissionLocked_Legacy(t *testing.T) {
 	}
 
 	// 5 + 0 (pending) + 1 (cost) + 1 (headroom) = 7 < 10, should accept
-	reject, _ := m.checkMemoryAdmissionLocked()
+	reject, _ := m.checkMemoryAdmissionLocked(m.cpuCostConfig.MemoryCost)
 	require.False(t, reject)
 
 	// Increase usage to trigger rejection
 	m.memoryUsage = 8 // 8 + 0 + 1 + 1 = 10 >= 10, should reject
-	reject, reason := m.checkMemoryAdmissionLocked()
+	reject, reason := m.checkMemoryAdmissionLocked(m.cpuCostConfig.MemoryCost)
 	require.True(t, reject)
 	require.Equal(t, "memory", reason)
 }
@@ -55,12 +55,12 @@ func TestCheckMemoryAdmissionLocked_CgroupWorkingSet(t *testing.T) {
 	}
 
 	// Working set is 5 GB, should accept
-	reject, _ := m.checkMemoryAdmissionLocked()
+	reject, _ := m.checkMemoryAdmissionLocked(m.cpuCostConfig.MemoryCost)
 	require.False(t, reject)
 
 	// Increase working set to trigger rejection
 	m.cgroupUsageBytes = 8 * gb
-	reject, reason := m.checkMemoryAdmissionLocked()
+	reject, reason := m.checkMemoryAdmissionLocked(m.cpuCostConfig.MemoryCost)
 	require.True(t, reject)
 	require.Equal(t, "memory_cgroup", reason)
 }
@@ -77,11 +77,11 @@ func TestCheckMemoryAdmissionLocked_FallbackToProcRSS(t *testing.T) {
 	}
 
 	// Should fall back to proc_rss
-	reject, _ := m.checkMemoryAdmissionLocked()
+	reject, _ := m.checkMemoryAdmissionLocked(m.cpuCostConfig.MemoryCost)
 	require.False(t, reject) // 5 + 0 + 1 + 1 = 7 < 10
 
 	m.memoryUsage = 8
-	reject, reason := m.checkMemoryAdmissionLocked()
+	reject, reason := m.checkMemoryAdmissionLocked(m.cpuCostConfig.MemoryCost)
 	require.True(t, reject)
 	require.Equal(t, "memory", reason) // proc_rss reason
 }
@@ -96,7 +96,7 @@ func TestCheckMemoryAdmissionLocked_NoMaxMemory(t *testing.T) {
 	}
 
 	// Should not reject when MaxMemory is 0
-	reject, _ := m.checkMemoryAdmissionLocked()
+	reject, _ := m.checkMemoryAdmissionLocked(m.cpuCostConfig.MemoryCost)
 	require.False(t, reject)
 }
 
@@ -112,11 +112,11 @@ func TestCheckMemoryAdmissionLocked_WithPendingMemory(t *testing.T) {
 
 	// Add pending memory
 	m.pendingMemoryUsage.Store(2) // 5 + 2 + 1 + 1 = 9 < 10
-	reject, _ := m.checkMemoryAdmissionLocked()
+	reject, _ := m.checkMemoryAdmissionLocked(m.cpuCostConfig.MemoryCost)
 	require.False(t, reject)
 
 	m.pendingMemoryUsage.Store(3) // 5 + 3 + 1 + 1 = 10 >= 10
-	reject, reason := m.checkMemoryAdmissionLocked()
+	reject, reason := m.checkMemoryAdmissionLocked(m.cpuCostConfig.MemoryCost)
 	require.True(t, reject)
 	require.Equal(t, "memory", reason)
 }


### PR DESCRIPTION
## Motivation

Audio-only room composites without a `layout` or `custom_base_url` run on the SDK source (no chrome) and use a small fraction of the CPU and memory of the chrome path sharing their cost class. Since admission costs also bound how quickly a node can absorb new requests during the hold window, pricing the SDK path separately allows much denser packing and faster ramp for audio-only workloads, without touching the chrome-based costs.

## Changes

**Commit 1 — refactor**: extracts the duplicated cost selection in `canAcceptRequestLocked` and `AcceptRequest` into a single `costsForRequest` helper returning `{cpu, memory, isWeb}`, parameterizes the memory admission check, and adds a pricing table test covering all v1/v2 request shapes. Also fixes v2 template/web requests not being rejected when the pulse client limit is reached (the closure's rejection result was ignored at its call sites, so only v1 requests were enforced).

Preserved behavior (now visible in the table test): v2 `Media` requests are held at `ParticipantCpuCost` regardless of kind, and a v2 request with no recognizable source costs 0.

**Commit 2 — the split**: adds `sdk_audio_room_composite_cpu_cost` and `sdk_audio_room_composite_memory_cost`, applied when `ShouldUseSDKSource` is true for audio-only room composites (v1) and audio-only templates (v2, including replay) — the same predicate the pipeline uses for source selection, so admission cost and the actual pipeline can't disagree.

Both default to `audio_room_composite_cpu_cost` / `memory_cost` when unset, so **behavior is unchanged until explicitly configured**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)