### PR TITLE
Don't quarantine livekit dependency updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,11 +28,13 @@
       "groupName": "npm deps"
     },
     {
+      "description": "First-party deps, no need to quarantine new releases",
       "matchManagers": ["gomod"],
       "groupName": "livekit deps",
       "matchPackageNames": [
         "github.com/livekit{/,}**"
-      ]
+      ],
+      "minimumReleaseAge": null
     },
     {
       "enabled": false,


### PR DESCRIPTION
The global `minimumReleaseAge` of 2 weeks exists to let third-party releases settle before we pick them up. That quarantine adds no value for our own modules, so the `livekit deps` group now overrides it with `minimumReleaseAge: null` and `github.com/livekit/*` bumps are eligible as soon as they're released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)