### PR TITLE
Version 1.14.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 const (
-	Version         = "1.13.0"
+	Version         = "1.14.0"
 	TemplateVersion = "sha-f88afa8"
 )


### PR DESCRIPTION
## Changelog


### Added
- New sync engine — rewritten A/V synchronization with per-track drift probes and audio tempo control (#1198, #1277)
- Egress v2 API implementation (#1240)
- Two-tiered pacer (#1239)
- Drain egress on sustained high CPU instead of hard-killing, uploading what was recorded (#1265)
- Reap orphaned PulseAudio sinks in a dedicated monitor goroutine, so a crashed handler no longer permanently blocks web egress on the pod; reaper is tunable at runtime (#1289, #1294)
- Detect wedged RTMP sinks via an active per-stream liveness monitor; per-stream failures are isolated so multi-output egresses keep streaming on surviving outputs (#1244)
- Detect missing keyframes and re-request PLI across video codecs (#1256)
- Upload observability: report upload error status class (4xx/5xx/internal) and custom-endpoint usage in upload metrics (#1264, #1271)
- Chrome 150 (#1288)
- Logging improvements: hardware stats logged at info level at egress end (#1297), CPU info in memory stats dumps (#1306), room disconnect reason (#1262), warning on PTS patching (#1260)

### Changed
- Handler processes no longer connect to the message bus — per-egress RPC topics (UpdateStream, UpdateEgress, StopEgress) are served by the service process and forwarded to handlers over IPC (#1309)
- Handler config and request are passed via environment variables instead of command-line args, so credentials no longer leak through the process list (#1298)
- Egress now fails instead of transparently succeeding when it is disconnected from a room and cannot reconnect; media recorded up to that point is still uploaded (#1270)
- Recover appsrc from a stranded flushing state with flush start/stop events instead of failing the egress (#1305, #1312)
- Handler counters and histograms drop the per-egress `egress_id` label and are merged in the service, so metrics from handlers that die uncleanly are still accounted for without phantom counter resets (#1269)
- Exit silently on duplicate-identity disconnect instead of uploading a partial recording (#1251)
- Restore `livekitwebrtcsrc`/`livekitwebrtcsink` in GStreamer images and support image revision tags (#1290)
- Raise the PulseAudio open-file limit to a sensible value (#1276)
- Don't log user-initiated room deletion as a warning (#1302)

### Fixed
- Fix appsrc state regression when source bins are added during pipeline startup — one of the main causes of "pipeline frozen" errors (#1293)
- Fix silent upload failures orphaning HLS segments on disk when no backup storage is configured (#1284)
- Fix panic when a track is closed during start-gate priming (#1285)
- Fix nil-deref race on the SDK source room during disconnect (#1282)
- Fix RTMP fast-fail logic depending on peer ack behavior, which could incorrectly fail long-running healthy streams on their first disconnect (#1244)
- Don't leak goroutines when handler launch fails (#1291)
- Retry web egresses on ERR_CONNECTION_CLOSED page load errors (#1263)
- Fix double-unref of pads retrieved via GetStaticPad (#1261)
- Fix truncated stack traces in panic logs (#1281)
- Fix error shadowing that returned empty 200 responses from the debug dump endpoint on oversized dumps (#1292)
- Fix isReplay (#1243)
- Fix Azure storage locations (#1241)

### Dependencies
- Update google.golang.org/grpc to v1.82.1 (GHSA-hrxh-6v49-42gf) (#1310)
- Update server-sdk-go — cross-region failover fixes, replace retracted DTLS version (#1278)
- Update livekit/protocol and related LiveKit modules (#1245)
- Update Azure SDK (#1242)

Syncs main with the v1.14.0 release (tagged at 8cb751d on release/v1.14.0, cut from 1956613).
