### PR TITLE
Raise minimum image upload queue capacity to absorb frame bursts

### DIFF
--- a/pkg/pipeline/sink/image.go
+++ b/pkg/pipeline/sink/image.go
@@ -54,6 +54,18 @@ type imageUpdate struct {
 	filename  string
 }
 
+// covers frame bursts that outpace the capture interval: videorate's
+// skip-to-first plus the first rate-aligned frame at startup, and the EOS flush
+const minPendingUploads = 4
+
+func imageQueueCapacity(maxUploadQueue int, captureInterval uint32) int {
+	capacity := (maxUploadQueue * 60) / int(captureInterval)
+	if capacity < minPendingUploads {
+		capacity = minPendingUploads
+	}
+	return capacity
+}
+
 func newImageSink(
 	p *gstreamer.Pipeline,
 	conf *config.PipelineConfig,
@@ -74,10 +86,6 @@ func newImageSink(
 		return nil, err
 	}
 
-	maxPendingUploads := (conf.MaxUploadQueue * 60) / int(o.CaptureInterval)
-	if maxPendingUploads < 1 {
-		maxPendingUploads = 1
-	}
 	return &ImageSink{
 		base: &base{
 			bin: imageBin,
@@ -88,7 +96,7 @@ func newImageSink(
 
 		conf:          conf,
 		callbacks:     callbacks,
-		createdImages: make(chan *imageUpdate, maxPendingUploads),
+		createdImages: make(chan *imageUpdate, imageQueueCapacity(conf.MaxUploadQueue, o.CaptureInterval)),
 	}, nil
 }
 

--- a/pkg/pipeline/sink/image.go
+++ b/pkg/pipeline/sink/image.go
@@ -59,11 +59,7 @@ type imageUpdate struct {
 const minPendingUploads = 4
 
 func imageQueueCapacity(maxUploadQueue int, captureInterval uint32) int {
-	capacity := (maxUploadQueue * 60) / int(captureInterval)
-	if capacity < minPendingUploads {
-		capacity = minPendingUploads
-	}
-	return capacity
+	return max((maxUploadQueue*60)/int(captureInterval), minPendingUploads)
 }
 
 func newImageSink(

--- a/pkg/pipeline/sink/image_test.go
+++ b/pkg/pipeline/sink/image_test.go
@@ -162,3 +162,13 @@ func TestImageSinkCloseDrainsPendingUploads(t *testing.T) {
 	default:
 	}
 }
+
+// Regression: a capture interval of exactly 3600s used to yield a single-slot
+// queue, which the startup frame burst overflows, failing the egress.
+func TestImageQueueCapacity(t *testing.T) {
+	require.Equal(t, 360, imageQueueCapacity(60, 10))
+	require.Equal(t, 60, imageQueueCapacity(60, 60))
+	require.Equal(t, minPendingUploads, imageQueueCapacity(60, 3600))
+	require.Equal(t, minPendingUploads, imageQueueCapacity(60, 7200))
+	require.Equal(t, minPendingUploads, imageQueueCapacity(0, 10))
+}

--- a/pkg/pipeline/sink/image_test.go
+++ b/pkg/pipeline/sink/image_test.go
@@ -163,8 +163,8 @@ func TestImageSinkCloseDrainsPendingUploads(t *testing.T) {
 	}
 }
 
-// Regression: a capture interval of exactly 3600s used to yield a single-slot
-// queue, which the startup frame burst overflows, failing the egress.
+// a capture interval of 3600s or more must not yield a queue too small to
+// absorb the startup frame burst
 func TestImageQueueCapacity(t *testing.T) {
 	require.Equal(t, 360, imageQueueCapacity(60, 10))
 	require.Equal(t, 60, imageQueueCapacity(60, 60))


### PR DESCRIPTION
Follow-up to #1336, which made `ImageSink.NewImage` a non-blocking send that fails the egress when the upload queue is full. The queue capacity is computed as `max_upload_queue * 60 / capture_interval`, so a capture interval of 3600s or longer yields at most one slot. That single slot is overflowed by a normal startup frame burst — `videorate`'s skip-to-first frame and the first rate-aligned frame arrive back-to-back while the first upload is still in flight — and the egress fails immediately with `image upload queue full (1 pending)`. Caught on a real hourly-snapshot egress right after #1336 rolled out.

The capacity computation moves into `imageQueueCapacity` with a floor of `minPendingUploads = 4`: enough for every burst source we can name (startup burst, EOS flush) with margin, while a full queue still means a genuine multi-interval upload backlog. Queue slots are two-field structs, so the floor costs nothing. Includes a regression test pinning the 3600s case and the formula boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)