### PR TITLE
Disable B-frames for RTMP and SRT outputs

### DIFF
--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -619,6 +619,15 @@ func (b *VideoBin) addEncoder() error {
 			return errors.ErrGstPipelineError(err)
 		}
 
+		if sc := b.conf.GetStreamConfig(); sc != nil {
+			switch sc.OutputType {
+			case types.OutputTypeRTMP, types.OutputTypeSRT:
+				if err = x264Enc.SetProperty("bframes", uint(0)); err != nil {
+					return errors.ErrGstPipelineError(err)
+				}
+			}
+		}
+
 		if sc := b.conf.GetStreamConfig(); sc != nil && sc.OutputType == types.OutputTypeRTMP {
 			options = append(options, "nal-hrd=cbr")
 		}


### PR DESCRIPTION
## Summary

Disable B-frames in the x264 encoder when an RTMP or SRT stream output is configured.

## Motivation

B-frames introduce frame reordering and additional latency, and may cause compatibility issues with some real-time streaming destinations.

## Behavior

- RTMP and SRT outputs explicitly use `bframes=0`.
- File-only and segment-only pipelines retain the existing encoder configuration.
- When stream and file or segment outputs are combined, they share the same H.264 encoder, so B-frames are disabled for all encoded outputs in that pipeline.

## Testing

- `gofmt` completed successfully.
- `git diff --check` passed.
- Full Go tests were not run locally because the GStreamer development environment and `pkg-config` are unavailable.