### PR TITLE
Bound websocket sink writes with a write deadline

### DIFF
--- a/pkg/pipeline/sink/websocket.go
+++ b/pkg/pipeline/sink/websocket.go
@@ -36,7 +36,14 @@ import (
 	"github.com/livekit/psrpc"
 )
 
-const pingPeriod = time.Second * 30
+const (
+	pingPeriod = time.Second * 30
+
+	// writeTimeout bounds every websocket write; without it, a consumer that
+	// stops reading blocks the appsink callback and samples accumulate in the
+	// unbounded appsink queue for as long as the connection stays up.
+	writeTimeout = time.Second * 30
+)
 
 type WebsocketSink struct {
 	*base
@@ -125,7 +132,7 @@ func (s *WebsocketSink) Start() error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
-		_ = s.conn.WriteMessage(websocket.PongMessage, []byte("pong"))
+		_ = s.writeMessageLocked(websocket.PongMessage, []byte("pong"))
 		return nil
 	})
 
@@ -166,7 +173,7 @@ func (s *WebsocketSink) Start() error {
 				s.mu.Unlock()
 				return
 			}
-			_ = s.conn.WriteMessage(websocket.PingMessage, []byte("ping"))
+			_ = s.writeMessageLocked(websocket.PingMessage, []byte("ping"))
 			s.mu.Unlock()
 		}
 	}()
@@ -181,7 +188,15 @@ func (s *WebsocketSink) Write(p []byte) (int, error) {
 		return 0, io.EOF
 	}
 
-	return len(p), s.conn.WriteMessage(websocket.BinaryMessage, p)
+	return len(p), s.writeMessageLocked(websocket.BinaryMessage, p)
+}
+
+// writeMessageLocked writes with writeTimeout as the deadline. s.mu must be held.
+func (s *WebsocketSink) writeMessageLocked(messageType int, data []byte) error {
+	if err := s.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		return err
+	}
+	return s.conn.WriteMessage(messageType, data)
 }
 
 func (s *WebsocketSink) OnTrackMuted(_ string) {
@@ -214,7 +229,7 @@ func (s *WebsocketSink) writeMutedMessage(muted bool) error {
 		return nil
 	}
 
-	return s.conn.WriteMessage(websocket.TextMessage, data)
+	return s.writeMessageLocked(websocket.TextMessage, data)
 }
 
 func (s *WebsocketSink) UploadManifest(_ string) (string, bool, error) {
@@ -230,7 +245,7 @@ func (s *WebsocketSink) Close() error {
 		logger.Debugw("closing websocket connection")
 
 		// write close message for graceful disconnection
-		_ = s.conn.WriteMessage(websocket.CloseMessage, nil)
+		_ = s.writeMessageLocked(websocket.CloseMessage, nil)
 
 		// terminate connection and close the `closed` channel
 		_ = s.conn.Close()


### PR DESCRIPTION
## Motivation

A websocket track egress whose consumer stops reading currently buffers unboundedly instead of failing:

- `WebsocketSink.Write` calls `conn.WriteMessage` with no deadline from inside the appsink `NewSampleFunc` callback, so a stalled TCP peer blocks the callback indefinitely.
- ~The appsink is created without a `max-buffers` bound (`builder.BuildWebsocketBin`), so while the callback is blocked, every incoming sample queues in the appsink.~
- The ping goroutine's `WriteMessage` can block on the same stalled connection **while holding the sink mutex**, and `Close` can block writing the close message — so even shutdown stalls.

Observed in production — a 3h05m websocket audio stream to a consumer behind a CDN that read slowly and eventually reset. Peak egress memory reached **2.48 GB** — consistent with hours of raw PCM at ~190 KB/s accumulating in the appsink queue — before the peer's RST finally failed the egress with `write: broken pipe`.

## Changes

All websocket writes (samples, ping, pong, mute/unmute text, close) go through a `writeMessageLocked` helper that sets a **30s write deadline** before each write. A consumer that stops reading for 30s now fails the sample write, which propagates through the existing `NewSampleFunc` error path as a destination error (`psrpc.Unavailable`) and ends the egress — bounding worst-case buffering to ~30s of media (a few MB for audio) instead of hours.

30s is deliberately generous: it only triggers when the peer has accepted no TCP data at all for the full window, i.e. the consumer is effectively gone — transient slow reads that drain within the window are unaffected (a live stream 30s behind real time is already unrecoverable for the reader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)