### PR TITLE
Adding support for setting max number of encoder threads

### DIFF
--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -64,6 +64,7 @@ type BaseConfig struct {
 	ChromeFlags                   map[string]interface{}              `yaml:"chrome_flags"`                       // additional flags to pass to Chrome
 	Latency                       LatencyConfig                       `yaml:"latency"`                            // gstreamer latencies, modifying these may break the service
 	LatencyOverrides              map[types.RequestType]LatencyConfig `yaml:"latency_overrides"`                  // latency overrides for different request types, experimental only, will be removed
+	VideoEncoderThreads           uint                                `yaml:"video_encoder_threads"`              // x264enc thread count, 0 = x264 auto (1.5x host cores)
 	EnableOneShotSenderReportSync bool                                `yaml:"enable_one_shot_sender_report_sync"` // temporary rollout flag enabling one-shot sender report correction for room composite / track requests that previously used audio PTS adjustment disabling
 	EnableSyncEngine              bool                                `yaml:"enable_sync_engine"`                 // use Chrome-inspired sync engine for improved cross-participant alignment and A/V sync
 	AudioTempoController          AudioTempoController                `yaml:"audio_tempo_controller"`             // audio tempo controller

--- a/pkg/pipeline/builder/video.go
+++ b/pkg/pipeline/builder/video.go
@@ -586,6 +586,12 @@ func (b *VideoBin) addEncoder() error {
 
 		x264Enc.SetArg("speed-preset", "veryfast")
 
+		if b.conf.VideoEncoderThreads > 0 {
+			if err = x264Enc.SetProperty("threads", b.conf.VideoEncoderThreads); err != nil {
+				return errors.ErrGstPipelineError(err)
+			}
+		}
+
 		var options []string
 		disabledSceneCut := false
 		// Streaming outputs always set KeyFrameInterval, so this effectively disables scenecut for RTMP/SRT.


### PR DESCRIPTION
Number of encoder threads for x264enc influences both latency and throughput - more threads higher throughput but also higher latency. If left unset - gstreamer will use num cpu cores x 1.5 - and that could increase depending on the machine spec where egress runs. That could result in high number of threads and video latency increase to an extent that min video latency exceeds max audio latency which results in a pipeline error.

The change adds an advanced config option to set number of x264 encoder threads through the configuration. The same clamping could also be applied to vp8 and vp9 decoders but that's not latency critical and will come in subsequent PRs.