### PR TITLE
Fixing another memory leak source for web stream

### DIFF
--- a/pkg/pipeline/sink/websocket.go
+++ b/pkg/pipeline/sink/websocket.go
@@ -92,6 +92,7 @@ func newWebsocketSink(
 
 			// map the buffer to READ operation
 			samples := buffer.Map(gst.MapRead).Bytes()
+			defer buffer.Unmap()
 
 			// send to writer
 			_, err = websocketSink.Write(samples)


### PR DESCRIPTION
While testing previous websocket change - I have noticed that the memory consumption still keeps increasing. It ended up that a buffer unmap call was missing on a buffer after performing the Map operation. Unrefing the buffer isn't enough - C contract requires explicit unmapping if mapped. With this fix - long running test sessions were leak free.