### PR TITLE
construct the psrpc servers with observability

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -114,7 +114,7 @@ func NewServer(conf *config.ServiceConfig, bus psrpc.MessageBus, ioClient info.S
 		return nil, err
 	}
 
-	psrpcServer, err := rpc.NewEgressInternalServer(s, bus)
+	psrpcServer, err := rpc.NewEgressInternalServer(s, bus, rpc.WithServerObservability(logger.GetLogger()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/handler_proxy.go
+++ b/pkg/service/handler_proxy.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
 	"github.com/livekit/psrpc"
 )
@@ -34,7 +35,7 @@ type HandlerRPCProxy struct {
 
 func NewHandlerRPCProxy(pm ProcessManager, bus psrpc.MessageBus) (*HandlerRPCProxy, error) {
 	p := &HandlerRPCProxy{pm: pm}
-	server, err := rpc.NewEgressHandlerServer(p, bus)
+	server, err := rpc.NewEgressHandlerServer(p, bus, rpc.WithServerObservability(logger.GetLogger()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

`EgressInternal` (service process) and `EgressHandler` (hosted in the service process by `HandlerRPCProxy`) were constructed with no server options, so they were invisible to everything `rpc.WithServerObservability` carries: psrpc server metrics, claim-outcome observation, and — at protocol ≥ `14f581a` (livekit/protocol#1729) — the process-wide claim-skip election on queue rpcs (livekit/psrpc#122).

Two one-line changes thread it in.

## Effect by deployment

- **Binaries that enable the skip** (LiveKit Cloud's cloud-egress calls `rpc.SetPSRPCServerSkipClaim`, gated on reloadable config): `StopEgress` and `UpdateStream` — both `requireClaim+queue` — get answered with an announcement instead of the claim round trip. This was the last uncovered claim traffic in that process.
- **Deployments that never call the setter** (OSS default): behavior unchanged except these two servers now emit server metrics and claim-outcome observations, which they were silently missing.

The option resolves against whatever protocol version the consuming binary pins, so this repo's own protocol pin does not need to move.

## Verification

- `gofmt` clean; verified at this repo's pinned protocol (`v1.50.5-0.20260815071601`) that both generated constructors accept variadic `psrpc.ServerOption` and `WithServerObservability` has the used signature.
- This machine has no GStreamer, so no package in this repo compiles locally — the cgo dependency fails before these files build. CI is the real check; flagging that plainly rather than claiming a green local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)