### PR TITLE
Send EOS for every appsrc linked into the pipeline (CS-1547)

### DIFF
--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -489,6 +489,15 @@ func (c *Controller) trackStreamRetry(ctx context.Context, stream *config.Stream
 }
 
 func (c *Controller) onEOSSent() {
+	// A track ending mid-build reaches this before BuildPipeline() assigns c.p:
+	// reading it would panic and would race with that write. BuildReady closes
+	// once c.p is set, so an open channel means there is no pipeline to stop.
+	select {
+	case <-c.callbacks.BuildReady:
+	default:
+		return
+	}
+
 	// for video-only track/track composite, EOS might have already
 	// made it through the pipeline by the time endRecording is closed
 	if (c.Passthrough || c.RequestType == types.RequestTypeTrackComposite) && !c.AudioEnabled {

--- a/pkg/pipeline/controller_test.go
+++ b/pkg/pipeline/controller_test.go
@@ -171,7 +171,7 @@ func TestUnsolicitedEOSBeforeSendEOS(t *testing.T) {
 
 // TestOnEOSSentBeforePipelineBuilt: a writer whose track EOFs during the build
 // phase reaches onEOSSent() before BuildPipeline() has assigned c.p. It must
-// neither dereference the pipeline nor start the EOS sequence (CS-1547).
+// neither dereference the pipeline nor start the EOS sequence.
 //
 // The config is the one combination that makes onEOSSent() forward to SendEOS():
 // passthrough / track composite with no audio.

--- a/pkg/pipeline/controller_test.go
+++ b/pkg/pipeline/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/livekit/egress/pkg/gstreamer"
 	"github.com/livekit/egress/pkg/ipc"
 	"github.com/livekit/egress/pkg/pipeline/source"
+	"github.com/livekit/egress/pkg/types"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/rpc"
 )
@@ -165,4 +167,28 @@ func TestUnsolicitedEOSBeforeSendEOS(t *testing.T) {
 	if stat.Size() == 0 {
 		t.Fatal("output file is empty")
 	}
+}
+
+// TestOnEOSSentBeforePipelineBuilt: a writer whose track EOFs during the build
+// phase reaches onEOSSent() before BuildPipeline() has assigned c.p. It must
+// neither dereference the pipeline nor start the EOS sequence (CS-1547).
+//
+// The config is the one combination that makes onEOSSent() forward to SendEOS():
+// passthrough / track composite with no audio.
+func TestOnEOSSentBeforePipelineBuilt(t *testing.T) {
+	c := &Controller{
+		PipelineConfig: &config.PipelineConfig{
+			RequestType: types.RequestTypeTrackComposite,
+			Passthrough: true,
+			AudioConfig: config.AudioConfig{AudioEnabled: false},
+		},
+		// BuildReady still open and p still nil: the pipeline is mid-build
+		callbacks: &gstreamer.Callbacks{BuildReady: make(chan struct{})},
+	}
+
+	require.NotPanics(t, c.onEOSSent,
+		"cleanup running during the build phase must not dereference the pipeline")
+	require.False(t, c.eosSent.IsBroken(),
+		"onEOSSent must not start the EOS sequence before the pipeline exists")
+	require.Nil(t, c.p, "sanity: the test covers the pre-build window")
 }

--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -273,7 +273,7 @@ func (w *AppWriter) start() {
 	if w.shouldSendEOS() {
 		if !w.playing.IsBroken() {
 			// Linked into the pipeline but never reported PLAYING: the CloseWriters
-			// race (CS-1547). Expect this to be rare and confined to shutdown.
+			// race. Expect this to be rare and confined to shutdown.
 			w.logger.Warnw("appsrc never reported PLAYING, sending EOS anyway", nil,
 				"active", w.active.Load(),
 				"draining", w.draining.IsBroken(),
@@ -693,7 +693,7 @@ func (w *AppWriter) MarkAddedToPipeline() {
 //
 // The test is whether the appsrc is linked into the pipeline, not whether it was
 // reported PLAYING: once CloseWriters() sets closing that notification is dropped,
-// while the pipeline still waits on the pad (CS-1547).
+// while the pipeline still waits on the pad.
 func (w *AppWriter) shouldSendEOS() bool {
 	return w.addedToPipeline.IsBroken()
 }

--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -104,6 +104,7 @@ type AppWriter struct {
 	lastReceived             atomic.Time
 	lastPushed               atomic.Time
 	playing                  core.Fuse
+	addedToPipeline          core.Fuse
 	draining                 core.Fuse
 	unsubscribed             core.Fuse
 	endStreamSignaled        core.Fuse
@@ -260,6 +261,7 @@ func (w *AppWriter) start() {
 		w.logger.Errorw("endStreamProcessed not broken after 3 seconds, bug in the draining logic!", nil,
 			"endStreamSourceProcessed", w.endStreamSourceProcessed.IsBroken(),
 			"playing", w.playing.IsBroken(),
+			"addedToPipeline", w.addedToPipeline.IsBroken(),
 			"active", w.active.Load(),
 			"lastReceived", w.lastReceived.Load(),
 			"lastPushed", w.lastPushed.Load(),
@@ -268,7 +270,17 @@ func (w *AppWriter) start() {
 	}
 
 	// clean up
-	if w.playing.IsBroken() {
+	if w.shouldSendEOS() {
+		if !w.playing.IsBroken() {
+			// Linked into the pipeline but never reported PLAYING: the CloseWriters
+			// race (CS-1547). Expect this to be rare and confined to shutdown.
+			w.logger.Warnw("appsrc never reported PLAYING, sending EOS anyway", nil,
+				"active", w.active.Load(),
+				"draining", w.draining.IsBroken(),
+				"unsubscribed", w.unsubscribed.IsBroken(),
+				"lastReceived", w.lastReceived.Load(),
+			)
+		}
 		w.callbacks.OnEOSSent()
 		flow := w.src.EndStream()
 		if flow == gst.FlowFlushing {
@@ -665,7 +677,25 @@ func (w *AppWriter) maybeCheckPipelineLag(pts time.Duration) {
 }
 
 func (w *AppWriter) Playing() {
+	// Reaching PLAYING implies the appsrc is linked. handleSubscribe normally
+	// marks it first; this keeps the invariant if a marking call is ever missed.
+	w.addedToPipeline.Break()
 	w.playing.Break()
+}
+
+// MarkAddedToPipeline signals that the appsrc is linked into the pipeline, which
+// blocks EOS aggregation on this writer until it ends its stream.
+func (w *AppWriter) MarkAddedToPipeline() {
+	w.addedToPipeline.Break()
+}
+
+// shouldSendEOS reports whether cleanup must push EOS into this writer's appsrc.
+//
+// The test is whether the appsrc is linked into the pipeline, not whether it was
+// reported PLAYING: once CloseWriters() sets closing that notification is dropped,
+// while the pipeline still waits on the pad (CS-1547).
+func (w *AppWriter) shouldSendEOS() bool {
+	return w.addedToPipeline.IsBroken()
 }
 
 // Drain blocks until finished

--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -272,8 +272,8 @@ func (w *AppWriter) start() {
 	// clean up
 	if w.shouldSendEOS() {
 		if !w.playing.IsBroken() {
-			// Linked into the pipeline but never reported PLAYING: the CloseWriters
-			// race. Expect this to be rare and confined to shutdown.
+			// Linked into the pipeline but never reported PLAYING. Expect this to be
+			// rare and confined to shutdown.
 			w.logger.Warnw("appsrc never reported PLAYING, sending EOS anyway", nil,
 				"active", w.active.Load(),
 				"draining", w.draining.IsBroken(),
@@ -677,23 +677,20 @@ func (w *AppWriter) maybeCheckPipelineLag(pts time.Duration) {
 }
 
 func (w *AppWriter) Playing() {
-	// Reaching PLAYING implies the appsrc is linked. handleSubscribe normally
-	// marks it first; this keeps the invariant if a marking call is ever missed.
+	// Reaching PLAYING implies the appsrc is linked.
 	w.addedToPipeline.Break()
 	w.playing.Break()
 }
 
-// MarkAddedToPipeline signals that the appsrc is linked into the pipeline, which
-// blocks EOS aggregation on this writer until it ends its stream.
 func (w *AppWriter) MarkAddedToPipeline() {
 	w.addedToPipeline.Break()
 }
 
 // shouldSendEOS reports whether cleanup must push EOS into this writer's appsrc.
 //
-// The test is whether the appsrc is linked into the pipeline, not whether it was
-// reported PLAYING: once CloseWriters() sets closing that notification is dropped,
-// while the pipeline still waits on the pad.
+// The test is whether the pipeline links the appsrc, not whether it was reported
+// PLAYING: that notification is not delivered during shutdown, while the pipeline
+// still waits on the pad.
 func (w *AppWriter) shouldSendEOS() bool {
 	return w.addedToPipeline.IsBroken()
 }

--- a/pkg/pipeline/source/sdk/appwriter_test.go
+++ b/pkg/pipeline/source/sdk/appwriter_test.go
@@ -16,16 +16,13 @@ package sdk
 
 import (
 	"testing"
-	"time"
 
-	"github.com/go-gst/go-gst/gst"
-	"github.com/go-gst/go-gst/gst/app"
 	"github.com/stretchr/testify/require"
 )
 
 // TestShouldSendEOS pins the cleanup decision in AppWriter.start(): EOS is owed
 // by any appsrc linked into the pipeline, reported PLAYING or not. The two differ
-// during shutdown, when the notification is dropped (CS-1547).
+// during shutdown, when the PLAYING notification is dropped.
 func TestShouldSendEOS(t *testing.T) {
 	t.Run("never added to the pipeline", func(t *testing.T) {
 		w := &AppWriter{}
@@ -38,11 +35,10 @@ func TestShouldSendEOS(t *testing.T) {
 		w := &AppWriter{}
 		w.MarkAddedToPipeline()
 
-		require.False(t, w.playing.IsBroken(),
-			"precondition: this is the race - the PLAYING notification was dropped")
+		require.False(t, w.playing.IsBroken(), "precondition: the notification was dropped")
 		require.True(t, w.shouldSendEOS(),
-			"CS-1547: the appsrc is linked into the pipeline, so cleanup must send EOS "+
-				"even though we were never told it reached PLAYING")
+			"the appsrc is linked into the pipeline, so cleanup must send EOS even "+
+				"though it was never reported PLAYING")
 
 		// this state is what AppWriter.start() logs as
 		// "appsrc never reported PLAYING, sending EOS anyway"
@@ -54,177 +50,6 @@ func TestShouldSendEOS(t *testing.T) {
 
 		require.True(t, w.addedToPipeline.IsBroken(),
 			"an appsrc cannot reach PLAYING without being linked into the pipeline")
-		require.True(t, w.shouldSendEOS(),
-			"the normal path must keep sending EOS exactly as before")
+		require.True(t, w.shouldSendEOS(), "the normal path must still send EOS")
 	})
-}
-
-const (
-	testAudioCaps     = "audio/x-raw,format=S16LE,layout=interleaved,rate=48000,channels=1"
-	testFrameSize     = 1920 // 20ms of 48kHz mono S16LE
-	testFrameDuration = 20 * time.Millisecond
-	eosWaitTimeout    = 5 * time.Second
-)
-
-type mixerTestPipeline struct {
-	pipeline *gst.Pipeline
-	mixer    *gst.Element
-}
-
-func newMixerTestPipeline(t *testing.T) *mixerTestPipeline {
-	t.Helper()
-	gst.Init(nil)
-
-	pipeline, err := gst.NewPipeline("cs-1547")
-	require.NoError(t, err)
-
-	mixer, err := gst.NewElement("audiomixer")
-	require.NoError(t, err)
-	sink, err := gst.NewElement("fakesink")
-	require.NoError(t, err)
-	require.NoError(t, sink.SetProperty("sync", false))
-
-	require.NoError(t, pipeline.AddMany(mixer, sink))
-	require.NoError(t, mixer.Link(sink))
-
-	p := &mixerTestPipeline{pipeline: pipeline, mixer: mixer}
-	t.Cleanup(func() { _ = pipeline.SetState(gst.StateNull) })
-	return p
-}
-
-// addTrack links a new appsrc into the pipeline, exactly like OnTrackAdded().
-func (p *mixerTestPipeline) addTrack(t *testing.T, name string) *app.Source {
-	t.Helper()
-
-	elem, err := gst.NewElementWithName("appsrc", "app_"+name)
-	require.NoError(t, err)
-	conv, err := gst.NewElement("audioconvert")
-	require.NoError(t, err)
-
-	src := app.SrcFromElement(elem)
-	src.SetCaps(gst.NewCapsFromString(testAudioCaps))
-	src.SetArg("format", "time")
-	require.NoError(t, elem.SetProperty("is-live", false))
-
-	require.NoError(t, p.pipeline.AddMany(elem, conv))
-	require.NoError(t, gst.ElementLinkMany(elem, conv, p.mixer))
-
-	// dynamic add: bring the new branch up to the pipeline's state
-	require.True(t, elem.SyncStateWithParent())
-	require.True(t, conv.SyncStateWithParent())
-
-	return src
-}
-
-func pushSilence(t *testing.T, src *app.Source, frames int, startPTS time.Duration) time.Duration {
-	t.Helper()
-
-	pts := startPTS
-	silence := make([]byte, testFrameSize)
-	for i := 0; i < frames; i++ {
-		b := gst.NewBufferFromBytes(silence)
-		b.SetPresentationTimestamp(gst.ClockTime(uint64(pts)))
-		b.SetDuration(gst.ClockTime(uint64(testFrameDuration)))
-		require.Equal(t, gst.FlowOK, src.PushBuffer(b))
-		pts += testFrameDuration
-	}
-	return pts
-}
-
-// waitForEOS returns true if the pipeline reached EOS within eosWaitTimeout.
-func (p *mixerTestPipeline) waitForEOS(t *testing.T) bool {
-	t.Helper()
-
-	bus := p.pipeline.GetPipelineBus()
-	deadline := time.Now().Add(eosWaitTimeout)
-	for time.Now().Before(deadline) {
-		msg := bus.TimedPopFiltered(gst.ClockTime(uint64(500*time.Millisecond)), gst.MessageEOS|gst.MessageError)
-		if msg == nil {
-			continue
-		}
-		switch msg.Type() {
-		case gst.MessageEOS:
-			return true
-		case gst.MessageError:
-			t.Fatalf("pipeline error: %s", msg.String())
-		}
-	}
-	return false
-}
-
-// TestMissingEOSFreezesPipeline: an appsrc linked into the mixer that never sends
-// EOS blocks EOS aggregation, and shutdown hangs.
-func TestMissingEOSFreezesPipeline(t *testing.T) {
-	p := newMixerTestPipeline(t)
-
-	srcA := p.addTrack(t, "A")
-	require.NoError(t, p.pipeline.SetState(gst.StatePlaying))
-	pts := pushSilence(t, srcA, 10, 0)
-
-	// a late subscription: the appsrc is linked into the running pipeline
-	srcB := p.addTrack(t, "B")
-	pushSilence(t, srcB, 2, pts)
-
-	// shutdown: A sends EOS, B never does
-	require.Equal(t, gst.FlowOK, srcA.EndStream())
-
-	require.False(t, p.waitForEOS(t),
-		"CS-1547: expected the pipeline to hang - it should NOT reach EOS while app_B never sent EOS")
-}
-
-// TestEOSFromAllWritersCompletes is the control: with EndStream() on every linked
-// appsrc, EOS propagates immediately.
-func TestEOSFromAllWritersCompletes(t *testing.T) {
-	p := newMixerTestPipeline(t)
-
-	srcA := p.addTrack(t, "A")
-	require.NoError(t, p.pipeline.SetState(gst.StatePlaying))
-	pts := pushSilence(t, srcA, 10, 0)
-
-	srcB := p.addTrack(t, "B")
-	pushSilence(t, srcB, 2, pts)
-
-	require.Equal(t, gst.FlowOK, srcA.EndStream())
-	require.Equal(t, gst.FlowOK, srcB.EndStream())
-
-	require.True(t, p.waitForEOS(t), "pipeline should reach EOS once every appsrc sent EOS")
-}
-
-// TestEOSFromNotYetPlayingAppsrc: an appsrc that is linked and started, but not
-// yet reported PLAYING, still delivers EOS to the mixer. AddSourceBin calls
-// SyncStateWithParent, so this is the state a track added during shutdown is in.
-//
-// An appsrc left in NULL behaves differently: EndStream() returns FlowOK but
-// nothing propagates and the pipeline hangs. Linking a bin without syncing its
-// state would need more than EOS to shut down cleanly.
-func TestEOSFromNotYetPlayingAppsrc(t *testing.T) {
-	p := newMixerTestPipeline(t)
-
-	srcA := p.addTrack(t, "A")
-	require.NoError(t, p.pipeline.SetState(gst.StatePlaying))
-	pts := pushSilence(t, srcA, 10, 0)
-
-	// linked and started, but only as far as PAUSED
-	elem, err := gst.NewElementWithName("appsrc", "app_B")
-	require.NoError(t, err)
-	conv, err := gst.NewElement("audioconvert")
-	require.NoError(t, err)
-
-	srcB := app.SrcFromElement(elem)
-	srcB.SetCaps(gst.NewCapsFromString(testAudioCaps))
-	srcB.SetArg("format", "time")
-	require.NoError(t, elem.SetProperty("is-live", false))
-	require.NoError(t, p.pipeline.AddMany(elem, conv))
-	require.NoError(t, gst.ElementLinkMany(elem, conv, p.mixer))
-	require.NoError(t, elem.SetState(gst.StatePaused))
-	require.NoError(t, conv.SetState(gst.StatePaused))
-	require.Equal(t, gst.StatePaused, elem.GetCurrentState(), "precondition: never reported PLAYING")
-
-	pushSilence(t, srcB, 2, pts)
-	require.Equal(t, gst.FlowOK, srcA.EndStream())
-	require.Equal(t, gst.FlowOK, srcB.EndStream())
-
-	require.True(t, p.waitForEOS(t),
-		"EOS from a linked-but-not-yet-PLAYING appsrc must still complete the pipeline - "+
-			"this is what makes addedToPipeline a valid guard")
 }

--- a/pkg/pipeline/source/sdk/appwriter_test.go
+++ b/pkg/pipeline/source/sdk/appwriter_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-gst/go-gst/gst"
+	"github.com/go-gst/go-gst/gst/app"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShouldSendEOS pins the cleanup decision in AppWriter.start(): EOS is owed
+// by any appsrc linked into the pipeline, reported PLAYING or not. The two differ
+// during shutdown, when the notification is dropped (CS-1547).
+func TestShouldSendEOS(t *testing.T) {
+	t.Run("never added to the pipeline", func(t *testing.T) {
+		w := &AppWriter{}
+
+		require.False(t, w.shouldSendEOS(),
+			"no appsrc in the pipeline means nothing downstream is waiting for EOS")
+	})
+
+	t.Run("added to the pipeline but PLAYING never delivered", func(t *testing.T) {
+		w := &AppWriter{}
+		w.MarkAddedToPipeline()
+
+		require.False(t, w.playing.IsBroken(),
+			"precondition: this is the race - the PLAYING notification was dropped")
+		require.True(t, w.shouldSendEOS(),
+			"CS-1547: the appsrc is linked into the pipeline, so cleanup must send EOS "+
+				"even though we were never told it reached PLAYING")
+
+		// this state is what AppWriter.start() logs as
+		// "appsrc never reported PLAYING, sending EOS anyway"
+	})
+
+	t.Run("PLAYING implies added to the pipeline", func(t *testing.T) {
+		w := &AppWriter{}
+		w.Playing()
+
+		require.True(t, w.addedToPipeline.IsBroken(),
+			"an appsrc cannot reach PLAYING without being linked into the pipeline")
+		require.True(t, w.shouldSendEOS(),
+			"the normal path must keep sending EOS exactly as before")
+	})
+}
+
+const (
+	testAudioCaps     = "audio/x-raw,format=S16LE,layout=interleaved,rate=48000,channels=1"
+	testFrameSize     = 1920 // 20ms of 48kHz mono S16LE
+	testFrameDuration = 20 * time.Millisecond
+	eosWaitTimeout    = 5 * time.Second
+)
+
+type mixerTestPipeline struct {
+	pipeline *gst.Pipeline
+	mixer    *gst.Element
+}
+
+func newMixerTestPipeline(t *testing.T) *mixerTestPipeline {
+	t.Helper()
+	gst.Init(nil)
+
+	pipeline, err := gst.NewPipeline("cs-1547")
+	require.NoError(t, err)
+
+	mixer, err := gst.NewElement("audiomixer")
+	require.NoError(t, err)
+	sink, err := gst.NewElement("fakesink")
+	require.NoError(t, err)
+	require.NoError(t, sink.SetProperty("sync", false))
+
+	require.NoError(t, pipeline.AddMany(mixer, sink))
+	require.NoError(t, mixer.Link(sink))
+
+	p := &mixerTestPipeline{pipeline: pipeline, mixer: mixer}
+	t.Cleanup(func() { _ = pipeline.SetState(gst.StateNull) })
+	return p
+}
+
+// addTrack links a new appsrc into the pipeline, exactly like OnTrackAdded().
+func (p *mixerTestPipeline) addTrack(t *testing.T, name string) *app.Source {
+	t.Helper()
+
+	elem, err := gst.NewElementWithName("appsrc", "app_"+name)
+	require.NoError(t, err)
+	conv, err := gst.NewElement("audioconvert")
+	require.NoError(t, err)
+
+	src := app.SrcFromElement(elem)
+	src.SetCaps(gst.NewCapsFromString(testAudioCaps))
+	src.SetArg("format", "time")
+	require.NoError(t, elem.SetProperty("is-live", false))
+
+	require.NoError(t, p.pipeline.AddMany(elem, conv))
+	require.NoError(t, gst.ElementLinkMany(elem, conv, p.mixer))
+
+	// dynamic add: bring the new branch up to the pipeline's state
+	require.True(t, elem.SyncStateWithParent())
+	require.True(t, conv.SyncStateWithParent())
+
+	return src
+}
+
+func pushSilence(t *testing.T, src *app.Source, frames int, startPTS time.Duration) time.Duration {
+	t.Helper()
+
+	pts := startPTS
+	silence := make([]byte, testFrameSize)
+	for i := 0; i < frames; i++ {
+		b := gst.NewBufferFromBytes(silence)
+		b.SetPresentationTimestamp(gst.ClockTime(uint64(pts)))
+		b.SetDuration(gst.ClockTime(uint64(testFrameDuration)))
+		require.Equal(t, gst.FlowOK, src.PushBuffer(b))
+		pts += testFrameDuration
+	}
+	return pts
+}
+
+// waitForEOS returns true if the pipeline reached EOS within eosWaitTimeout.
+func (p *mixerTestPipeline) waitForEOS(t *testing.T) bool {
+	t.Helper()
+
+	bus := p.pipeline.GetPipelineBus()
+	deadline := time.Now().Add(eosWaitTimeout)
+	for time.Now().Before(deadline) {
+		msg := bus.TimedPopFiltered(gst.ClockTime(uint64(500*time.Millisecond)), gst.MessageEOS|gst.MessageError)
+		if msg == nil {
+			continue
+		}
+		switch msg.Type() {
+		case gst.MessageEOS:
+			return true
+		case gst.MessageError:
+			t.Fatalf("pipeline error: %s", msg.String())
+		}
+	}
+	return false
+}
+
+// TestMissingEOSFreezesPipeline: an appsrc linked into the mixer that never sends
+// EOS blocks EOS aggregation, and shutdown hangs.
+func TestMissingEOSFreezesPipeline(t *testing.T) {
+	p := newMixerTestPipeline(t)
+
+	srcA := p.addTrack(t, "A")
+	require.NoError(t, p.pipeline.SetState(gst.StatePlaying))
+	pts := pushSilence(t, srcA, 10, 0)
+
+	// a late subscription: the appsrc is linked into the running pipeline
+	srcB := p.addTrack(t, "B")
+	pushSilence(t, srcB, 2, pts)
+
+	// shutdown: A sends EOS, B never does
+	require.Equal(t, gst.FlowOK, srcA.EndStream())
+
+	require.False(t, p.waitForEOS(t),
+		"CS-1547: expected the pipeline to hang - it should NOT reach EOS while app_B never sent EOS")
+}
+
+// TestEOSFromAllWritersCompletes is the control: with EndStream() on every linked
+// appsrc, EOS propagates immediately.
+func TestEOSFromAllWritersCompletes(t *testing.T) {
+	p := newMixerTestPipeline(t)
+
+	srcA := p.addTrack(t, "A")
+	require.NoError(t, p.pipeline.SetState(gst.StatePlaying))
+	pts := pushSilence(t, srcA, 10, 0)
+
+	srcB := p.addTrack(t, "B")
+	pushSilence(t, srcB, 2, pts)
+
+	require.Equal(t, gst.FlowOK, srcA.EndStream())
+	require.Equal(t, gst.FlowOK, srcB.EndStream())
+
+	require.True(t, p.waitForEOS(t), "pipeline should reach EOS once every appsrc sent EOS")
+}
+
+// TestEOSFromNotYetPlayingAppsrc: an appsrc that is linked and started, but not
+// yet reported PLAYING, still delivers EOS to the mixer. AddSourceBin calls
+// SyncStateWithParent, so this is the state a track added during shutdown is in.
+//
+// An appsrc left in NULL behaves differently: EndStream() returns FlowOK but
+// nothing propagates and the pipeline hangs. Linking a bin without syncing its
+// state would need more than EOS to shut down cleanly.
+func TestEOSFromNotYetPlayingAppsrc(t *testing.T) {
+	p := newMixerTestPipeline(t)
+
+	srcA := p.addTrack(t, "A")
+	require.NoError(t, p.pipeline.SetState(gst.StatePlaying))
+	pts := pushSilence(t, srcA, 10, 0)
+
+	// linked and started, but only as far as PAUSED
+	elem, err := gst.NewElementWithName("appsrc", "app_B")
+	require.NoError(t, err)
+	conv, err := gst.NewElement("audioconvert")
+	require.NoError(t, err)
+
+	srcB := app.SrcFromElement(elem)
+	srcB.SetCaps(gst.NewCapsFromString(testAudioCaps))
+	srcB.SetArg("format", "time")
+	require.NoError(t, elem.SetProperty("is-live", false))
+	require.NoError(t, p.pipeline.AddMany(elem, conv))
+	require.NoError(t, gst.ElementLinkMany(elem, conv, p.mixer))
+	require.NoError(t, elem.SetState(gst.StatePaused))
+	require.NoError(t, conv.SetState(gst.StatePaused))
+	require.Equal(t, gst.StatePaused, elem.GetCurrentState(), "precondition: never reported PLAYING")
+
+	pushSilence(t, srcB, 2, pts)
+	require.Equal(t, gst.FlowOK, srcA.EndStream())
+	require.Equal(t, gst.FlowOK, srcB.EndStream())
+
+	require.True(t, p.waitForEOS(t),
+		"EOS from a linked-but-not-yet-PLAYING appsrc must still complete the pipeline - "+
+			"this is what makes addedToPipeline a valid guard")
+}

--- a/pkg/pipeline/source/track_worker.go
+++ b/pkg/pipeline/source/track_worker.go
@@ -310,7 +310,22 @@ func (s *SDKSource) handleSubscribe(w *trackWorker, trackID string, state *worke
 	// For post-init subscriptions, notify pipeline to add track
 	if isPostInit {
 		<-s.callbacks.BuildReady
+		// Mark before linking: the writer runs on its own goroutine and must never
+		// find its appsrc in the pipeline without knowing it owes an EOS (CS-1547).
+		writer.MarkAddedToPipeline()
 		s.callbacks.OnTrackAdded(ts)
+	} else {
+		// Tracks present at startup are linked by BuildPipeline(). BuildReady closes
+		// once the pipeline is assigned, so cleanup can never reach a nil pipeline.
+		go func() {
+			select {
+			case <-s.callbacks.BuildReady:
+				writer.MarkAddedToPipeline()
+			case <-writer.Finished():
+				// Ended before the pipeline was built; doCleanup tears down its
+				// source bin, so no EOS is owed.
+			}
+		}()
 	}
 
 	return writer

--- a/pkg/pipeline/source/track_worker.go
+++ b/pkg/pipeline/source/track_worker.go
@@ -307,25 +307,16 @@ func (s *SDKSource) handleSubscribe(w *trackWorker, trackID string, state *worke
 	// Release subLock before transitioning to ACTIVE - we're done with pre-init work
 	s.subLock.RUnlock()
 
+	// The pipeline links this appsrc, either here or during the build, so cleanup
+	// owes it an EOS. Mark before the link rather than after: the writer runs on
+	// its own goroutine, and an EOS sent before the element is linked is still
+	// delivered once the pipeline starts it.
+	writer.MarkAddedToPipeline()
+
 	// For post-init subscriptions, notify pipeline to add track
 	if isPostInit {
 		<-s.callbacks.BuildReady
-		// Mark before linking: the writer runs on its own goroutine and must never
-		// find its appsrc in the pipeline without knowing it owes an EOS.
-		writer.MarkAddedToPipeline()
 		s.callbacks.OnTrackAdded(ts)
-	} else {
-		// Tracks present at startup are linked by BuildPipeline(). BuildReady closes
-		// once the pipeline is assigned, so cleanup can never reach a nil pipeline.
-		go func() {
-			select {
-			case <-s.callbacks.BuildReady:
-				writer.MarkAddedToPipeline()
-			case <-writer.Finished():
-				// Ended before the pipeline was built; doCleanup tears down its
-				// source bin, so no EOS is owed.
-			}
-		}()
 	}
 
 	return writer

--- a/pkg/pipeline/source/track_worker.go
+++ b/pkg/pipeline/source/track_worker.go
@@ -311,7 +311,7 @@ func (s *SDKSource) handleSubscribe(w *trackWorker, trackID string, state *worke
 	if isPostInit {
 		<-s.callbacks.BuildReady
 		// Mark before linking: the writer runs on its own goroutine and must never
-		// find its appsrc in the pipeline without knowing it owes an EOS (CS-1547).
+		// find its appsrc in the pipeline without knowing it owes an EOS.
 		writer.MarkAddedToPipeline()
 		s.callbacks.OnTrackAdded(ts)
 	} else {

--- a/pkg/pipeline/source/track_worker_test.go
+++ b/pkg/pipeline/source/track_worker_test.go
@@ -198,7 +198,7 @@ func contains(ops []OpType, t OpType) bool {
 // TestPlayingLostAfterCloseWriters: once CloseWriters() sets closing, submitOp()
 // drops OpPlaying, so a writer whose appsrc was linked just before shutdown is
 // never told it reached PLAYING. This is why cleanup keys off addedToPipeline
-// rather than playing (CS-1547).
+// rather than playing.
 func TestPlayingLostAfterCloseWriters(t *testing.T) {
 	s := testSDKSource(t)
 	w := newIdleWorker(s, "track-1")

--- a/pkg/pipeline/source/track_worker_test.go
+++ b/pkg/pipeline/source/track_worker_test.go
@@ -186,15 +186,6 @@ func delivered(w *trackWorker) []OpType {
 	}
 }
 
-func contains(ops []OpType, t OpType) bool {
-	for _, op := range ops {
-		if op == t {
-			return true
-		}
-	}
-	return false
-}
-
 // TestPlayingLostAfterCloseWriters: once CloseWriters() sets closing, submitOp()
 // drops OpPlaying, so a writer whose appsrc was linked just before shutdown is
 // never told it reached PLAYING. This is why cleanup keys off addedToPipeline
@@ -210,10 +201,9 @@ func TestPlayingLostAfterCloseWriters(t *testing.T) {
 	s.Playing("track-1")
 
 	ops := delivered(w)
-	require.True(t, contains(ops, OpClose), "worker should have received OpClose, got %v", ops)
-	require.False(t, contains(ops, OpPlaying),
-		"OpPlaying is dropped by submitOp() once closing is set, so writer.Playing() "+
-			"is never called. ops=%v", ops)
+	require.Contains(t, ops, OpClose)
+	require.NotContains(t, ops, OpPlaying,
+		"OpPlaying is dropped once closing is set, so writer.Playing() is never called")
 }
 
 // TestPlayingDeliveredBeforeClose is the control: with closing unset, OpPlaying
@@ -226,6 +216,6 @@ func TestPlayingDeliveredBeforeClose(t *testing.T) {
 	s.CloseWriters()
 
 	ops := delivered(w)
-	require.True(t, contains(ops, OpPlaying), "OpPlaying should be delivered before closing, got %v", ops)
-	require.True(t, contains(ops, OpClose), "worker should have received OpClose, got %v", ops)
+	require.Contains(t, ops, OpPlaying)
+	require.Contains(t, ops, OpClose)
 }

--- a/pkg/pipeline/source/track_worker_test.go
+++ b/pkg/pipeline/source/track_worker_test.go
@@ -156,3 +156,76 @@ func TestStateTransitions_ActiveState(t *testing.T) {
 		})
 	}
 }
+
+// newIdleWorker registers a worker without starting its goroutine, so the test
+// can inspect exactly which operations were delivered to it.
+func newIdleWorker(s *SDKSource, trackID string) *trackWorker {
+	w := &trackWorker{
+		trackID:    trackID,
+		opChan:     make(chan Operation, 100),
+		generation: atomic.Uint64{},
+	}
+	w.generation.Store(1)
+
+	s.workersMu.Lock()
+	s.workers[trackID] = w
+	s.workersMu.Unlock()
+
+	return w
+}
+
+func delivered(w *trackWorker) []OpType {
+	var ops []OpType
+	for {
+		select {
+		case op := <-w.opChan:
+			ops = append(ops, op.Type)
+		default:
+			return ops
+		}
+	}
+}
+
+func contains(ops []OpType, t OpType) bool {
+	for _, op := range ops {
+		if op == t {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPlayingLostAfterCloseWriters: once CloseWriters() sets closing, submitOp()
+// drops OpPlaying, so a writer whose appsrc was linked just before shutdown is
+// never told it reached PLAYING. This is why cleanup keys off addedToPipeline
+// rather than playing (CS-1547).
+func TestPlayingLostAfterCloseWriters(t *testing.T) {
+	s := testSDKSource(t)
+	w := newIdleWorker(s, "track-1")
+
+	// shutdown begins while the new appsrc is mid state-change
+	s.CloseWriters()
+
+	// GStreamer reports PLAYING only afterwards
+	s.Playing("track-1")
+
+	ops := delivered(w)
+	require.True(t, contains(ops, OpClose), "worker should have received OpClose, got %v", ops)
+	require.False(t, contains(ops, OpPlaying),
+		"OpPlaying is dropped by submitOp() once closing is set, so writer.Playing() "+
+			"is never called. ops=%v", ops)
+}
+
+// TestPlayingDeliveredBeforeClose is the control: with closing unset, OpPlaying
+// is delivered normally.
+func TestPlayingDeliveredBeforeClose(t *testing.T) {
+	s := testSDKSource(t)
+	w := newIdleWorker(s, "track-1")
+
+	s.Playing("track-1")
+	s.CloseWriters()
+
+	ops := delivered(w)
+	require.True(t, contains(ops, OpPlaying), "OpPlaying should be delivered before closing, got %v", ops)
+	require.True(t, contains(ops, OpClose), "worker should have received OpClose, got %v", ops)
+}


### PR DESCRIPTION
Fixes [CS-1547](https://linear.app/livekit/issue/CS-1547/pipeline-frozen-when-writer-added-during-closewriters-race-window). Related customer report: CSCU-18.

## The problem

A track subscribed during the `CloseWriters()` window has its appsrc linked into the running pipeline by `OnTrackAdded()`, but never sends EOS. Cleanup in `AppWriter.start()` guards on `playing.IsBroken()`, and the PLAYING notification that would break that fuse is dropped by `submitOp()` once `closing` is set — permanently, not late. The mixer waits on that input pad forever: `endStreamProcessed not broken after 3 seconds`, then `ErrPipelineFrozen` 30s later. The recording is lost, not delayed: `Close()` skips `uploadManifest()` on `EGRESS_FAILED`.

## The fix

Guard cleanup on a new `addedToPipeline` fuse, broken where the appsrc actually becomes part of the pipeline:

- Marked once in `handleSubscribe`, before the appsrc is linked — by `OnTrackAdded()` for post-init subscriptions, or by `BuildPipeline()` for tracks present at startup. Marking after the link would leave a window where the appsrc is in the pipeline but the writer, on its own goroutine, does not yet know it owes an EOS. Over-marking costs a no-op `EndStream()`; under-marking freezes a recording.
- Marking before the link also covers a startup track that ends during the build: its source is already in the pipeline config, so `BuildPipeline` links the appsrc, and passthrough / track composite never remove that source bin. An EOS sent before the element is linked is retained and delivered once the pipeline starts it.
- `Playing()` breaks the fuse too, since reaching PLAYING implies being linked.

`onEOSSent()` also returns early while `BuildReady` is open. A track that EOFs mid-build otherwise reaches `c.p.Stop()` before `BuildPipeline()` has assigned `c.p` — a nil dereference and a race with that write. This is what made the earlier attempt (cfce5d0) panic in production.

## Verifying in production

Cleanup logs a warning when it sends EOS for a writer that was never reported PLAYING — the race happening and being handled:

```
appsrc never reported PLAYING, sending EOS anyway
  trackID=… kind=… active=… draining=… unsubscribed=… lastReceived=…
```

Before this change the same egress logged `endStreamProcessed not broken after 3 seconds` and failed. So `service:cloud-egress "appsrc never reported PLAYING"` counts races caught, and an egress logging both that and `endStreamProcessed not broken` would mean the fix was insufficient — worth alerting on. Expect it to be rare and confined to shutdown.

## Tests

| Test | Pins | Without the fix |
| --- | --- | --- |
| `TestShouldSendEOS` | The cleanup decision across three states: linked but never reported PLAYING must still owe EOS. | fails |
| `TestOnEOSSentBeforePipelineBuilt` | Cleanup reaching `onEOSSent()` mid-build must not dereference `c.p` or start the EOS sequence. | panics |
| `TestPlayingLostAfterCloseWriters` / `…DeliveredBeforeClose` | `OpPlaying` is dropped once `closing` is set, `OpClose` is not. | n/a |

No integration test: the dynamic-add path is already covered end to end by `testRoomCompositeLateTrackDuration`, and a test targeting the race itself would have to land a stop inside a few-millisecond window, so it would be green whenever it failed to reproduce. A deterministic version behind a test-only hook in `sdk_testing.go` is doable if wanted.

## Unrelated, found while testing

Both confirmed on `main` at feae0c7, not touched here:

- `Controller.Close()` racing `EgressInfo.UpdateStatus()` from `SendEOS()` on `c.Info` — both production paths, surfaced by `TestUnsolicitedEOSBeforeSendEOS`.
- `go test ./pkg/pipeline/ -count>1` panics on duplicate Prometheus collector registration, so repeat `-race` runs need `-count=1` in a loop.
- `TestLivePlaylistWriter` (`sink/m3u8`) and `TestUploader` (`sink/uploader`, needs AWS credentials) also fail on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

