### PR TITLE
Add configurable timeout for web egress start signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ session_limits: # optional egress duration limits - once hit, egress will end wi
   file_output_max_duration: 1h
   stream_output_max_duration: 90m
   segment_output_max_duration: 3h
+  await_start_signal_timeout: 5m # optional - max time to wait for the web start signal before aborting
 
 # file upload config - only one of the following. Can be overridden per request
 storage:

--- a/pkg/config/base.go
+++ b/pkg/config/base.go
@@ -77,6 +77,7 @@ type SessionLimits struct {
 	StreamOutputMaxDuration  time.Duration `yaml:"stream_output_max_duration"`
 	SegmentOutputMaxDuration time.Duration `yaml:"segment_output_max_duration"`
 	ImageOutputMaxDuration   time.Duration `yaml:"image_output_max_duration"`
+	AwaitStartSignalTimeout  time.Duration `yaml:"await_start_signal_timeout"` // max time to wait for the start signal (web egress); 0 to disable
 }
 
 type DebugConfig struct {

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -286,8 +286,21 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 	start := c.src.StartRecording()
 	if start != nil {
 		logger.Debugw("waiting for start signal")
+
+		var timeout <-chan time.Time
+		if c.AwaitStartSignalTimeout > 0 {
+			timer := time.NewTimer(c.AwaitStartSignalTimeout)
+			defer timer.Stop()
+			timeout = timer.C
+		}
+
 		select {
 		case <-c.stopped.Watch():
+			c.src.Close()
+			c.Info.SetAborted(livekit.MsgStartNotReceived)
+			return c.Info
+		case <-timeout:
+			logger.Warnw("timed out waiting for start signal", nil)
 			c.src.Close()
 			c.Info.SetAborted(livekit.MsgStartNotReceived)
 			return c.Info


### PR DESCRIPTION
Web egress waits indefinitely for the page to log `START_RECORDING` before starting sinks. If that signal never arrives (e.g. the recorder page never logs it), the egress hangs forever with no way to self-recover — we hit this in production, stuck for days until manually stopped.

This adds an optional `session_limits.await_start_signal_timeout` config. When set, the egress aborts with `MsgStartNotReceived` if the start signal doesn't arrive in time, instead of waiting forever. Defaults to `0` (disabled), so existing behavior is unchanged unless configured.