### PR TITLE
Fill audio gaps after resampling to stop A/V drift in mixed audio outputs

### DIFF
--- a/pkg/pipeline/builder/audio.go
+++ b/pkg/pipeline/builder/audio.go
@@ -454,11 +454,6 @@ func (b *AudioBin) addEncoder() error {
 }
 
 func addAudioConverter(b *gstreamer.Bin, p *config.PipelineConfig, channel livekit.AudioChannel, isLeaky bool) error {
-	rate, err := gstreamer.BuildAudioRate("audio_rate", audioRateTolerance)
-	if err != nil {
-		return err
-	}
-
 	audioQueue, err := gstreamer.BuildQueue(fmt.Sprintf("%s_input_queue", audioBinName), p.Latency.PipelineLatency, isLeaky)
 	if err != nil {
 		return err
@@ -479,7 +474,12 @@ func addAudioConverter(b *gstreamer.Bin, p *config.PipelineConfig, channel livek
 		return err
 	}
 
-	return b.AddElements(rate, audioQueue, audioConvert, audioResample, capsFilter)
+	rate, err := gstreamer.BuildAudioRate("audio_rate", audioRateTolerance)
+	if err != nil {
+		return err
+	}
+
+	return b.AddElements(audioQueue, audioConvert, audioResample, capsFilter, rate)
 }
 
 func installPitchProbes(pacer *audioPacer) {
@@ -571,12 +571,6 @@ func installPitchProbes(pacer *audioPacer) {
 }
 
 func (b *AudioBin) addAudioConvertWithPitch(bin *gstreamer.Bin, p *config.PipelineConfig, channel livekit.AudioChannel, isLeaky bool) (*audioPacer, error) {
-	// add audio rate element to handle discontinuities or codec DTX
-	rate, err := gstreamer.BuildAudioRate("audio_rate", audioRateTolerance)
-	if err != nil {
-		return nil, err
-	}
-
 	q, err := gstreamer.BuildQueue(fmt.Sprintf("%s_input_queue", audioBinName), p.Latency.PipelineLatency, isLeaky)
 	if err != nil {
 		return nil, err
@@ -593,6 +587,11 @@ func (b *AudioBin) addAudioConvertWithPitch(bin *gstreamer.Bin, p *config.Pipeli
 
 	// go to float for pitch element
 	f32caps, err := newAudioFloatCapsFilter(p, channel)
+	if err != nil {
+		return nil, err
+	}
+
+	rate, err := gstreamer.BuildAudioRate("audio_rate", audioRateTolerance)
 	if err != nil {
 		return nil, err
 	}
@@ -628,7 +627,7 @@ func (b *AudioBin) addAudioConvertWithPitch(bin *gstreamer.Bin, p *config.Pipeli
 
 	installPitchProbes(pacer)
 
-	if err := bin.AddElements(rate, q, ac1, ar1, f32caps, pitch, ac2, s16caps); err != nil {
+	if err := bin.AddElements(q, ac1, ar1, f32caps, rate, pitch, ac2, s16caps); err != nil {
 		return nil, err
 	}
 	return pacer, nil


### PR DESCRIPTION
Participant, room composite and track composite recordings with AAC or MP3 could slowly lose A/V sync: audio falls behind video by roughly 1.5ms for every gap in the incoming audio, in a test run reached about 3 seconds after 45 minutes of a typical DTX conversation, then snapped back into sync with a 3 second cut, and started drifting again. 

Short background of how audio is processed:
1. Decoder turns Opus packets into raw audio.
2. Gap filler (audiorate) inserts silence wherever packets are missing, so the stream is continuous. Opus DTX (discontinuous transmission) stops sending packets during silence, so a normal conversation produces a gap e.g every 420ms while the participant is not speaking.
3. Resampler (audioresample) converts from 48kHz to the output rate. AAC and MP3 outputs default to 44.1kHz, so this step is always active for MP4 files and RTMP/HLS streams.
4. Mixer combines all tracks into one stream.

The mixer stacks each track's samples end to end. It only looks at timestamps to detect large discontinuities: if the position where samples physically land disagrees with their timestamps by more than 3 seconds (aligment-threshold) for at least a second, it re-aligns the track to its timestamps and discards the excess.

The resampler treats silence buffers from the gap filler through a special path, and that path has a bookkeeping error: each silence buffer it emits contains about 66 more samples (1.5ms) than its timestamp and duration claim for the gap specified above. The extra samples are real and go to the mixer, the timestamps do not know about them.

Because the mixer stacks samples rather than placing them by timestamp, every gap pushes all following audio 1.5ms later on the output timeline. Video frames are placed strictly by timestamp, so in the file the audio lags the video by the accumulated excess. After enough gaps the mismatch reaches the mixer's 3 second limit, the mixer drops 3 seconds of the track to re-align, and sync is restored until the drift builds up again.

Fix is moving the gap filer after resampler - the resampler now only ever sees decoded audio, where its sample counts and timestamps agree by construction, so the excess can no longer be created.

Manually tested - automated test would need updates to the test publisher to simulate DTX and will come in as a separate change.