### PR TITLE
Support opt-in psrpc bus compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ logging:
 template_base: can be used to host custom templates (default http://localhost:<template_port>/)
 backup_storage: files will be moved here when uploads fail. location must have write access granted for all users
 enable_chrome_sandbox: if true, egress will run Chrome with sandboxing enabled. This requires a specific Docker setup, see below.
+psrpc: # optional gzip compression of psrpc bus payloads, see the compatibility note below
+  compression:
+    quality: gzip level 1-9. 0, the default, disables compression
+    threshold: payload bytes below which compression is skipped (default 1024)
+    max_decompressed_size: cap on an inbound payload after decompression, 0 for unlimited
 cpu_cost: # optionally override cpu cost estimation, used when accepting or denying requests
   room_composite_cpu_cost: 3.0
   audio_room_composite_cpu_cost: 1.0
@@ -129,6 +134,19 @@ debug:
 ```
 
 The config file can be added to a mounted volume with its location passed in the EGRESS_CONFIG_FILE env var, or its body can be passed in the EGRESS_CONFIG_BODY env var.
+
+> **Compatibility note on `psrpc.compression`**
+>
+> Bus compression requires psrpc v0.7.6 or newer on **every** node sharing the redis bus. An older peer
+> ignores the compression marker and decodes the gzipped bytes as the message payload, so the message is
+> dropped without an error. Enabling it is therefore a two-stage operator action: roll a build with psrpc
+> v0.7.6+ out to livekit-server, egress, ingress, SIP and any agent workers first, then raise `quality` at
+> the publishers. It is off by default.
+>
+> `max_decompressed_size` only affects reading, so it can be set ahead of `quality`.
+>
+> The remaining `rpc.PSRPCConfig` keys (`max_attempts`, `timeout`, `backoff`, `buffer_size`) are accepted
+> under `psrpc:` for config parity with livekit-server, but egress does not read them.
 
 ### Filenames
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -114,7 +114,7 @@ func runService(_ context.Context, c *cli.Command) error {
 		return err
 	}
 
-	bus := psrpc.NewRedisMessageBus(rc)
+	bus := psrpc.NewRedisMessageBus(rc, conf.PSRPC.BusOptions()...)
 	ioClient, err := info.NewSessionReporter(&conf.BaseConfig, bus)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/livekit/media-samples/avsync v0.0.0-20260804064037-794748125298
 	github.com/livekit/media-sdk v0.0.0-20260828235137-cb2363a4cb4f
 	github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095
-	github.com/livekit/protocol v1.50.5-0.20260829123501-a469dd43727b
-	github.com/livekit/psrpc v0.7.5
+	github.com/livekit/protocol v1.51.1-0.20260905133529-a4f4b5c0c23f
+	github.com/livekit/psrpc v0.7.6
 	github.com/livekit/server-sdk-go/v2 v2.18.2-0.20260831001713-a41bea984454
 	github.com/livekit/storage v0.0.0-20260623170515-1297cb15775f
 	github.com/llehouerou/go-mp3 v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -238,10 +238,10 @@ github.com/livekit/media-sdk v0.0.0-20260828235137-cb2363a4cb4f h1:NhAeNlfiQrHZt
 github.com/livekit/media-sdk v0.0.0-20260828235137-cb2363a4cb4f/go.mod h1:TuYRjSepaakL6ATsM9V2VMuksewW1PlhA32BG7Pxty0=
 github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095 h1:BcliKAXoMhl/nWmzQweQ5kmh4Qqagxl4s3Z5pvM/7AY=
 github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.50.5-0.20260829123501-a469dd43727b h1:OOqCnFt5AZRVdSjYzaOzCR9KiB9IeeTPMGls+C1Ti2g=
-github.com/livekit/protocol v1.50.5-0.20260829123501-a469dd43727b/go.mod h1:x7m1nX86XfvS0YoqXnVe0jixkCmAZglR4mcbRHURSro=
-github.com/livekit/psrpc v0.7.5 h1:WxfJIQ41X1b+48A1uzc8Gy9FhYEMxBJNCpCYqPdO/Ds=
-github.com/livekit/psrpc v0.7.5/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
+github.com/livekit/protocol v1.51.1-0.20260905133529-a4f4b5c0c23f h1:+48IWNrsoTgbB0JGv+xJl4umx6e/vh1BX1Tcokuacwc=
+github.com/livekit/protocol v1.51.1-0.20260905133529-a4f4b5c0c23f/go.mod h1:zxowkRnQlJ2VMn6ZyinXMDi985wcKXuWNeXmEERqFAs=
+github.com/livekit/psrpc v0.7.6 h1:YG07lUMTtf+eaYI2goT9zcVZ0kGJNWN1K6ETNFtv1HQ=
+github.com/livekit/psrpc v0.7.6/go.mod h1:DMw15RO7x5XmcgfwzWJYk2In605kx+wu1QRVbPfzf8M=
 github.com/livekit/server-sdk-go/v2 v2.18.2-0.20260831001713-a41bea984454 h1:IEstXtUOyZnBE81hLLeWSph5TB6321wwpyiDwDqVaKM=
 github.com/livekit/server-sdk-go/v2 v2.18.2-0.20260831001713-a41bea984454/go.mod h1:KUMe/Urduz48J4wPavycH8fwnEffaYnC4rtFrlx14qE=
 github.com/livekit/storage v0.0.0-20260623170515-1297cb15775f h1:Dh+50htzSNMcE2VFn6KYK0yd8b7P2saxbN3+2fTFwvo=

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -72,6 +72,8 @@ type ServiceConfig struct {
 
 	PulseSinkReapGraceSec int `yaml:"pulse_sink_reap_grace_sec"` // seconds a leaked pulse sink must stay orphaned before it is unloaded (0 = use default, negative = disable reaping)
 
+	PSRPC rpc.PSRPCConfig `yaml:"psrpc,omitempty"`
+
 	*CPUCostConfig `yaml:"cpu_cost"` // CPU costs for the different egress types
 }
 
@@ -116,6 +118,7 @@ func NewServiceConfig(confString string) (*ServiceConfig, error) {
 			ApiSecret: os.Getenv("LIVEKIT_API_SECRET"),
 			WsUrl:     os.Getenv("LIVEKIT_WS_URL"),
 		},
+		PSRPC:         rpc.DefaultPSRPCConfig,
 		CPUCostConfig: &CPUCostConfig{},
 	}
 	if confString != "" {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -45,7 +45,7 @@ func TestEgress(t *testing.T) {
 	// rpc client and server
 	rc, err := redis.GetRedisClient(r.Redis)
 	require.NoError(t, err)
-	bus := psrpc.NewRedisMessageBus(rc)
+	bus := psrpc.NewRedisMessageBus(rc, r.PSRPC.BusOptions()...)
 
 	ioClient, err := info.NewSessionReporter(&r.BaseConfig, bus)
 	require.NoError(t, err)


### PR DESCRIPTION
psrpc v0.7.6 ([psrpc#130](https://github.com/livekit/psrpc/pull/130)) added opt-in gzip at the bus boundary, and [protocol#1771](https://github.com/livekit/protocol/pull/1771) surfaced it as `rpc.PSRPCConfig.Compression` with a `BusOptions()` conversion. `runService` built the bus from the redis client alone, so there was no way to reach the setting.

```yaml
psrpc:
  compression:
    quality: 6
    threshold: 1024
    max_decompressed_size: 0
```

### Shape

Egress carried no `rpc.PSRPCConfig` at all, so this adds the whole block under a `psrpc:` key, matching livekit-server ([livekit#4844](https://github.com/livekit/livekit/pull/4844)) and ingress ([ingress#488](https://github.com/livekit/ingress/pull/488)). Only `compression` is read here — egress uses the `rpc.NewXClient(bus, opts...)` shorthand and its own `io_selection_timeout`, so `max_attempts`, `timeout`, `backoff` and `buffer_size` are accepted for config parity but inert. The README says so.

It is seeded in the `NewServiceConfig` struct literal rather than `InitDefaults`, so the seed lands before the yaml unmarshal. Without that, a config setting only `quality` would leave `Threshold` at zero and compress every payload, however small. `NewServiceConfig` is the sole construction path — nothing else builds a `ServiceConfig` literal or calls `InitDefaults` — so the one seed covers the service and the integration runner.

`PipelineConfig` deliberately gets nothing. The per-session handler subprocess talks to the parent over unix-socket gRPC IPC and never builds a bus (see the comment at `pkg/service/handler_proxy.go:27`), so nothing else needed threading.

### Compression is off by default

A peer on a psrpc older than v0.7.6 ignores the compression marker — psrpc deserializes with `DiscardUnknown` — and then decodes the gzipped bytes as the payload, so the message is dropped without an error. livekit-server, egress, ingress, SIP and agent workers share this bus, so enabling it is a two-stage operator action: roll v0.7.6+ everywhere, then raise `quality` at the publishers. The README says so at the setting.

`max_decompressed_size` only affects reading, so it can be set ahead of `quality`.

### Testing

`pkg/config/config_test.go` gains coverage of the defaults and of an override that leaves `Threshold` at its default.

Verified the config actually reaches the compressor with a throwaway pub/sub over a local bus: the default config round-trips a 16 KB payload, `quality: 6` round-trips it, and adding `max_decompressed_size: 64` drops that same payload — which is what proves it was gzipped rather than skipped by the threshold. `quality: 0` with the same cap delivers it.

Not verified against a live livekit-server; that needs a peer already on psrpc v0.7.6+. The integration suite was not run — it needs redis, chrome and a live server, and nothing here changes behavior at the default `quality: 0`.

Two pre-existing failures in `go test ./...` are unrelated and fail identically on `main`: `m3u8.TestLivePlaylistWriter` (wall-clock timestamp) and `uploader.TestUploader` (needs real AWS credentials).

### Note on the protocol pin

`v1.51.1-0.20260905133529-a4f4b5c0c23f` is protocol main at the `#1771` merge, the same pseudo-version livekit#4844 and ingress#488 use. It is 14 commits ahead of the previous pin and additive for egress — the only `livekit/` package deletions in the range are in `sip.go`, and egress uses neither those nor the data-track packet code that moved in #1757.
