### PR TITLE
Don't misclassify aborted with failed egress

### DIFF
--- a/pkg/gstreamer/callbacks.go
+++ b/pkg/gstreamer/callbacks.go
@@ -32,13 +32,14 @@ type Callbacks struct {
 	onDebugDotRequest func(string)
 
 	// source callbacks
-	onTrackAdded     []func(*config.TrackSource)
-	onTrackMuted     []func(string)
-	onTrackUnmuted   []func(string)
-	onTrackRemoved   []func(string)
-	onEOSSent        func()
+	onTrackAdded   []func(*config.TrackSource)
+	onTrackMuted   []func(string)
+	onTrackUnmuted []func(string)
+	onTrackRemoved []func(string)
+	onEOSSent      func()
 
-	pipelinePaused core.Fuse
+	pipelinePaused   core.Fuse
+	pipelineStopping core.Fuse
 }
 
 func (c *Callbacks) SetOnError(f func(error)) {
@@ -87,7 +88,14 @@ func (c *Callbacks) AddOnStop(f func() error) {
 	c.mu.Unlock()
 }
 
+// PipelineStopping reports whether Pipeline.Stop has begun tearing the pipeline down.
+func (c *Callbacks) PipelineStopping() bool {
+	return c.pipelineStopping.IsBroken()
+}
+
 func (c *Callbacks) OnStop() error {
+	c.pipelineStopping.Break()
+
 	c.mu.RLock()
 	onStop := c.onStop
 	c.mu.RUnlock()

--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -543,8 +543,8 @@ func (w *AppWriter) pushSamples() {
 		for _, pkt := range item.sample {
 			if err := w.pushPacket(pkt); err != nil {
 				if errors.Is(err, errFlowFlushingThreshold) {
-					if w.draining.IsBroken() {
-						w.logger.Infow("appsrc rejected the remaining backlog while draining",
+					if w.callbacks.PipelineStopping() {
+						w.logger.Infow("appsrc rejected the remaining backlog during pipeline stop",
 							"flushingCount", w.flushingCount)
 					} else {
 						w.callbacks.OnError(errors.ErrPersistentFlushing)

--- a/pkg/pipeline/source/sdk/appwriter.go
+++ b/pkg/pipeline/source/sdk/appwriter.go
@@ -543,7 +543,12 @@ func (w *AppWriter) pushSamples() {
 		for _, pkt := range item.sample {
 			if err := w.pushPacket(pkt); err != nil {
 				if errors.Is(err, errFlowFlushingThreshold) {
-					w.callbacks.OnError(errors.ErrPersistentFlushing)
+					if w.draining.IsBroken() {
+						w.logger.Infow("appsrc rejected the remaining backlog while draining",
+							"flushingCount", w.flushingCount)
+					} else {
+						w.callbacks.OnError(errors.ErrPersistentFlushing)
+					}
 					w.draining.Break()
 					w.notifyPushSamples()
 					return

--- a/pkg/pipeline/source/sdk/appwriter_flushing_test.go
+++ b/pkg/pipeline/source/sdk/appwriter_flushing_test.go
@@ -51,9 +51,10 @@ func (fixedPTS) Close()                                         {}
 // flushingHarness runs pushSamples against a real appsrc inside a pipeline the
 // test can tear down mid-stream, the way Pipeline.Stop() does.
 type flushingHarness struct {
-	pipeline *gst.Pipeline
-	writer   *AppWriter
-	errs     chan error
+	pipeline  *gst.Pipeline
+	callbacks *gstreamer.Callbacks
+	writer    *AppWriter
+	errs      chan error
 }
 
 func newFlushingHarness(t *testing.T) *flushingHarness {
@@ -90,7 +91,7 @@ func newFlushingHarness(t *testing.T) *flushingHarness {
 	w.samplesCond = sync.NewCond(&w.samplesLock)
 	w.Playing()
 
-	return &flushingHarness{pipeline: pipeline, writer: w, errs: errs}
+	return &flushingHarness{pipeline: pipeline, callbacks: callbacks, writer: w, errs: errs}
 }
 
 // enqueue hands pushSamples one sample of n packets, as the jitter buffer does.
@@ -127,28 +128,33 @@ func (h *flushingHarness) reportedError() (error, bool) {
 }
 
 // TestPushSamplesFlushingThreshold pins how pushSamples reacts once the appsrc
-// has refused flushingThreshold consecutive buffers. A live track reports the
-// stall through OnError. A draining track does not: the pipeline being torn
-// down underneath it is the expected end of the stream, and the queued backlog
-// being refused must not turn the abort into a failed egress.
+// has refused flushingThreshold consecutive buffers. While the pipeline is
+// running, that is a stranded appsrc and is reported through OnError, whether
+// or not the track itself is ending. Once Pipeline.Stop has begun, the refused
+// backlog is the expected consequence of the teardown and must not turn an
+// abort into a failed egress.
 func TestPushSamplesFlushingThreshold(t *testing.T) {
-	run := func(t *testing.T, draining bool) (error, bool) {
+	run := func(t *testing.T, trackDraining, pipelineStopping bool) (error, bool) {
 		h := newFlushingHarness(t)
 		w := h.writer
 
 		go w.pushSamples()
 
 		// one buffer through the live pipeline proves pushSamples is past its
-		// start gates before the pipeline is stopped
+		// start gates before the appsrc starts refusing buffers
 		h.enqueue(1)
 		require.Eventually(t, func() bool { return !w.lastPushed.Load().IsZero() },
 			5*time.Second, 10*time.Millisecond)
 
+		if pipelineStopping {
+			// Pipeline.Stop runs OnStop before it sets the pipeline to NULL
+			require.NoError(t, h.callbacks.OnStop())
+		}
 		require.NoError(t, h.pipeline.SetState(gst.StateNull))
 		require.Equal(t, gst.FlowFlushing, w.src.PushBuffer(gst.NewBufferFromBytes([]byte{0})),
 			"precondition: a stopped appsrc refuses buffers with FlowFlushing")
 
-		if draining {
+		if trackDraining {
 			w.draining.Break()
 		}
 		for i := 0; i < 3; i++ {
@@ -161,15 +167,22 @@ func TestPushSamplesFlushingThreshold(t *testing.T) {
 		return h.reportedError()
 	}
 
-	t.Run("live track reports persistent flushing", func(t *testing.T) {
-		err, reported := run(t, false)
-		require.True(t, reported, "a live track whose appsrc refuses every buffer must fail the egress")
+	t.Run("live track in a running pipeline reports persistent flushing", func(t *testing.T) {
+		err, reported := run(t, false, false)
+		require.True(t, reported, "a stranded appsrc under a live track must fail the egress")
 		require.ErrorIs(t, err, errors.ErrPersistentFlushing)
 	})
 
-	t.Run("draining track ends without an error", func(t *testing.T) {
-		err, reported := run(t, true)
+	t.Run("ending track in a running pipeline still reports persistent flushing", func(t *testing.T) {
+		err, reported := run(t, true, false)
+		require.True(t, reported,
+			"a track draining into a stranded appsrc must still fail the egress, or its queued tail is silently lost")
+		require.ErrorIs(t, err, errors.ErrPersistentFlushing)
+	})
+
+	t.Run("stopping pipeline ends the track without an error", func(t *testing.T) {
+		err, reported := run(t, true, true)
 		require.False(t, reported,
-			"a track that is already draining must not fail the egress when the torn-down pipeline refuses its backlog, got %v", err)
+			"a pipeline being torn down must not fail the egress when it refuses the queued backlog, got %v", err)
 	})
 }

--- a/pkg/pipeline/source/sdk/appwriter_flushing_test.go
+++ b/pkg/pipeline/source/sdk/appwriter_flushing_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-gst/go-gst/gst"
+	"github.com/go-gst/go-gst/gst/app"
+	"github.com/pion/rtp"
+	"github.com/pion/webrtc/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/egress/pkg/config"
+	"github.com/livekit/egress/pkg/errors"
+	"github.com/livekit/egress/pkg/gstreamer"
+	"github.com/livekit/media-sdk/jitter"
+	"github.com/livekit/protocol/logger"
+	"github.com/livekit/server-sdk-go/v2/pkg/synchronizer"
+)
+
+var gstInitOnce sync.Once
+
+// fixedPTS is a TrackSync that assigns every packet the same PTS.
+type fixedPTS struct{}
+
+var _ synchronizer.TrackSync = fixedPTS{}
+
+func (fixedPTS) PrimeForStart(pkt jitter.ExtPacket) ([]jitter.ExtPacket, int, bool) {
+	return []jitter.ExtPacket{pkt}, 0, true
+}
+func (fixedPTS) GetPTS(jitter.ExtPacket) (time.Duration, error) { return time.Millisecond, nil }
+func (fixedPTS) OnSenderReport(func(time.Duration))             {}
+func (fixedPTS) LastPTSAdjusted() time.Duration                 { return 0 }
+func (fixedPTS) Close()                                         {}
+
+// flushingHarness runs pushSamples against a real appsrc inside a pipeline the
+// test can tear down mid-stream, the way Pipeline.Stop() does.
+type flushingHarness struct {
+	pipeline *gst.Pipeline
+	writer   *AppWriter
+	errs     chan error
+}
+
+func newFlushingHarness(t *testing.T) *flushingHarness {
+	t.Helper()
+	gstInitOnce.Do(func() { gst.Init(nil) })
+
+	pipeline, err := gst.NewPipeline("flushing-test")
+	require.NoError(t, err)
+	appsrc, err := gst.NewElement("appsrc")
+	require.NoError(t, err)
+	sink, err := gst.NewElement("fakesink")
+	require.NoError(t, err)
+	require.NoError(t, pipeline.AddMany(appsrc, sink))
+	require.NoError(t, appsrc.Link(sink))
+	require.NoError(t, pipeline.SetState(gst.StatePlaying))
+	t.Cleanup(func() { _ = pipeline.SetState(gst.StateNull) })
+
+	errs := make(chan error, 1)
+	callbacks := &gstreamer.Callbacks{}
+	callbacks.SetOnError(func(err error) { errs <- err })
+	callbacks.OnPipelinePaused()
+
+	w := &AppWriter{
+		conf:         &config.PipelineConfig{},
+		logger:       logger.GetLogger(),
+		track:        &webrtc.TrackRemote{},
+		src:          app.SrcFromElement(appsrc),
+		callbacks:    callbacks,
+		translator:   NewNullTranslator(),
+		trackSync:    fixedPTS{},
+		sendPLI:      func() {},
+		timeProvider: gstreamer.NopTimeProvider(),
+	}
+	w.samplesCond = sync.NewCond(&w.samplesLock)
+	w.Playing()
+
+	return &flushingHarness{pipeline: pipeline, writer: w, errs: errs}
+}
+
+// enqueue hands pushSamples one sample of n packets, as the jitter buffer does.
+func (h *flushingHarness) enqueue(n int) {
+	sample := make([]jitter.ExtPacket, n)
+	for i := range sample {
+		sample[i] = jitter.ExtPacket{
+			ReceivedAt: time.Now(),
+			Packet: &rtp.Packet{
+				Header:  rtp.Header{Version: 2, SequenceNumber: uint16(i), Timestamp: uint32(i) * 960},
+				Payload: []byte{0},
+			},
+		}
+	}
+	h.writer.onPacket(sample)
+}
+
+func (h *flushingHarness) waitFinished(t *testing.T) {
+	t.Helper()
+	select {
+	case <-h.writer.endStreamProcessed.Watch():
+	case <-time.After(5 * time.Second):
+		t.Fatal("pushSamples did not finish")
+	}
+}
+
+func (h *flushingHarness) reportedError() (error, bool) {
+	select {
+	case err := <-h.errs:
+		return err, true
+	default:
+		return nil, false
+	}
+}
+
+// TestPushSamplesFlushingThreshold pins how pushSamples reacts once the appsrc
+// has refused flushingThreshold consecutive buffers. A live track reports the
+// stall through OnError. A draining track does not: the pipeline being torn
+// down underneath it is the expected end of the stream, and the queued backlog
+// being refused must not turn the abort into a failed egress.
+func TestPushSamplesFlushingThreshold(t *testing.T) {
+	run := func(t *testing.T, draining bool) (error, bool) {
+		h := newFlushingHarness(t)
+		w := h.writer
+
+		go w.pushSamples()
+
+		// one buffer through the live pipeline proves pushSamples is past its
+		// start gates before the pipeline is stopped
+		h.enqueue(1)
+		require.Eventually(t, func() bool { return !w.lastPushed.Load().IsZero() },
+			5*time.Second, 10*time.Millisecond)
+
+		require.NoError(t, h.pipeline.SetState(gst.StateNull))
+		require.Equal(t, gst.FlowFlushing, w.src.PushBuffer(gst.NewBufferFromBytes([]byte{0})),
+			"precondition: a stopped appsrc refuses buffers with FlowFlushing")
+
+		if draining {
+			w.draining.Break()
+		}
+		for i := 0; i < 3; i++ {
+			h.enqueue(flushingThreshold / 2)
+		}
+		w.endStreamSourceProcessed.Break()
+		w.notifyPushSamples()
+		h.waitFinished(t)
+
+		return h.reportedError()
+	}
+
+	t.Run("live track reports persistent flushing", func(t *testing.T) {
+		err, reported := run(t, false)
+		require.True(t, reported, "a live track whose appsrc refuses every buffer must fail the egress")
+		require.ErrorIs(t, err, errors.ErrPersistentFlushing)
+	})
+
+	t.Run("draining track ends without an error", func(t *testing.T) {
+		err, reported := run(t, true)
+		require.False(t, reported,
+			"a track that is already draining must not fail the egress when the torn-down pipeline refuses its backlog, got %v", err)
+	})
+}


### PR DESCRIPTION
Caught as a side observation during the latest release monitoring.

A participant egress that is removed from the room while its pipeline is still prerolling is correctly aborted with "stopped before started", but in some cases the abort is overwritten with `EGRESS_FAILED` and the error`FlowFlushing`. There is no stuck track: the appsrc is being torn down by `Pipeline.Stop()` and the writer is pushing its queued backlog into it. This PR stops the writer from reporting that as a stall when the track is already draining. Tests generated by claude.