### PR TITLE
Buffer the Chrome apt index before parsing it in publish-chrome

### DIFF
--- a/.github/workflows/publish-chrome.yaml
+++ b/.github/workflows/publish-chrome.yaml
@@ -36,9 +36,14 @@ jobs:
           set -euo pipefail
 
           apt_version() {
-            curl -fsSL --retry 3 --retry-delay 5 \
-              "https://dl.google.com/linux/chrome/deb/dists/stable/main/binary-$1/Packages" \
-              | awk '/^Package: google-chrome-stable$/{p=1} p&&/^Version:/{print $2; exit}'
+            local packages
+            if ! packages="$(curl -fsSL --retry 3 --retry-delay 5 \
+              "https://dl.google.com/linux/chrome/deb/dists/stable/main/binary-$1/Packages")"; then
+              echo "::error::Failed to fetch the Chrome apt index for $1" >&2
+              return 1
+            fi
+
+            awk '/^Package: google-chrome-stable$/{p=1} p&&/^Version:/{print $2; exit}' <<<"$packages"
           }
 
           version="$CHROME_VERSION"


### PR DESCRIPTION
Piping curl into awk let awk's exit close the read end of the pipe before the
trailing google-chrome-unstable stanza had been written, so curl failed
with CURLE_WRITE_ERROR and pipefail aborted the step. Buffering the
response into a variable drains the stream before awk runs, and a fetch
failure now reports a named error instead of a bare exit code.

https://github.com/livekit/egress/actions/runs/34292595909