### PR TITLE
Make tini PID 1 from the first instruction of the container

### DIFF
--- a/build/egress/Dockerfile
+++ b/build/egress/Dockerfile
@@ -117,4 +117,4 @@ ENV PATH=${PATH}:/chrome
 ENV XDG_RUNTIME_DIR=/home/egress/.cache/xdgr
 ENV CHROME_DEVEL_SANDBOX=/usr/local/sbin/chrome-devel-sandbox
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]

--- a/build/egress/entrypoint.sh
+++ b/build/egress/entrypoint.sh
@@ -26,4 +26,4 @@ rm -rf /var/run/pulse /var/lib/pulse /home/egress/.config/pulse /home/egress/.ca
 pulseaudio -D --verbose --exit-idle-time=-1 --disallow-exit > /dev/null 2>&1
 
 # Run egress service
-exec /tini -- egress
+exec egress


### PR DESCRIPTION
## What

`ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]` instead of `ENTRYPOINT ["/entrypoint.sh"]`, and the script ends with `exec egress` instead of `exec /tini -- egress`.

## Why

The entrypoint script is bash, and it is PID 1 of the container until its last line hands over to tini. PID 1 of a pid namespace has `SIGNAL_UNKILLABLE`: any signal for which it has the default disposition is discarded by the kernel, even when sent from the host (`kernel/signal.c`, `sig_task_ignored`). bash installs no `trap`, so a SIGTERM that arrives while the script is still running `rm` or `pulseaudio -D` is silently dropped.

Container runtimes send the stop signal once and then wait for the timeout before SIGKILLing. So a stop request that lands in that window (typically 0.1 to 0.9 s after container start, longer on a cold node) has this effect: bash ignores it, execs tini, tini starts egress, egress registers and serves normally, and at the end of the grace period the whole cgroup is SIGKILLed with every handler and in-flight recording. Kubernetes hits this window whenever a pod is deleted while its image is still pulling, because kubelet finishes starting the container and issues the kill milliseconds later.

With tini as PID 1 from the first instruction, signals are blocked and queued before anything else runs, then forwarded to tini's child:

| SIGTERM arrives | Before | After |
|---|---|---|
| During `rm` / `pulseaudio -D` | Dropped; container runs until SIGKILL at stop timeout | Forwarded to bash, which exits; tini exits 143; container stops in well under a second |
| After `exec egress`, before `signal.Notify` | Go default: exit | Same |
| After `signal.Notify` | Graceful drain | Graceful drain, unchanged |

The trailing `exec egress` is required: tini forwards only to its direct child and exits when that child exits, so egress must replace the shell in place rather than run as a grandchild. Handlers are children of egress exactly as before.

## Verification

Local docker tests, stop issued immediately after `docker run -d` returns (the same moment kubelet would issue it):

* Published image: one run landed inside the bash window. `docker stop` waited its full 20 s timeout and the container exited 137; egress had started after the stop was issued and never logged `exit requested`.
* This branch, 21 runs: 18 drained normally (`exit requested, finishing recording then shutting down`, exit 0), 3 exited 143 within 0.1 s with egress never starting. No run reached the timeout.
* This branch, stop issued after egress was up: normal drain, exit 0 in 0.17 s.
* A minimal image with the same shape (bash PID 1, 1.5 s setup, exec) reproduces both behaviours deterministically: old layout ignores the stop and is SIGKILLed at the timeout, new layout exits 143 in 0.15 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
