### PR TITLE
Guard EgressInfo with a shared lock and return snapshots from handler RPCs

### DIFF
--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-gst/go-gst/gst/app"
@@ -56,6 +57,7 @@ type PipelineConfig struct {
 	FinalizationRequired bool                                `yaml:"-"`
 
 	Info            *livekit.EgressInfo `yaml:"-"`
+	infoMu          sync.Mutex          `yaml:"-"`
 	Manifest        *Manifest           `yaml:"-"`
 	Live            bool                `yaml:"-"`
 	IsReplay        bool                `yaml:"-"`
@@ -974,4 +976,16 @@ func stringReplace(s string, replacements map[string]string) string {
 		s = strings.ReplaceAll(s, template, value)
 	}
 	return s
+}
+
+// LockInfo guards Info and the nested result messages it references. Hold it for every write and
+// release it before any IPC, GStreamer or upload call.
+func (p *PipelineConfig) LockInfo()   { p.infoMu.Lock() }
+func (p *PipelineConfig) UnlockInfo() { p.infoMu.Unlock() }
+
+// InfoSnapshot returns a copy of Info that is safe to read and marshal from any goroutine.
+func (p *PipelineConfig) InfoSnapshot() *livekit.EgressInfo {
+	p.infoMu.Lock()
+	defer p.infoMu.Unlock()
+	return proto.Clone(p.Info).(*livekit.EgressInfo)
 }

--- a/pkg/config/pipeline.go
+++ b/pkg/config/pipeline.go
@@ -20,10 +20,10 @@ import (
 	"net/url"
 	"path"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-gst/go-gst/gst/app"
+	"github.com/linkdata/deadlock"
 	"github.com/pion/webrtc/v4"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/atomic"
@@ -57,7 +57,7 @@ type PipelineConfig struct {
 	FinalizationRequired bool                                `yaml:"-"`
 
 	Info            *livekit.EgressInfo `yaml:"-"`
-	infoMu          sync.Mutex          `yaml:"-"`
+	infoMu          deadlock.Mutex      `yaml:"-"`
 	Manifest        *Manifest           `yaml:"-"`
 	Live            bool                `yaml:"-"`
 	IsReplay        bool                `yaml:"-"`

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -124,8 +124,10 @@ func (h *Handler) Run() {
 		})
 		cancel()
 		if err != nil {
+			h.conf.LockInfo()
 			h.conf.Info.SetFailed(err)
-			_, _ = h.ipcServiceClient.HandlerUpdate(context.Background(), h.conf.Info)
+			h.conf.UnlockInfo()
+			_, _ = h.ipcServiceClient.HandlerUpdate(context.Background(), h.conf.InfoSnapshot())
 			return
 		}
 		h.controller.SetReplayTiming(resp.StartAt, resp.DurationMs)

--- a/pkg/handler/handler_ipc.go
+++ b/pkg/handler/handler_ipc.go
@@ -145,7 +145,9 @@ func (h *Handler) KillEgress(ctx context.Context, req *ipc.KillEgressRequest) (*
 	}
 
 	h.controller.SendEOS(ctx, livekit.EndReasonKilled)
+	h.conf.LockInfo()
 	h.controller.Info.SetFailed(psrpc.NewErrorf(psrpc.PermissionDenied, "%s", req.Error))
+	h.conf.UnlockInfo()
 
 	return &emptypb.Empty{}, nil
 }

--- a/pkg/handler/handler_rpc.go
+++ b/pkg/handler/handler_rpc.go
@@ -34,7 +34,7 @@ func (h *Handler) UpdateStream(ctx context.Context, req *livekit.UpdateStreamReq
 	if err != nil {
 		return nil, err
 	}
-	return h.controller.Info, nil
+	return h.controller.InfoSnapshot(), nil
 }
 
 func (h *Handler) StopEgress(ctx context.Context, _ *livekit.StopEgressRequest) (*livekit.EgressInfo, error) {
@@ -47,5 +47,5 @@ func (h *Handler) StopEgress(ctx context.Context, _ *livekit.StopEgressRequest) 
 	}
 
 	h.controller.SendEOS(ctx, livekit.EndReasonAPI)
-	return h.controller.Info, nil
+	return h.controller.InfoSnapshot(), nil
 }

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/frostbyte73/core"
 	"github.com/go-gst/go-gst/gst"
-	"github.com/linkdata/deadlock"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
@@ -70,7 +69,6 @@ type Controller struct {
 	replayDuration int64 // milliseconds
 
 	// internal
-	mu                   deadlock.Mutex
 	monitor              *stats.HandlerMonitor
 	limitTimer           *time.Timer
 	storageMonitorCancel context.CancelFunc
@@ -249,8 +247,12 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 	ctx, span := tracer.Start(ctx, "Pipeline.Run")
 	defer span.End()
 
-	defer c.Close()
+	c.run(ctx)
+	c.Close()
+	return c.InfoSnapshot()
+}
 
+func (c *Controller) run(ctx context.Context) {
 	defer func() {
 		if c.VideoEnabled {
 			logger.Infow(
@@ -289,8 +291,8 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 		select {
 		case <-c.stopped.Watch():
 			c.src.Close()
-			c.Info.SetAborted(livekit.MsgStartNotReceived)
-			return c.Info
+			c.updateInfo(func() { c.Info.SetAborted(livekit.MsgStartNotReceived) })
+			return
 		case <-start:
 			// continue
 		}
@@ -304,8 +306,8 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 			select {
 			case <-c.stopped.Watch():
 				c.src.Close()
-				c.Info.SetAborted(livekit.MsgStartNotReceived)
-				return c.Info
+				c.updateInfo(func() { c.Info.SetAborted(livekit.MsgStartNotReceived) })
+				return
 			case <-time.After(waitDuration):
 				// continue
 			}
@@ -316,8 +318,8 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 		for _, s := range si {
 			if err := s.Start(); err != nil {
 				c.src.Close()
-				c.Info.SetFailed(err)
-				return c.Info
+				c.updateInfo(func() { c.Info.SetFailed(err) })
+				return
 			}
 		}
 	}
@@ -334,8 +336,8 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 	err := c.p.Run()
 	if err != nil {
 		c.src.Close()
-		c.Info.SetFailed(err)
-		return c.Info
+		c.updateInfo(func() { c.Info.SetFailed(err) })
+		return
 	}
 
 	logger.Debugw("closing source")
@@ -356,15 +358,17 @@ func (c *Controller) Run(ctx context.Context) *livekit.EgressInfo {
 		for _, si := range c.sinks {
 			for _, s := range si {
 				if c.eosReceived.IsBroken() || s.EOSReceived() {
-					if err := s.Close(); err != nil && c.Info.Status != livekit.EgressStatus_EGRESS_FAILED {
-						c.Info.SetFailed(err)
+					if err := s.Close(); err != nil {
+						c.updateInfo(func() {
+							if c.Info.Status != livekit.EgressStatus_EGRESS_FAILED {
+								c.Info.SetFailed(err)
+							}
+						})
 					}
 				}
 			}
 		}
 	}
-
-	return c.Info
 }
 
 func (c *Controller) UpdateStream(ctx context.Context, req *livekit.UpdateStreamRequest) error {
@@ -388,18 +392,20 @@ func (c *Controller) UpdateStream(ctx context.Context, req *livekit.UpdateStream
 		}
 
 		// add stream info to results
-		c.mu.Lock()
-		c.Info.StreamResults = append(c.Info.StreamResults, stream.StreamInfo)
-		if list := c.Info.GetStream(); list != nil { //nolint:staticcheck // keep deprecated field for older clients
-			list.Info = append(list.Info, stream.StreamInfo)
-		}
-		c.mu.Unlock()
+		c.updateInfo(func() {
+			c.Info.StreamResults = append(c.Info.StreamResults, stream.StreamInfo)
+			if list := c.Info.GetStream(); list != nil { //nolint:staticcheck // keep deprecated field for older clients
+				list.Info = append(list.Info, stream.StreamInfo)
+			}
+		})
 
 		// add stream
 		if err = c.getStreamSink().AddStream(stream); err != nil {
-			stream.StreamInfo.Status = livekit.StreamInfo_FAILED
-			stream.StreamInfo.Error = err.Error()
-			stream.UpdateEndTime(time.Now().UnixNano())
+			c.updateInfo(func() {
+				stream.StreamInfo.Status = livekit.StreamInfo_FAILED
+				stream.StreamInfo.Error = err.Error()
+				stream.UpdateEndTime(time.Now().UnixNano())
+			})
 			errs.AppendErr(err)
 			continue
 		}
@@ -425,8 +431,10 @@ func (c *Controller) UpdateStream(ctx context.Context, req *livekit.UpdateStream
 }
 
 func (c *Controller) streamFinished(ctx context.Context, stream *config.Stream) error {
-	stream.StreamInfo.Status = livekit.StreamInfo_FINISHED
-	stream.UpdateEndTime(time.Now().UnixNano())
+	c.updateInfo(func() {
+		stream.StreamInfo.Status = livekit.StreamInfo_FINISHED
+		stream.UpdateEndTime(time.Now().UnixNano())
+	})
 
 	// remove output
 	o := c.GetStreamConfig()
@@ -449,9 +457,11 @@ func (c *Controller) streamFinished(ctx context.Context, stream *config.Stream) 
 }
 
 func (c *Controller) streamFailed(ctx context.Context, stream *config.Stream, streamErr error) error {
-	stream.StreamInfo.Status = livekit.StreamInfo_FAILED
-	stream.StreamInfo.Error = streamErr.Error()
-	stream.UpdateEndTime(time.Now().UnixNano())
+	c.updateInfo(func() {
+		stream.StreamInfo.Status = livekit.StreamInfo_FAILED
+		stream.StreamInfo.Error = streamErr.Error()
+		stream.UpdateEndTime(time.Now().UnixNano())
+	})
 
 	// remove output
 	o := c.GetStreamConfig()
@@ -475,8 +485,10 @@ func (c *Controller) streamFailed(ctx context.Context, stream *config.Stream, st
 
 func (c *Controller) trackStreamRetry(ctx context.Context, stream *config.Stream) {
 	now := time.Now()
-	stream.StreamInfo.LastRetryAt = now.UnixNano()
-	stream.StreamInfo.Retries++
+	c.updateInfo(func() {
+		stream.StreamInfo.LastRetryAt = now.UnixNano()
+		stream.StreamInfo.Retries++
+	})
 	if !stream.ShouldSendRetryUpdate(now, streamRetryUpdateInterval) {
 		return
 	}
@@ -508,7 +520,7 @@ func (c *Controller) onEOSSent() {
 
 func (c *Controller) onStorageLimitReached() {
 	c.storageLimitOnce.Do(func() {
-		c.Info.SetLimitReached()
+		c.updateInfo(func() { c.Info.SetLimitReached() })
 		c.SendEOS(context.Background(), livekit.EndReasonLimitReached)
 	})
 }
@@ -522,25 +534,28 @@ func (c *Controller) SendEOS(ctx context.Context, reason string) {
 			c.limitTimer.Stop()
 		}
 
-		c.Info.SetEndReason(reason)
+		var status livekit.EgressStatus
+		c.updateInfo(func() {
+			c.Info.SetEndReason(reason)
+			status = c.Info.Status
+			switch status {
+			case livekit.EgressStatus_EGRESS_STARTING:
+				c.Info.SetAborted(livekit.MsgStoppedBeforeStarted)
+			case livekit.EgressStatus_EGRESS_ACTIVE:
+				c.Info.UpdateStatus(livekit.EgressStatus_EGRESS_ENDING)
+			}
+		})
 		logger.Debugw("stopping pipeline", "reason", reason)
 
-		switch c.Info.Status {
-		case livekit.EgressStatus_EGRESS_STARTING:
-			c.Info.SetAborted(livekit.MsgStoppedBeforeStarted)
-			c.p.Stop()
-
-		case livekit.EgressStatus_EGRESS_ABORTED,
+		switch status {
+		case livekit.EgressStatus_EGRESS_STARTING,
+			livekit.EgressStatus_EGRESS_ABORTED,
 			livekit.EgressStatus_EGRESS_FAILED:
 			c.p.Stop()
 
-		case livekit.EgressStatus_EGRESS_ACTIVE:
-			c.Info.UpdateStatus(livekit.EgressStatus_EGRESS_ENDING)
-			c.sendHandlerUpdate(ctx, c.Info)
-			c.sendEOS()
-
-		case livekit.EgressStatus_EGRESS_ENDING:
-			c.sendHandlerUpdate(ctx, c.Info)
+		case livekit.EgressStatus_EGRESS_ACTIVE,
+			livekit.EgressStatus_EGRESS_ENDING:
+			c.sendHandlerUpdate(ctx)
 			c.sendEOS()
 
 		case livekit.EgressStatus_EGRESS_LIMIT_REACHED:
@@ -600,9 +615,11 @@ func (c *Controller) OnError(err error) {
 		c.generatePProf()
 	}
 
-	if c.Info.Status != livekit.EgressStatus_EGRESS_FAILED && (!c.eosSent.IsBroken() || c.FinalizationRequired) {
-		c.Info.SetFailed(err)
-	}
+	c.updateInfo(func() {
+		if c.Info.Status != livekit.EgressStatus_EGRESS_FAILED && (!c.eosSent.IsBroken() || c.FinalizationRequired) {
+			c.Info.SetFailed(err)
+		}
+	})
 
 	go c.p.Stop()
 }
@@ -634,33 +651,38 @@ func (c *Controller) Close() {
 		c.updateEndTime()
 	}
 
-	// update status
-	if c.Info.Status == livekit.EgressStatus_EGRESS_FAILED {
-		if o := c.GetStreamConfig(); o != nil {
-			o.Streams.Range(func(_, stream any) bool {
-				stream.(*config.Stream).StreamInfo.Status = livekit.StreamInfo_FAILED
-				return true
-			})
-		}
-	}
-
 	duplicateIdentity := c.IsDuplicateIdentity()
 
 	// ensure egress ends with a final state
-	switch c.Info.Status {
-	case livekit.EgressStatus_EGRESS_STARTING:
-		c.Info.SetAborted(livekit.MsgStoppedBeforeStarted)
+	var status livekit.EgressStatus
+	c.updateInfo(func() {
+		status = c.Info.Status
+		switch status {
+		case livekit.EgressStatus_EGRESS_FAILED:
+			if o := c.GetStreamConfig(); o != nil {
+				o.Streams.Range(func(_, stream any) bool {
+					stream.(*config.Stream).StreamInfo.Status = livekit.StreamInfo_FAILED
+					return true
+				})
+			}
 
-	case livekit.EgressStatus_EGRESS_ACTIVE,
-		livekit.EgressStatus_EGRESS_ENDING:
-		if err := c.endError(); err != nil {
-			c.Info.SetFailed(err)
-		} else {
-			c.Info.SetComplete()
+		case livekit.EgressStatus_EGRESS_STARTING:
+			c.Info.SetAborted(livekit.MsgStoppedBeforeStarted)
+
+		case livekit.EgressStatus_EGRESS_ACTIVE,
+			livekit.EgressStatus_EGRESS_ENDING:
+			if err := c.endError(); err != nil {
+				c.Info.SetFailed(err)
+			} else {
+				c.Info.SetComplete()
+			}
 		}
-		fallthrough
+	})
 
-	case livekit.EgressStatus_EGRESS_LIMIT_REACHED,
+	switch status {
+	case livekit.EgressStatus_EGRESS_ACTIVE,
+		livekit.EgressStatus_EGRESS_ENDING,
+		livekit.EgressStatus_EGRESS_LIMIT_REACHED,
 		livekit.EgressStatus_EGRESS_COMPLETE:
 		if !duplicateIdentity {
 			// upload manifest and add location to egress info
@@ -695,12 +717,14 @@ func (c *Controller) startSessionLimitTimer(ctx context.Context) {
 
 	if timeout > 0 {
 		c.limitTimer = time.AfterFunc(timeout, func() {
-			switch c.Info.Status {
-			case livekit.EgressStatus_EGRESS_STARTING:
-				c.Info.SetAborted(livekit.MsgLimitReachedWithoutStart)
-			case livekit.EgressStatus_EGRESS_ACTIVE:
-				c.Info.SetLimitReached()
-			}
+			c.updateInfo(func() {
+				switch c.Info.Status {
+				case livekit.EgressStatus_EGRESS_STARTING:
+					c.Info.SetAborted(livekit.MsgLimitReachedWithoutStart)
+				case livekit.EgressStatus_EGRESS_ACTIVE:
+					c.Info.SetLimitReached()
+				}
+			})
 
 			if c.playing.IsBroken() {
 				c.SendEOS(ctx, livekit.EndReasonLimitReached)
@@ -859,6 +883,7 @@ func (c *Controller) logOutputFileSizes(files []outputFileStat, limit int) {
 }
 
 func (c *Controller) updateStartTime(startedAt int64) {
+	c.LockInfo()
 	for egressType, o := range c.Outputs {
 		if len(o) == 0 {
 			continue
@@ -889,52 +914,77 @@ func (c *Controller) updateStartTime(startedAt int64) {
 		}
 	}
 
-	if c.Info.Status == livekit.EgressStatus_EGRESS_STARTING {
+	activated := c.Info.Status == livekit.EgressStatus_EGRESS_STARTING
+	if activated {
 		c.Info.UpdateStatus(livekit.EgressStatus_EGRESS_ACTIVE)
-		c.sendHandlerUpdate(context.Background(), c.Info)
+	}
+	c.UnlockInfo()
+
+	if activated {
+		c.sendHandlerUpdate(context.Background())
 	}
 }
 
 func (c *Controller) updateStreamStartTime(streamID string) {
-	if o := c.GetStreamConfig(); o != nil {
+	o := c.GetStreamConfig()
+	if o == nil {
+		return
+	}
+
+	started := false
+	c.updateInfo(func() {
 		o.Streams.Range(func(_, s any) bool {
 			if stream := s.(*config.Stream); stream.StreamID == streamID && stream.StreamInfo.StartedAt == 0 {
 				logger.Debugw("stream started", "url", stream.RedactedUrl)
 				stream.StreamInfo.StartedAt = time.Now().UnixNano()
-				c.Info.UpdatedAt = time.Now().UnixNano()
-				c.streamUpdated(context.Background())
+				started = true
 				return false
 			}
 			return true
 		})
+	})
+
+	if started {
+		c.streamUpdated(context.Background())
 	}
 }
 
 func (c *Controller) streamUpdated(ctx context.Context) {
-	c.Info.UpdatedAt = time.Now().UnixNano()
+	skipUpdate := false
+	c.updateInfo(func() {
+		c.Info.UpdatedAt = time.Now().UnixNano()
 
-	if o := c.GetStreamConfig(); o != nil {
-		skipUpdate := false
-		// when adding streams, wait until they've all either started or failed before sending the update
-		o.Streams.Range(func(_, stream any) bool {
-			streamInfo := stream.(*config.Stream).StreamInfo
-			if streamInfo.Status == livekit.StreamInfo_ACTIVE && streamInfo.StartedAt == 0 {
-				skipUpdate = true
-				return false
-			}
-			return true
-		})
-		if skipUpdate {
-			return
+		if o := c.GetStreamConfig(); o != nil {
+			// when adding streams, wait until they've all either started or failed before sending the update
+			o.Streams.Range(func(_, stream any) bool {
+				streamInfo := stream.(*config.Stream).StreamInfo
+				if streamInfo.Status == livekit.StreamInfo_ACTIVE && streamInfo.StartedAt == 0 {
+					skipUpdate = true
+					return false
+				}
+				return true
+			})
 		}
+	})
+	if skipUpdate {
+		return
 	}
 
-	c.sendHandlerUpdate(ctx, c.Info)
+	c.sendHandlerUpdate(ctx)
 }
 
-func (c *Controller) sendHandlerUpdate(ctx context.Context, info *livekit.EgressInfo) {
+// updateInfo runs fn while holding the Info lock. fn must not block on IPC, GStreamer or uploads.
+func (c *Controller) updateInfo(fn func()) {
+	c.LockInfo()
+	defer c.UnlockInfo()
+	fn()
+}
+
+// sendHandlerUpdate forwards a snapshot of the current egress state to the service.
+func (c *Controller) sendHandlerUpdate(ctx context.Context) {
+	info := c.InfoSnapshot()
 	// Once duplicate-identity eviction is detected, suppress all further
-	// updates — another egress instance owns the recording.
+	// updates: another egress instance owns the recording.
 	if c.IsDuplicateIdentity() {
 		return
 	}
@@ -964,6 +1014,9 @@ func (c *Controller) endError() error {
 }
 
 func (c *Controller) updateEndTime() {
+	c.LockInfo()
+	defer c.UnlockInfo()
+
 	endedAt := c.src.GetEndedAt()
 	if c.pipelineEndedAt > endedAt {
 		endedAt = c.pipelineEndedAt
@@ -1051,7 +1104,7 @@ func (c *Controller) uploadManifest() {
 			}
 
 			if !infoUpdated && uploaded {
-				c.Info.ManifestLocation = location
+				c.updateInfo(func() { c.Info.ManifestLocation = location })
 				infoUpdated = true
 			}
 		}

--- a/pkg/pipeline/controller_info_test.go
+++ b/pkg/pipeline/controller_info_test.go
@@ -1,0 +1,92 @@
+package pipeline
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/livekit/egress/pkg/config"
+	"github.com/livekit/protocol/livekit"
+)
+
+// Handler RPCs marshal InfoSnapshot from their own goroutines while the pipeline, sinks and timers
+// keep writing Info. Every snapshot must encode with a stable size, and a returned snapshot must
+// never change afterwards.
+func TestInfoSnapshotUnderConcurrentWrites(t *testing.T) {
+	c := &Controller{
+		PipelineConfig: &config.PipelineConfig{
+			Info: &livekit.EgressInfo{
+				EgressId:    "EG_test",
+				Status:      livekit.EgressStatus_EGRESS_ACTIVE,
+				FileResults: []*livekit.FileInfo{{Filename: "out.mp4"}},
+			},
+		},
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	writer := func(fn func(i int64)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := int64(1); ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+					c.updateInfo(func() { fn(i) })
+				}
+			}
+		}()
+	}
+
+	// Close(): end time and final status
+	writer(func(i int64) {
+		fileInfo := c.Info.FileResults[0]
+		fileInfo.EndedAt = i
+		fileInfo.Duration = i
+		fileInfo.Location = "s3://bucket/out.mp4"
+		c.Info.SetComplete()
+	})
+	// UpdateStream: repeated field grows and is reset
+	writer(func(i int64) {
+		c.Info.StreamResults = append(c.Info.StreamResults, &livekit.StreamInfo{Url: "rtmp://x"})
+		if len(c.Info.StreamResults) > 64 {
+			c.Info.StreamResults = c.Info.StreamResults[:0]
+		}
+	})
+	// stream callbacks: nested message writes
+	writer(func(i int64) {
+		if len(c.Info.StreamResults) > 0 {
+			c.Info.StreamResults[0].Retries++
+			c.Info.StreamResults[0].LastRetryAt = int64(c.Info.StreamResults[0].Retries)
+		}
+	})
+
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		snap := c.InfoSnapshot()
+
+		size := proto.Size(snap)
+		first, err := proto.Marshal(snap)
+		require.NoError(t, err)
+		require.Len(t, first, size)
+
+		second, err := proto.Marshal(snap)
+		require.NoError(t, err)
+		require.Equal(t, first, second)
+		require.Equal(t, "EG_test", snap.EgressId)
+
+		// each writer sets these fields together under the lock, so a snapshot never sees them apart
+		fileInfo := snap.FileResults[0]
+		require.Equal(t, fileInfo.EndedAt, fileInfo.Duration)
+		for _, stream := range snap.StreamResults {
+			require.Equal(t, stream.LastRetryAt, int64(stream.Retries))
+		}
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/pkg/pipeline/controller_info_test.go
+++ b/pkg/pipeline/controller_info_test.go
@@ -52,14 +52,14 @@ func TestInfoSnapshotUnderConcurrentWrites(t *testing.T) {
 		c.Info.SetComplete()
 	})
 	// UpdateStream: repeated field grows and is reset
-	writer(func(i int64) {
+	writer(func(_ int64) {
 		c.Info.StreamResults = append(c.Info.StreamResults, &livekit.StreamInfo{Url: "rtmp://x"})
 		if len(c.Info.StreamResults) > 64 {
 			c.Info.StreamResults = c.Info.StreamResults[:0]
 		}
 	})
 	// stream callbacks: nested message writes
-	writer(func(i int64) {
+	writer(func(_ int64) {
 		if len(c.Info.StreamResults) > 0 {
 			c.Info.StreamResults[0].Retries++
 			c.Info.StreamResults[0].LastRetryAt = int64(c.Info.StreamResults[0].Retries)

--- a/pkg/pipeline/sink/file.go
+++ b/pkg/pipeline/sink/file.go
@@ -41,7 +41,7 @@ func newFileSink(
 	o *config.FileConfig,
 	monitor *stats.HandlerMonitor,
 ) (*FileSink, error) {
-	u, err := uploader.New(o.StorageConfig, conf.BackupConfig, monitor, conf.StorageObserver, conf.Info)
+	u, err := uploader.New(o.StorageConfig, conf.BackupConfig, monitor, conf.StorageObserver, conf)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +88,10 @@ func (s *FileSink) Close() error {
 		return err
 	}
 
+	s.conf.LockInfo()
 	s.FileInfo.Location = location
 	s.FileInfo.Size = size
+	s.conf.UnlockInfo()
 	logger.Debugw("file upload completed",
 		"bytes", size,
 		"duration", time.Since(start))

--- a/pkg/pipeline/sink/image.go
+++ b/pkg/pipeline/sink/image.go
@@ -69,7 +69,7 @@ func newImageSink(
 	callbacks *gstreamer.Callbacks,
 	monitor *stats.HandlerMonitor,
 ) (*ImageSink, error) {
-	u, err := uploader.New(o.StorageConfig, conf.BackupConfig, monitor, conf.StorageObserver, conf.Info)
+	u, err := uploader.New(o.StorageConfig, conf.BackupConfig, monitor, conf.StorageObserver, conf)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,9 @@ func (s *ImageSink) Start() error {
 }
 
 func (s *ImageSink) handleNewImage(update *imageUpdate) error {
+	s.conf.LockInfo()
 	s.ImagesInfo.ImageCount++
+	s.conf.UnlockInfo()
 
 	filename := update.filename
 	ts := s.getImageTime(update.timestamp)

--- a/pkg/pipeline/sink/segments.go
+++ b/pkg/pipeline/sink/segments.go
@@ -52,7 +52,6 @@ type SegmentSink struct {
 	livePlaylist m3u8.PlaylistWriter
 
 	segmentLock  deadlock.Mutex
-	infoLock     deadlock.Mutex
 	playlistLock deadlock.Mutex
 
 	initialized           bool
@@ -80,7 +79,7 @@ func newSegmentSink(
 	callbacks *gstreamer.Callbacks,
 	monitor *stats.HandlerMonitor,
 ) (*SegmentSink, error) {
-	u, err := uploader.New(o.StorageConfig, conf.BackupConfig, monitor, conf.StorageObserver, conf.Info)
+	u, err := uploader.New(o.StorageConfig, conf.BackupConfig, monitor, conf.StorageObserver, conf)
 	if err != nil {
 		return nil, err
 	}
@@ -186,13 +185,13 @@ func (s *SegmentSink) handleClosedSegment(update SegmentUpdate) {
 		}
 
 		// lock segment info updates
-		s.infoLock.Lock()
+		s.conf.LockInfo()
 		s.SegmentsInfo.SegmentCount++
 		s.SegmentsInfo.Size += size
 		if s.manifestPlaylist != nil {
 			s.manifestPlaylist.AddSegment(segmentStoragePath, location)
 		}
-		s.infoLock.Unlock()
+		s.conf.UnlockInfo()
 	}()
 }
 
@@ -253,7 +252,9 @@ func (s *SegmentSink) uploadPlaylist() error {
 	}
 
 	s.lastUpload = time.Now()
+	s.conf.LockInfo()
 	s.SegmentsInfo.PlaylistLocation = playlistLocation
+	s.conf.UnlockInfo()
 	if s.manifestPlaylist != nil {
 		s.manifestPlaylist.Location = playlistLocation
 	}
@@ -265,7 +266,9 @@ func (s *SegmentSink) uploadLivePlaylist() error {
 	liveStoragePath := path.Join(s.StorageDir, s.LivePlaylistFilename)
 	livePlaylistLocation, _, err := s.Upload(liveLocalPath, liveStoragePath, s.OutputType, false)
 	if err == nil {
+		s.conf.LockInfo()
 		s.SegmentsInfo.LivePlaylistLocation = livePlaylistLocation
+		s.conf.UnlockInfo()
 	}
 	return err
 }

--- a/pkg/pipeline/sink/uploader/uploader.go
+++ b/pkg/pipeline/sink/uploader/uploader.go
@@ -25,7 +25,6 @@ import (
 	"github.com/livekit/egress/pkg/errors"
 	"github.com/livekit/egress/pkg/stats"
 	"github.com/livekit/egress/pkg/types"
-	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/observability/storageobs"
 	"github.com/livekit/psrpc"
@@ -39,7 +38,7 @@ type Uploader struct {
 	backup          *store
 	primaryFailed   bool
 	disabled        atomic.Bool
-	info            *livekit.EgressInfo
+	conf            *config.PipelineConfig
 	monitor         *stats.HandlerMonitor
 	storageObserver config.StorageObserver
 }
@@ -56,7 +55,7 @@ type store struct {
 	hasCustomEndpoint bool
 }
 
-func New(primary, backup *config.StorageConfig, monitor *stats.HandlerMonitor, storageObserver config.StorageObserver, info *livekit.EgressInfo) (*Uploader, error) {
+func New(primary, backup *config.StorageConfig, monitor *stats.HandlerMonitor, storageObserver config.StorageObserver, conf *config.PipelineConfig) (*Uploader, error) {
 	p, err := getUploader(primary)
 	if err != nil {
 		return nil, err
@@ -64,7 +63,7 @@ func New(primary, backup *config.StorageConfig, monitor *stats.HandlerMonitor, s
 
 	u := &Uploader{
 		primary:         p,
-		info:            info,
+		conf:            conf,
 		monitor:         monitor,
 		storageObserver: storageObserver,
 	}
@@ -161,8 +160,10 @@ func (u *Uploader) Upload(
 	if u.backup != nil {
 		location, size, backupErr := u.upload(localFilepath, storageFilepath, outputType, false)
 		if backupErr == nil {
-			if u.info != nil {
-				u.info.SetBackupUsed()
+			if u.conf != nil {
+				u.conf.LockInfo()
+				u.conf.Info.SetBackupUsed()
+				u.conf.UnlockInfo()
 			}
 			if u.monitor != nil {
 				u.monitor.IncBackupStorageWrites(string(outputType))
@@ -212,7 +213,7 @@ func (u *Uploader) upload(localFilepath string, storageFilepath string, outputTy
 	}
 
 	if !primary && u.storageObserver != nil {
-		u.storageObserver.OnStorageEvent(u.info.EgressId, string(storageobs.EventOperationUpload), location, size, int64(presignedExpiration/time.Hour/24))
+		u.storageObserver.OnStorageEvent(u.conf.Info.EgressId, string(storageobs.EventOperationUpload), location, size, int64(presignedExpiration/time.Hour/24))
 	}
 
 	if s.conf.GeneratePresignedUrl {
@@ -222,7 +223,7 @@ func (u *Uploader) upload(localFilepath string, storageFilepath string, outputTy
 		}
 
 		if !primary && u.storageObserver != nil {
-			u.storageObserver.OnStorageEvent(u.info.EgressId, string(storageobs.EventOperationDownload), location, size, 0)
+			u.storageObserver.OnStorageEvent(u.conf.Info.EgressId, string(storageobs.EventOperationDownload), location, size, 0)
 		}
 	}
 

--- a/pkg/pipeline/sink/uploader/uploader_test.go
+++ b/pkg/pipeline/sink/uploader/uploader_test.go
@@ -44,7 +44,7 @@ func TestUploader(t *testing.T) {
 	}
 
 	info := &livekit.EgressInfo{}
-	u, err := New(primary, backup, nil, nil, info)
+	u, err := New(primary, backup, nil, nil, &config.PipelineConfig{Info: info})
 	require.NoError(t, err)
 
 	filepath := "uploader_test.go"
@@ -143,7 +143,7 @@ func TestUploadErrorHasStatusCode(t *testing.T) {
 				},
 			}
 
-			u, err := New(primary, nil, nil, nil, &livekit.EgressInfo{})
+			u, err := New(primary, nil, nil, nil, &config.PipelineConfig{Info: &livekit.EgressInfo{}})
 			require.NoError(t, err)
 
 			_, _, err = u.Upload("uploader_test.go", "uploader_test.go", "text/plain", false)


### PR DESCRIPTION
## Problem

The `Egress errors in logs` Datadog monitor fired during post-deployment monitoring of `v2026-09-09-0855` on this error from a handler process:

```
grpc: server failed to encode response: rpc error: code = Internal desc = grpc: error while marshaling:
marshaling livekit.EgressInfo: size mismatch (see https://github.com/golang/protobuf/issues/1609): calculated=228, measured=245
```

It is not a regression of that image. The same error appears roughly once a day across all regions for as long as the logs go back, on `v2026-08-15-0848`, `v2026-09-07-0832` and `v2026-09-09-0855` alike (22 occurrences in the last 30 days).

### Root cause

`Handler.StopEgress` and `Handler.UpdateStream` returned `h.controller.Info`, the live `*livekit.EgressInfo`, as the IPC response. gRPC computes the message size and then marshals it. Between those two steps the pipeline keeps writing the same struct from other goroutines: `Close()` sets `FileInfo.EndedAt` and `Duration` (the recurring 17 byte delta), `SetComplete()` flips the status, sinks record upload results, stream callbacks update `StreamInfo`. When a `StopEgress` lands inside the natural end-of-egress window (an agent calling stop at hangup, or the cloud-io sweeper stopping an egress whose room just closed) the marshal and the write collide.

The recording itself is unaffected, because the final state reaches cloud-io through `HandlerUpdate`. The `StopEgress` caller receives an Internal error for an egress that actually completed; cloud-io returns that to the API caller, and the sweeper logs `failed to end egress` and retries. `HandlerUpdate` marshaled the same live pointer and discarded any marshal error, so an ENDING update could also be dropped silently.

`StreamInfo`, `FileInfo`, `SegmentsInfo` and `ImagesInfo` are not independent objects: the pointers held by the sinks and stream configs are the same messages nested inside `EgressInfo.*Results`, so a write to any of them is a write to the message being encoded.

## Fix

- `PipelineConfig` gains a mutex next to `Info`, with `LockInfo`, `UnlockInfo` and `InfoSnapshot` (clone under the lock). It lives on the config because the controller, sinks, uploader and handler all share that struct.
- Every write to `Info` or a nested result message takes the lock: controller (`updateInfo` helper for short writes, explicit lock for `updateStartTime` and `updateEndTime`), file/image/segment sinks, the uploader's `SetBackupUsed`, and `KillEgress` in the handler. Read-modify-write sequences in `SendEOS`, `OnError`, `Close` and the limit timer run inside one critical section, with the outcome captured and acted on after release. Nothing blocking (IPC, GStreamer, uploads) runs under the lock.
- Handler RPCs return `InfoSnapshot()`. `sendHandlerUpdate` and `Run` (via `HandlerFinished`) marshal snapshots as well.
- The controller's `mu`, which only guarded the `StreamResults` append, is folded into the shared lock. The segment sink's private `infoLock` likewise.
- `Close()` keeps the original manifest-upload behavior: the upload runs when the pre-finalization status was ACTIVE, ENDING, LIMIT_REACHED or COMPLETE, regardless of whether finalization ended in FAILED.

## Testing

`TestInfoSnapshotUnderConcurrentWrites` runs three writers (end-time and status writes, `StreamResults` append and reset, nested `StreamInfo` writes) through `updateInfo` while a reader loops on `InfoSnapshot`, asserts `proto.Size` equals the marshaled length (gRPC's check), marshals twice for byte equality, and asserts that fields the writers set together are never observed apart.

Outcomes:

| Variant | `-race` | plain |
|---|---|---|
| with the lock | pass | pass (11 runs) |
| reader's lock removed, writers locked | 15 reports, all `proto.Clone` in `InfoSnapshot` vs a writer | fails 10 of 10 on the paired-field assertion |

The paired-field assertion is what makes the test fail without the race detector; the size check alone passes on a torn clone because a clone is always self-consistent. Package tests in CI run without `-race` (`build/test/Dockerfile`), so that assertion is the coverage that matters there.

`go vet` is clean on all changed packages, including the copylocks check on the new field.

## Out of scope

- Unlocked reads of `Info.Status` used only for logging in `streamFinished` and `streamFailed`.
- Adding `-race` to the pkg unit test line in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
