### PR TITLE
Skip the memory kill when no handler accounts for the usage

### DIFF
--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -843,19 +843,28 @@ func (m *Monitor) checkMemoryKill(maxMemoryEgress string, maxMemoryGroup *hwstat
 		}
 		if time.Since(m.highMemoryStart) >= time.Duration(m.cpuCostConfig.MemoryKillGraceSec)*time.Second {
 			killTriggerGB := float64(killTriggerBytes) / gb
+			m.highMemoryStart = time.Time{}
+			if maxMemoryGroup == nil {
+				logger.Errorw("memory over limit with no handler to kill", errors.ErrOOM(killTriggerGB),
+					"source", m.cpuCostConfig.MemorySource,
+					"memoryGB", killTriggerGB,
+					"maxMemoryGB", m.cpuCostConfig.MaxMemory,
+					"requests", m.requests.Load(),
+					"hint", "usage is not from egress handlers: check the memory source scope or the service process",
+				)
+				return
+			}
 			logger.Warnw("high memory usage", nil,
 				"source", m.cpuCostConfig.MemorySource,
 				"memoryGB", killTriggerGB,
 				"maxMemoryGB", m.cpuCostConfig.MaxMemory,
 				"requests", m.requests.Load(),
+				"egressID", maxMemoryEgress,
 			)
-			if maxMemoryGroup != nil {
-				logger.Infow("killing egress process memory",
-					"egressID", maxMemoryEgress, "processes", maxMemoryGroup.Procs)
-			}
+			logger.Infow("killing egress process memory",
+				"egressID", maxMemoryEgress, "processes", maxMemoryGroup.Procs)
 			// Report the actual memory that triggered the kill, not per-process max
 			m.svc.KillProcess(maxMemoryEgress, ResultKilledOOM, errors.ErrOOM(killTriggerGB))
-			m.highMemoryStart = time.Time{}
 		}
 	} else {
 		m.highMemoryStart = time.Time{}


### PR DESCRIPTION
## Summary

`checkMemoryKill` picks the handler group holding the most memory and kills it once usage stays above `max_memory` past the grace period. When no handler processes are observed there is no group to pick, and the kill was issued with an empty egress id: `KillProcess` found nothing to terminate but still logged `killing egress`, so anything counting that line saw phantom handler kills.

## Change

- When usage is over the limit and no handler accounts for it, log `memory over limit with no handler to kill` at error level, with a `hint` field pointing at the memory source scope or the service process, and return without calling `KillProcess`.
- The real-kill path is unchanged, apart from the existing `high memory usage` warning now carrying `egressID`.

## Why

Memory above the limit with zero handlers cannot be freed by killing a handler. Whatever it is (a memory reading scoped wider than the egress process tree, or the service process itself), surfacing it as a distinct error is more useful than a no-op kill that looks like a real one in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
