### PR TITLE
Disable the whisper and validate plugins from GStreamer 1.28 on

### DIFF
--- a/build/gstreamer/compile-rs
+++ b/build/gstreamer/compile-rs
@@ -34,6 +34,14 @@ for repo in gst-plugins-rs; do
     opts="$opts -D webrtc-livekit=enabled"
   fi
 
+  # whisper needs libclang and validate needs gstreamer-validate-1.0 from
+  # gst-devtools; neither is available here, and an auto feature is still
+  # scheduled when its dependency probe fails. The options only exist from
+  # 1.28 on, and older versions error out on them.
+  if (( gst_major > 1 || (gst_major == 1 && gst_minor >= 28) )); then
+    opts="$opts -D whisper=disabled -D validate=disabled"
+  fi
+
   if [[ $DEBUG == 'true' ]]; then
     if [[ $OPTIMIZATIONS == 'true' ]]; then
       opts="$opts -D buildtype=debugoptimized"


### PR DESCRIPTION
Building any GStreamer 1.28+ image currently fails. `gst-plugins-rs` gained two plugins in the 1.28 series whose build dependencies are not in our base image:

- `whisper` (`whispertranscriber`, speech to text) needs `libclang` for its `bindgen` build script. Its `whisper-rs-sys` build script panics with `Unable to find libclang`.
- `validate` needs `gstreamer-validate-1.0`, which comes from `gst-devtools`. `Dockerfile-base` does not fetch that module.

Both are upstream `auto` features. `auto` does not reliably mean "skip when unavailable": meson printed `Run-time dependency gstreamer-validate-1.0 found: NO` and then scheduled `libgstrsvalidate.so` for build anyway. So they have to be disabled explicitly.

The options only exist from 1.28, and meson errors out on an unknown option, so the disable is gated on the version the same way `webrtc-livekit` is gated on 1.25 just above it. It reuses the `gst_major`/`gst_minor` the script already parses, so no new variable.

**This is a no-op for every version published so far.** The gate is false for 1.24 and 1.26, which is the range `#1371` added this build system to regenerate.

## Verification

Built locally on arm64 from this branch, both sides of the gate:

| GStreamer | meson options emitted | `compile-rs` | Result |
| --- | --- | --- | --- |
| 1.28.6 | `-D webrtc-livekit=enabled -D whisper=disabled -D validate=disabled` | exit 0 | 300 plugins / 1535 features |
| 1.26.7 | `-D webrtc-livekit=enabled` (neither option passed) | exit 0 | 293 plugins / 1491 features |

- `livekitwebrtcsrc` and `livekitwebrtcsink` present in both, so the `compile-rs` assertions pass and the neighbouring 1.25 gate is undisturbed.
- `skia` and `demucs` still build. I disabled them at first on the assumption they also needed libclang; they do not, so they are not in this change.
- Gate boolean checked against the real upstream `meson_options.txt` at each tag: 1.24.12 no, 1.26.7 no, 1.28.0 yes, 1.28.6 yes. It flips exactly where the options begin to exist.
- Full 1.28.6 `base`/`dev`/`prod` set built from this branch, an ingress image built against it, and a transcoded RTMP ingest published 2 tracks into a room with simulcast 1280x720 and clean EOS teardown.

Lint: `golangci-lint run --timeout=5m --modules-download-mode=mod` (v2.11.3, matching CI) reports one pre-existing `typecheck` issue for `go:embed templates`, which reproduces identically on `main` and only occurs outside the Docker test image where templates are copied in. No Go files are changed here.

## Not included

This does not bump the GStreamer version. `.gst-version` is untouched. Publishing 1.28.x still needs a manual `publish-gstreamer` dispatch, and this change is what makes that dispatch succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)